### PR TITLE
Allow switching CouchDB long polling from heartbeat to timeout

### DIFF
--- a/src/ObsidianLiveSyncSettingTab.ts
+++ b/src/ObsidianLiveSyncSettingTab.ts
@@ -1279,6 +1279,20 @@ export class ObsidianLiveSyncSettingTab extends PluginSettingTab {
                 text.inputEl.setAttribute("type", "number");
             });
 
+        new Setting(containerSyncSettingEl)
+            .setName("Use timeouts instead of heartbeats")
+            .setDesc("If this option is enabled, PouchDB will hold the connection open for 60 seconds, and if no change arrives in that time, close and reopen the socket, instead of holding it open indefinitely. Useful when a proxy limits request duration but can increase resource usage.")
+            .addToggle((toggle) => {
+                toggle
+                    .setValue(this.plugin.settings.useTimeouts)
+                    .onChange(async (value) => {
+                        this.plugin.settings.useTimeouts = value;
+                        await this.plugin.saveSettings();
+                    })
+                return toggle;
+            }
+        );
+
         addScreenElement("30", containerSyncSettingEl);
         const containerMiscellaneousEl = containerEl.createDiv();
         containerMiscellaneousEl.createEl("h3", { text: "Miscellaneous" });


### PR DESCRIPTION
Hello, 
First of all thanks a lot for this amazing plugin.

I am using a configuration with self-hosted CouchDB instance and have been noticing errors in the log while the editor is idle. From a bit of investigation and debugging I've found that the culprit was Cloudflare which limits requests to 100 seconds on non-enterprise plans and breaks the long polling with heartbeats ([related CouchDB docs](https://docs.couchdb.org/en/stable/api/database/changes.html#long-polling)).

To reproduce:
1. Setup a CouchDB instance behind Cloudflare
2. Wait for a `_changes` longpoll request
3. Wait a bit over 100 seconds
4. Observe 524 response and the resulting error `TypeError:Failed to fetch`

I've managed to workaround the 100s timeout by disabling heartbeat and using the built-in timeout instead in the PouchDB sync options ([docs](https://pouchdb.com/api.html#options-3)).

Here's a PR that adds a simple toggle between the two options. I've tested it and it did fix the issue for me.

Requires https://github.com/vrtmrz/livesync-commonlib/pull/2