### PR TITLE
[Feature] Add password protection to askString function

### DIFF
--- a/src/CmdSetupLiveSync.ts
+++ b/src/CmdSetupLiveSync.ts
@@ -41,7 +41,7 @@ export class SetupLiveSync extends LiveSyncCommands {
     async realizeSettingSyncMode() { }
 
     async command_copySetupURI() {
-        const encryptingPassphrase = await askString(this.app, "Encrypt your settings", "The passphrase to encrypt the setup URI", "");
+        const encryptingPassphrase = await askString(this.app, "Encrypt your settings", "The passphrase to encrypt the setup URI", "", true);
         if (encryptingPassphrase === false)
             return;
         const setting = { ...this.settings, configPassphraseStore: "", encryptedCouchDBConnection: "", encryptedPassphrase: "" };
@@ -57,7 +57,7 @@ export class SetupLiveSync extends LiveSyncCommands {
         Logger("Setup URI copied to clipboard", LOG_LEVEL.NOTICE);
     }
     async command_copySetupURIFull() {
-        const encryptingPassphrase = await askString(this.app, "Encrypt your settings", "The passphrase to encrypt the setup URI", "");
+        const encryptingPassphrase = await askString(this.app, "Encrypt your settings", "The passphrase to encrypt the setup URI", "", true);
         if (encryptingPassphrase === false)
             return;
         const setting = { ...this.settings, configPassphraseStore: "", encryptedCouchDBConnection: "", encryptedPassphrase: "" };
@@ -81,7 +81,7 @@ export class SetupLiveSync extends LiveSyncCommands {
     async setupWizard(confString: string) {
         try {
             const oldConf = JSON.parse(JSON.stringify(this.settings));
-            const encryptingPassphrase = await askString(this.app, "Passphrase", "The passphrase to decrypt your setup URI", "");
+            const encryptingPassphrase = await askString(this.app, "Passphrase", "The passphrase to decrypt your setup URI", "", true);
             if (encryptingPassphrase === false)
                 return;
             const newConf = await JSON.parse(await decrypt(confString, encryptingPassphrase, false));

--- a/src/dialogs.ts
+++ b/src/dialogs.ts
@@ -43,13 +43,15 @@ export class InputStringDialog extends Modal {
     key: string;
     placeholder: string;
     isManuallyClosed = false;
+    isPassword: boolean = false;
 
-    constructor(app: App, title: string, key: string, placeholder: string, onSubmit: (result: string | false) => void) {
+    constructor(app: App, title: string, key: string, placeholder: string, isPassword: boolean, onSubmit: (result: string | false) => void) {
         super(app);
         this.onSubmit = onSubmit;
         this.title = title;
         this.placeholder = placeholder;
         this.key = key;
+        this.isPassword = isPassword;
     }
 
     onOpen() {
@@ -58,7 +60,7 @@ export class InputStringDialog extends Modal {
         contentEl.createEl("h1", { text: this.title });
         // For enter to submit
         const formEl = contentEl.createEl("form");
-        new Setting(formEl).setName(this.key).addText((text) =>
+        new Setting(formEl).setName(this.key).setClass(this.isPassword ? "password-input" : "normal-input").addText((text) =>
             text.onChange((value) => {
                 this.result = value;
             })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -405,9 +405,9 @@ export const askSelectString = (app: App, message: string, items: string[]): Pro
 };
 
 
-export const askString = (app: App, title: string, key: string, placeholder: string): Promise<string | false> => {
+export const askString = (app: App, title: string, key: string, placeholder: string, isPassword?: boolean): Promise<string | false> => {
     return new Promise((res) => {
-        const dialog = new InputStringDialog(app, title, key, placeholder, (result) => res(result));
+        const dialog = new InputStringDialog(app, title, key, placeholder, isPassword, (result) => res(result));
         dialog.open();
     });
 };

--- a/styles.css
+++ b/styles.css
@@ -256,3 +256,7 @@ div.sls-setting-menu-btn {
 .sls-setting-hidden {
     display: none;
 }
+
+.password-input > .setting-item-control >input {
+  -webkit-text-security: disc;
+}


### PR DESCRIPTION
Adds option to create hidden password inputs using `askString`. This is implemented using the `-webkit-text-security` CSS style and replaces all text in the input field with disc (●) characters. The change is only visual. This change only affects setting import URI passwords as I found nothing else that would need to be hidden.