### PR TITLE
Fixed docker-compose command in docs

### DIFF
--- a/docs/setup_own_server_cn.md
+++ b/docs/setup_own_server_cn.md
@@ -91,7 +91,7 @@ services:
 最后, 创建并启动容器:
 ```
 # -d will launch detached so the container runs in background
-docker compose up -d
+docker-compose up -d
 ```
 
 ## 创建数据库


### PR DESCRIPTION
Hey,there! 
I've noticed that running the docker command 
```
docker compose up -d
```
resulted into the following error
```
unknown shorthand flag: 'd' in -d
See 'docker --help'.
```
It is because the `docker-compose` command was mistakenly written as `docker compose`

I've fixed this by changing  "docker compose" into "docker-compose".

Thank you for reviewing this pull request,have a good time!