### PR TITLE
chore: Change eslint config to ignore _tools

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -38,6 +38,7 @@ export default [
             "modules/octagonal-wheels/rollup.config.js",
             "modules/octagonal-wheels/dist/**/*",
             "src/lib/test",
+            "src/lib/_tools",
             "src/lib/src/cli",
             "**/main.js",
             "src/apps/**/*",


### PR DESCRIPTION
Add `src/lib/_tools` to the ignore list of eslint