### PR TITLE
✨ Quality: Fix `[object Object]` in conflict notice and clarify false conflict message.

### DIFF
--- a/src/modules/coreFeatures/ModuleConflictChecker.ts
+++ b/src/modules/coreFeatures/ModuleConflictChecker.ts
@@ -11,7 +11,7 @@ export class ModuleConflictChecker extends AbstractModule {
         if (this.settings.checkConflictOnlyOnOpen) {
             const af = this.services.vault.getActiveFilePath();
             if (af && af != path) {
-                this._log(`${file} is conflicted, merging process has been postponed.`, LOG_LEVEL_NOTICE);
+                this._log(`Conflict check for '${file.path}' postponed because it's not the active file (setting: checkConflictOnlyOnOpen).`, LOG_LEVEL_NOTICE);
                 return;
             }
         }


### PR DESCRIPTION
## Problem



**Severity**: `high`
**File**: `src/modules/coreFeatures/ModuleConflictChecker.ts`

## Solution



## Changes

- `src/modules/coreFeatures/ModuleConflictChecker.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


Closes #465