### PR TITLE
feat(WIP): auto configuration tweak-values

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,7 @@ import { enableI18nFeature } from "./serviceFeatures/onLayoutReady/enablei18n.ts
 import { useOfflineScanner } from "@lib/serviceFeatures/offlineScanner.ts";
 import { useRemoteConfiguration } from "@lib/serviceFeatures/remoteConfig.ts";
 import { useCheckRemoteSize } from "@lib/serviceFeatures/checkRemoteSize.ts";
+import { useAutoConfig } from "@lib/serviceFeatures/autoConfig.ts";
 import { useRedFlagFeatures } from "./serviceFeatures/redFlag.ts";
 import { useSetupProtocolFeature } from "./serviceFeatures/setupObsidian/setupProtocol.ts";
 import { useSetupQRCodeFeature } from "@lib/serviceFeatures/setupObsidian/qrCode";
@@ -185,6 +186,7 @@ export default class ObsidianLiveSyncPlugin extends Plugin {
                 useOfflineScanner(core);
                 useRedFlagFeatures(core);
                 useCheckRemoteSize(core);
+                useAutoConfig(core);
                 // p2pReplicatorResult = useP2PReplicator(core, [
                 //     VIEW_TYPE_P2P,
                 //     (leaf: any) => new P2PReplicatorPaneView(leaf, core, p2pReplicatorResult!),

--- a/src/modules/features/SettingDialogue/ObsidianLiveSyncSettingTab.ts
+++ b/src/modules/features/SettingDialogue/ObsidianLiveSyncSettingTab.ts
@@ -35,7 +35,8 @@ import { $msg } from "../../../lib/src/common/i18n.ts";
 import { LiveSyncSetting as Setting } from "./LiveSyncSetting.ts";
 import { fireAndForget, yieldNextAnimationFrame } from "octagonal-wheels/promises";
 import { confirmWithMessage } from "../../coreObsidian/UILib/dialogs.ts";
-import { EVENT_REQUEST_RELOAD_SETTING_TAB, eventHub } from "../../../common/events.ts";
+import { EVENT_REQUEST_RELOAD_SETTING_TAB, EVENT_AUTO_CONFIG_KEYS_CHANGED, eventHub } from "../../../common/events.ts";
+import { AutoConfigEfficiencyKeys } from "@lib/common/models/tweak.definition.ts";
 import { JournalSyncMinio } from "../../../lib/src/replication/journal/objectstore/JournalSyncMinio.ts";
 import { paneChangeLog } from "./PaneChangeLog.ts";
 import {
@@ -175,6 +176,14 @@ export class ObsidianLiveSyncSettingTab extends PluginSettingTab {
 
         if (hasChanged) {
             await this.services.setting.saveSettingData();
+        }
+
+        // Notify autoConfig when efficiency-affecting tweak keys are changed.
+        const changedEfficiencyKeys = appliedKeys.filter((k) =>
+            (AutoConfigEfficiencyKeys as string[]).includes(k)
+        ) as (keyof ObsidianLiveSyncSettings)[];
+        if (changedEfficiencyKeys.length > 0) {
+            eventHub.emitEvent(EVENT_AUTO_CONFIG_KEYS_CHANGED, changedEfficiencyKeys);
         }
 
         // if (runOnSaved) {

--- a/src/modules/features/SetupManager.ts
+++ b/src/modules/features/SetupManager.ts
@@ -23,6 +23,8 @@ import SetupRemoteP2P from "./SetupWizard/dialogs/SetupRemoteP2P.svelte";
 import SetupRemoteE2EE from "./SetupWizard/dialogs/SetupRemoteE2EE.svelte";
 import { decodeSettingsFromQRCodeData } from "../../lib/src/API/processSetting.ts";
 import { AbstractModule } from "../AbstractModule.ts";
+import { EVENT_SETTINGS_IMPORTED } from "../../lib/src/events/coreEvents.ts";
+import { eventHub } from "../../lib/src/hub/hub.ts";
 
 /**
  * User modes for onboarding and setup
@@ -374,6 +376,7 @@ export class SetupManager extends AbstractModule {
     async applySetting(newConf: ObsidianLiveSyncSettings, userMode: UserMode) {
         this.services.setting.clearUsedPassphrase();
         await this.services.setting.applyExternalSettings(newConf, true);
+        eventHub.emitEvent(EVENT_SETTINGS_IMPORTED);
         return true;
     }
 }


### PR DESCRIPTION
This PR is intended to achieve the following:
- Automating the resolution of troublesome Tweak Settings as much as possible

We recognise that this PR will result in the loss of the following:
- Abilities that users apply settings with a clear purpose.
- Users' awareness of database efficiency explicitly.

Justification for the loss of compatibility
- We realised that managing the tweak values themselves was a faff and a source of stress in its own.
- Also, automatically adjusting and reporting the results to the user makes it easier to optimise the migration.

Note
- This feature does not work with configuration changes that break compatibility.