### PR TITLE
[docs] added changing docker compose data and etc folder ownership to user 5984.

### DIFF
--- a/docs/setup_own_server.md
+++ b/docs/setup_own_server.md
@@ -64,6 +64,10 @@ Congrats, move on to [step 2](#2-run-couchdb-initsh-for-initialise)
 # Creating the save data & configuration directories.
 mkdir couchdb-data
 mkdir couchdb-etc
+
+# Changing perms to user 5984.
+chown -R 5984:5984 ./couchdb-data
+chown -R 5984:5984 ./couchdb-etc
 ```
 
 #### 2. Create a `docker-compose.yml` file with the following added to it


### PR DESCRIPTION
while trying to follow the docker compose guide i created the data folders using the root user, and had this error when i run the stack: 
`touch: cannot touch '/opt/couchdb/etc/local.d/docker.ini': Permission denied`

the problem was solved by changing the ownership of the folder to the user 5984, then one in the docker compose file.