### PR TITLE
CouchDB config corrections, reverse proxy documentation, other additions

### DIFF
--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -1,0 +1,46 @@
+# For details and other explanations about this file refer to:
+# https://github.com/vrtmrz/obsidian-livesync/blob/main/docs/setup_own_server.md#traefik
+
+version: "2.1"
+services:
+  couchdb:
+    image: couchdb:latest
+    container_name: obsidian-livesync
+    user: 1000:1000
+    environment:
+      - COUCHDB_USER=username
+      - COUCHDB_PASSWORD=password
+    volumes:
+      - ./data:/opt/couchdb/data
+      - ./local.ini:/opt/couchdb/etc/local.ini
+    # Ports not needed when already passed to Traefik
+    #ports:
+    #  - 5984:5984
+    restart: unless-stopped
+    networks:
+      - proxy
+    labels:
+      - "traefik.enable=true"
+      # The Traefik Network
+      - "traefik.docker.network=proxy"
+      # Don't forget to replace 'obsidian-livesync.example.org' with your own domain
+      - "traefik.http.routers.obsidian-livesync.rule=Host(`obsidian-livesync.example.org`)"
+      # The 'websecure' entryPoint is basically your HTTPS entrypoint. Check the next code snippet if you are encountering problems only; you probably have a working traefik configuration if this is not your first container you are reverse proxying.
+      - "traefik.http.routers.obsidian-livesync.entrypoints=websecure"
+      - "traefik.http.routers.obsidian-livesync.service=obsidian-livesync"
+      - "traefik.http.services.obsidian-livesync.loadbalancer.server.port=5984"
+      - "traefik.http.routers.obsidian-livesync.tls=true"
+      # Replace the string 'letsencrypt' with your own certificate resolver
+      - "traefik.http.routers.obsidian-livesync.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.obsidian-livesync.middlewares=obsidiancors"
+      # The part needed for CORS to work on Traefik 2.x starts here
+      - "traefik.http.middlewares.obsidiancors.headers.accesscontrolallowmethods=GET,PUT,POST,HEAD,DELETE"
+      - "traefik.http.middlewares.obsidiancors.headers.accesscontrolallowheaders=accept,authorization,content-type,origin,referer"
+      - "traefik.http.middlewares.obsidiancors.headers.accesscontrolalloworiginlist=app://obsidian.md,capacitor://localhost,http://localhost"
+      - "traefik.http.middlewares.obsidiancors.headers.accesscontrolmaxage=3600"
+      - "traefik.http.middlewares.obsidiancors.headers.addvaryheader=true"
+      - "traefik.http.middlewares.obsidiancors.headers.accessControlAllowCredentials=true"
+
+networks:
+  proxy:
+    external: true

--- a/docs/setup_own_server.md
+++ b/docs/setup_own_server.md
@@ -4,7 +4,7 @@
 
 The easiest way to set up a CouchDB instance is using the official [docker image](https://hub.docker.com/_/couchdb).
 
-Some initial configuration is required. Create a `local.ini` to use Self-hosted LiveSync as follows:
+Some initial configuration is required. Create a `local.ini` to use Self-hosted LiveSync as follows ([CouchDB has to be version 3.2 or higher](https://docs.couchdb.org/en/latest/config/http.html#chttpd/enable_cors), if lower `enable_cors = true` has to be under section `[httpd]` ):
 
 ```ini
 [couchdb]
@@ -14,6 +14,7 @@ max_document_size = 50000000
 [chttpd]
 require_valid_user = true
 max_http_request_size = 4294967296
+enable_cors = true
 
 [chttpd_auth]
 require_valid_user = true
@@ -21,13 +22,13 @@ authentication_redirect = /_utils/session.html
 
 [httpd]
 WWW-Authenticate = Basic realm="couchdb"
-enable_cors = true
+bind_address = 0.0.0.0
 
 [cors]
-origins = app://obsidian.md,capacitor://localhost,http://localhost
+origins = app://obsidian.md, capacitor://localhost, http://localhost
 credentials = true
 headers = accept, authorization, content-type, origin, referer
-methods = GET, PUT, POST, HEAD, DELETE
+methods = GET,PUT,POST,HEAD,DELETE
 max_age = 3600
 ```
 
@@ -48,7 +49,7 @@ $ docker run -d --restart always -e COUCHDB_USER=admin -e COUCHDB_PASSWORD=passw
 *Remember to replace the path with the path to your local.ini*
 
 ### Docker Compose
-Create a directory, place your `local.ini` within it, and create a `docker-compose.yml` alongside it. The directory structure should look similar to this:
+Create a directory, place your `local.ini` within it, and create a `docker-compose.yml` alongside it. Make sure to have write permissions for `local.ini` and the about to be created `data` folder after the container start. The directory structure should look similar to this:
 ```
 obsidian-livesync
 ├── docker-compose.yml


### PR DESCRIPTION
- [enable_cors is now under section [chttpd] since version 3.2](https://docs.couchdb.org/en/latest/config/http.html#chttpd/enable_cors).
- Not everyone will use version 3.2+ so I made it clear that's a new thing.
- Added `bind_address` for making sure the container uses all interfaces given; I myself use Traefik as a reverse proxy and using this somehow made it work, since this option does not harm other reverse proxies and there are lots of Traefik users this option should be there for wider compatibility.
- Added spaces between `origins` elements and removed spaces between the `methods` elements because it's like this in the official documentation, see [1](https://docs.couchdb.org/en/latest/config/http.html#cors/origins) and [2](https://docs.couchdb.org/en/latest/config/http.html#cors/methods).
- Added a write permission warning since many newbies had this mistake with couchdb, including myself.