### PR TITLE
chore: remove obsolete `version` attribute from docker-compose.yml

### DIFF
--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -1,7 +1,6 @@
 # For details and other explanations about this file refer to:
 # https://github.com/vrtmrz/obsidian-livesync/blob/main/docs/setup_own_server.md#traefik
 
-version: "2.1"
 services:
   couchdb:
     image: couchdb:latest

--- a/docs/setup_own_server.md
+++ b/docs/setup_own_server.md
@@ -230,7 +230,6 @@ And, be sure to check the server log and be careful of malicious access.
 If you are using Traefik, this [docker-compose.yml](https://github.com/vrtmrz/obsidian-livesync/blob/main/docker-compose.traefik.yml) file (also pasted below) has all the right CORS parameters set. It assumes you have an external network called `proxy`.
 
 ```yaml
-version: "2.1"
 services:
   couchdb:
     image: couchdb:latest

--- a/docs/setup_own_server_cn.md
+++ b/docs/setup_own_server_cn.md
@@ -71,7 +71,6 @@ obsidian-livesync
 
 可以参照以下内容编辑 `docker-compose.yml`:
 ```yaml
-version: "2.1"
 services:
   couchdb:
     image: couchdb


### PR DESCRIPTION
### Description
This PR removes the `version: "2.1"` attribute from the `docker-compose.yml` file to resolve the following terminal warning encountered when using modern Docker Compose (V2):

> `WARN[0000] /home/user/.../docker-compose.yml: the attribute version is obsolete, it will be ignored, please remove it to avoid potential confusion`

### Motivation
Under the unified Compose Specification used by Docker Compose V2, the top-level `version` property is officially deprecated and completely ignored by the engine. Since Docker Compose V1 reached its End of Life (EOL) in July 2023, it is safe to omit this property. Removing it cleans up the console output for users deploying the LiveSync CouchDB server. 

Thanks for this cool project btw :)

### Changes
* Removed `version: "2.1"` from the `docker-compose.yml` template.