### PR TITLE
fix/env var shell collisions in URI setup

### DIFF
--- a/docs/setup_own_server.md
+++ b/docs/setup_own_server.md
@@ -170,17 +170,17 @@ Now `https://tiles-photograph-routine-groundwater.trycloudflare.com` is our serv
 
 ### 1. Generate the setup URI on a desktop device or server
 ```bash
-export hostname=https://tiles-photograph-routine-groundwater.trycloudflare.com #Point to your vault
-export database=obsidiannotes #Please change as you like
-export passphrase=dfsapkdjaskdjasdas #Please change as you like
-export username=johndoe
-export password=abc123
+export LIVESYNC_HOST=https://tiles-photograph-routine-groundwater.trycloudflare.com #Point to your vault
+export LIVESYNC_DB=obsidiannotes #Please change as you like
+export LIVESYNC_PASSPHRASE=dfsapkdjaskdjasdas #Please change as you like
+export LIVESYNC_USER=johndoe
+export LIVESYNC_PASS=abc123
 deno run -A https://raw.githubusercontent.com/vrtmrz/obsidian-livesync/main/utils/flyio/generate_setupuri.ts
 ```
 
 > [!TIP]
-> What is the `passphrase`? Is it different from `uri_passphrase`?
-> Yes, the `passphrase` we have exported now is for an End-to-End Encryption passphrase.
+> What is the `LIVESYNC_PASSPHRASE`? Is it different from `uri_passphrase`?
+> Yes, the `LIVESYNC_PASSPHRASE` we have exported now is for an End-to-End Encryption passphrase.
 > And, `uri_passphrase` that used in the `generate_setupuri.ts` is a different one; for decrypting Set-up URI at using that.
 > Why: I (vorotamoroz) think that the passphrase of the Setup-URI should be different from the E2EE passphrase to prevent exposure caused by operational errors or the possibility of evil in our environment. On top of that, I believe that it is desirable for the Setup-URI to be random. Setup-URI is inevitably long, so it goes through the clipboard. I think that its passphrase should not go through the same path, so it should essentially be typed manually.
 > Hence, if we keep empty for uri_passphrase, generate_setupuri.ts generates an adjective-noun-randomnumber passphrase so that we can remember it without going through the clipboard.

--- a/utils/flyio/generate_setupuri.ts
+++ b/utils/flyio/generate_setupuri.ts
@@ -141,16 +141,16 @@ const uri_passphrase = `${Deno.env.get("uri_passphrase") ?? friendlyString()}`;
 const URIBASE = "obsidian://setuplivesync?settings=";
 async function main() {
     const conf = {
-        couchDB_URI: `${Deno.env.get("hostname")}`,
-        couchDB_USER: `${Deno.env.get("username")}`,
-        couchDB_PASSWORD: `${Deno.env.get("password")}`,
-        couchDB_DBNAME: `${Deno.env.get("database")}`,
+        couchDB_URI: `${Deno.env.get("LIVESYNC_HOST")}`,
+        couchDB_USER: `${Deno.env.get("LIVESYNC_USER")}`,
+        couchDB_PASSWORD: `${Deno.env.get("LIVESYNC_PASS")}`,
+        couchDB_DBNAME: `${Deno.env.get("LIVESYNC_DB")}`,
         syncOnStart: true,
         gcDelay: 0,
         periodicReplication: true,
         syncOnFileOpen: true,
         encrypt: true,
-        passphrase: `${Deno.env.get("passphrase")}`,
+        passphrase: `${Deno.env.get("LIVESYNC_PASSPHRASE")}`,
         usePathObfuscation: true,
         batchSave: true,
         batch_size: 50,


### PR DESCRIPTION
The variables `hostname` and `username` used in the URI setup script potentially collide with shell-reserved variables. On some systems, this makes it impossible to set them via export (e.g. fish shell on arch has `hostname` set to read-only). The other variable names (password, database, etc.) are generic enough to risk collisions with other tools.

This PR renames all environment variables in the URI setup to use a LIVESYNC_ prefix, following the common convention for namespaced environment variables. I rewrote the docs (EN only) accordingly. Fix is tested and works fine. As the variables do not seem to be used as dependencies elsewhere, this should be safe to merge