### PR TITLE
Fixed Docker command in docs.

### DIFF
--- a/docs/setup_own_server.md
+++ b/docs/setup_own_server.md
@@ -32,16 +32,18 @@ max_age = 3600
 
 Make `local.ini` and run with docker run like this, you can launch the CouchDB.
 ```
-$ docker run --rm -it -e COUCHDB_USER=admin -e COUCHDB_PASSWORD=password -v .local.ini:/opt/couchdb/etc/local.ini -p 5984:5984 couchdb
+$ docker run --rm -it -e COUCHDB_USER=admin -e COUCHDB_PASSWORD=password -v /path/to/local.ini:/opt/couchdb/etc/local.ini -p 5984:5984 couchdb
 ```
+*Remember to replace the path with the path to your local.ini*
 Note: At this time, the file owner of local.ini became 5984:5984. It's the limitation docker image. please change the owner before editing local.ini again.
 
 If you could confirm that Self-hosted LiveSync can sync with the server, launch docker image as background as you like.
 
-example)
+Example to run docker in detached mode:
 ```
-$ docker run -d --restart always -e COUCHDB_USER=admin -e COUCHDB_PASSWORD=password -v .local.ini:/opt/couchdb/etc/local.ini -p 5984:5984 couchdb
+$ docker run -d --restart always -e COUCHDB_USER=admin -e COUCHDB_PASSWORD=password -v /path/to/local.ini:/opt/couchdb/etc/local.ini -p 5984:5984 couchdb
 ```
+*Remember to replace the path with the path to your local.ini*
 
 ## Access from mobile device
 If you want to access Self-hosted LiveSync from mobile devices, you need a valid SSL certificate.


### PR DESCRIPTION
Hey, I've noticed that running the docker command  
```
$ docker run --rm -it -e COUCHDB_USER=admin -e COUCHDB_PASSWORD=password -v .local.ini:/opt/couchdb/etc/local.ini -p 5984:5984 couchdb
```
runs into the following error:

```
docker: Error response from daemon: create .local.ini: ".local.ini" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
See 'docker run --help'.
```

This is because **-v** expects full paths as documented [here](https://docs.docker.com/engine/reference/run/#volume-shared-filesystems).

I fixed this by adding this to the docs:

```
$ docker run --rm -it -e COUCHDB_USER=admin -e COUCHDB_PASSWORD=password -v /path/to/local.ini:/opt/couchdb/etc/local.ini -p 5984:5984 couchdb
*Remember to replace the path with the path to your local.ini*
```

Thanks for developing such a great tool 👍🏼 