### PR TITLE
fix(cli): handle incomplete localStorage in Node.js v25+

### DIFF
--- a/src/apps/cli/main.ts
+++ b/src/apps/cli/main.ts
@@ -3,7 +3,7 @@
  * Command-line version of Self-hosted LiveSync plugin for syncing vaults without Obsidian
  */
 
-if (!("localStorage" in globalThis)) {
+if (!("localStorage" in globalThis) || typeof (globalThis as any).localStorage?.getItem !== "function") {
     const store = new Map<string, string>();
     (globalThis as any).localStorage = {
         getItem: (key: string) => (store.has(key) ? store.get(key)! : null),


### PR DESCRIPTION
## Problem

The CLI crashes on Node.js v25+ with:

```
TypeError: localStorage.getItem is not a function
```

Node.js v25 provides a built-in `localStorage` on `globalThis`, but without `--localstorage-file` it is an empty object lacking `getItem`/`setItem`. The existing check `!("localStorage" in globalThis)` passes, so the polyfill in `main.ts` is skipped.

## Fix

Also check that `getItem` is a function before deciding to skip the polyfill.

```diff
-if (!("localStorage" in globalThis)) {
+if (!("localStorage" in globalThis) || typeof (globalThis as any).localStorage?.getItem !== "function") {
```

## Testing

Verified the CLI starts and runs commands successfully on both Node.js v22.22.1 and v25.6.1 (macOS arm64).