### PR TITLE
Partially corrected CORS checks on the client side

### DIFF
--- a/src/ObsidianLiveSyncSettingTab.ts
+++ b/src/ObsidianLiveSyncSettingTab.ts
@@ -372,6 +372,12 @@ export class ObsidianLiveSyncSettingTab extends PluginSettingTab {
                                 } else {
                                     addResult("✔ chttpd_auth.require_valid_user is ok.");
                                 }
+                                if (responseConfig?.chttpd?.enable_cors != "true") {
+                                    addResult("❗ chttpd.enable_cors is wrong");
+                                    addConfigFixButton("Set chttpd.enable_cors", "chttpd/enable_cors", "true");
+                                } else {
+                                    addResult("✔ chttpd.enable_cors is ok.");
+                                }
                                 // HTTPD check
                                 //  Check Authentication header
                                 if (!responseConfig?.httpd["WWW-Authenticate"]) {
@@ -379,12 +385,6 @@ export class ObsidianLiveSyncSettingTab extends PluginSettingTab {
                                     addConfigFixButton("Set httpd.WWW-Authenticate", "httpd/WWW-Authenticate", 'Basic realm="couchdb"');
                                 } else {
                                     addResult("✔ httpd.WWW-Authenticate is ok.");
-                                }
-                                if (responseConfig?.httpd?.enable_cors != "true") {
-                                    addResult("❗ httpd.enable_cors is wrong");
-                                    addConfigFixButton("Set httpd.enable_cors", "httpd/enable_cors", "true");
-                                } else {
-                                    addResult("✔ httpd.enable_cors is ok.");
                                 }
                                 // If the server is not cloudant, configure request size
                                 if (!isCloudantURI(this.plugin.settings.couchDB_URI)) {


### PR DESCRIPTION
Hi, like explained [here](https://github.com/vrtmrz/obsidian-livesync/pull/236) since version 3.2 the `enable_cors` option is under `[chttpd]` and not `[httpd]`. I only moved the `enable_cors` option. Result on my testing rig:

<img width="500" alt="cors-check-fix" src="https://github.com/vrtmrz/obsidian-livesync/assets/30238916/79e12ff0-18bd-455c-a4b2-4bd0762d971a">


\
 The `cors.origins` check still needs an addition, it works just fine when there are no spaces between the origins, on my setup I have them so that's the reason why I have this error; since both are valid in the local.ini configuration both can be accepted? Please check code comments.