### PR TITLE
fix: strip trailing slash from couchDB_URI to avoid double-slash 401

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -138,7 +138,7 @@ export const _requestToCouchDBFetch = async (
         authorization: authHeader,
         "content-type": "application/json",
     };
-    const uri = `${baseUri}/${path}`;
+    const uri = `${baseUri.replace(/\/+$/, "")}/${path}`;
     const requestParam = {
         url: uri,
         method: method || (body ? "PUT" : "GET"),
@@ -162,7 +162,7 @@ export const _requestToCouchDB = async (
     const authHeaderGen = new AuthorizationHeaderGenerator();
     const authHeader = await authHeaderGen.getAuthorizationHeader(credentials);
     const transformedHeaders: Record<string, string> = { authorization: authHeader, origin: origin, ...customHeaders };
-    const uri = `${baseUri}/${path}`;
+    const uri = `${baseUri.replace(/\/+$/, "")}/${path}`;
     const requestParam: RequestUrlParam = {
         url: uri,
         method: method || (body ? "PUT" : "GET"),

--- a/src/features/LocalDatabaseMainte/CmdLocalDatabaseMainte.ts
+++ b/src/features/LocalDatabaseMainte/CmdLocalDatabaseMainte.ts
@@ -781,7 +781,8 @@ Success: ${successCount}, Errored: ${errored}`;
         const credential = generateCredentialObject(this.settings);
         const request = async (path: string, method: string = "GET", body: any = undefined) => {
             const req = await _requestToCouchDB(
-                this.settings.couchDB_URI + (this.settings.couchDB_DBNAME ? `/${this.settings.couchDB_DBNAME}` : ""),
+                this.settings.couchDB_URI.replace(/\/+$/, "") +
+                    (this.settings.couchDB_DBNAME ? `/${this.settings.couchDB_DBNAME}` : ""),
                 credential,
                 window.origin,
                 path,


### PR DESCRIPTION
## Problem

When `couchDB_URI` ends with a trailing slash (e.g. `http://127.0.0.1:5984/`), concatenation with the database name produces a double-slash path (`http://127.0.0.1:5984//obsidiannotes`). CouchDB rejects the request with 401 `Name or password is incorrect.` even though the credentials are valid.

Workaround for users today: remove the trailing slash from the URL field manually. This PR removes the need for that.

See #859 for full reproduction and root-cause analysis.

## Fix

Strip trailing slashes at the path-concatenation sites in this repo:

- `src/common/utils.ts` — `_requestToCouchDBFetch` (line 141), `_requestToCouchDB` (line 165)
- `src/features/LocalDatabaseMainte/CmdLocalDatabaseMainte.ts` (line 784)

The replication path lives in `src/lib` (livesync-commonlib) and is fixed in a companion PR there. Both PRs together fully address the issue.

## Testing

### Static checks

| Check | Result |
| --- | --- |
| `npm run lint` (eslint) | ✅ clean |
| `npm run test:unit` (vitest, includes submodule tests via recursive glob) | ✅ 39 files / 889 tests passed |
| `npm run tsc-check` | ⚠️ Pre-existing errors only — none in the files touched by this PR; same errors reproduce on `main`. |

### End-to-end reproduction in a real Obsidian vault against a generic HTTPS CouchDB endpoint

1. With unfixed plugin + URI containing trailing slash → `GET https://example.com//obsidiannotes/` 401 (Unauthorized).
2. With fixed plugin (this PR + companion submodule PR) + same URI → `GET https://example.com/obsidiannotes/` succeeds; only the expected PouchDB "does the remote exist?" 404 probe remains.

Closes #859