### PR TITLE
Default to _local when node not supplied

### DIFF
--- a/utils/couchdb/couchdb-init.sh
+++ b/utils/couchdb/couchdb-init.sh
@@ -13,23 +13,8 @@ if [[ -z "$password" ]]; then
     exit 1
 fi
 if [[ -z "$node" ]]; then
-    echo "INFO: Node missing, trying to detect..."
-    node=$(curl -X GET "${hostname}/_membership" --user "${username}:${password}"  | jq -r '.cluster_nodes[0] // .all_nodes[0]')
-    if [[ -n "$node" ]]; then
-        echo "INFO: Detected node: $node"
-        # confirm
-        while true; do
-            read -p "May we use this node? (defaultly, it may be 'node@nohost') " yn
-            case $yn in
-                [Yy]* ) break;;
-                [Nn]* ) exit 1;;
-                * ) echo "Please answer yes or no.";;
-            esac
-        done
-    else
-        echo "ERROR: Node missing (default should be located in /opt/couchdb/etc/vm.args under -name)"
-        exit 1
-    fi
+    echo "INFO: defaulting to _local"
+    node=_local
 fi
 
 echo "-- Configuring CouchDB by REST APIs... -->"


### PR DESCRIPTION
A simpler method for accessing the target node during installation.

This doesn't require setting `NODENAME` in the container,
or setting the `node` for the init script.

(Issue #570 )