### PR TITLE
Fix check warning for max_document_size, max_http_request_size

### DIFF
--- a/docs/setup_own_server.md
+++ b/docs/setup_own_server.md
@@ -10,9 +10,11 @@ But some additional configurations are required in `local.ini` to use from Self-
 ```
 [couchdb]
 single_node=true
+max_document_size = 50000000
 
 [chttpd]
 require_valid_user = true
+max_http_request_size = 4294967296
 
 [chttpd_auth]
 require_valid_user = true

--- a/docs/setup_own_server_cn.md
+++ b/docs/setup_own_server_cn.md
@@ -11,9 +11,11 @@
 ```
 [couchdb]
 single_node=true
+max_document_size = 50000000
 
 [chttpd]
 require_valid_user = true
+max_http_request_size = 4294967296
 
 [chttpd_auth]
 require_valid_user = true


### PR DESCRIPTION
> Refer: https://github.com/vrtmrz/self-hosted-livesync-server/pull/7

obsidian-livesync's Check database configuration print some warning for max_document_size, max_http_request_size.

![image](https://user-images.githubusercontent.com/9838749/203482747-8c13a595-3ccb-4ffc-b297-cc9268d79214.png)
