### PR TITLE
fix: truncate sub-millisecond CLI mtimes to prevent mobile crash

### DIFF
--- a/src/apps/cli/adapters/NodeFileSystemAdapter.ts
+++ b/src/apps/cli/adapters/NodeFileSystemAdapter.ts
@@ -104,8 +104,8 @@ export class NodeFileSystemAdapter implements IFileSystemAdapter<NodeFile, NodeF
                 path: pathStr as FilePath,
                 stat: {
                     size: stat.size,
-                    mtime: stat.mtimeMs,
-                    ctime: stat.ctimeMs,
+                    mtime: Math.floor(stat.mtimeMs),
+                    ctime: Math.floor(stat.ctimeMs),
                     type: "file",
                 },
             };
@@ -137,8 +137,8 @@ export class NodeFileSystemAdapter implements IFileSystemAdapter<NodeFile, NodeF
                         path: entryRelativePath as FilePath,
                         stat: {
                             size: stat.size,
-                            mtime: stat.mtimeMs,
-                            ctime: stat.ctimeMs,
+                            mtime: Math.floor(stat.mtimeMs),
+                            ctime: Math.floor(stat.ctimeMs),
                             type: "file",
                         },
                     };

--- a/src/apps/cli/adapters/NodeStorageAdapter.ts
+++ b/src/apps/cli/adapters/NodeStorageAdapter.ts
@@ -28,8 +28,8 @@ export class NodeStorageAdapter implements IStorageAdapter<NodeStat> {
             const stat = await fs.stat(this.resolvePath(p));
             return {
                 size: stat.size,
-                mtime: stat.mtimeMs,
-                ctime: stat.ctimeMs,
+                mtime: Math.floor(stat.mtimeMs),
+                ctime: Math.floor(stat.ctimeMs),
                 type: stat.isDirectory() ? "folder" : "file",
             };
         } catch {

--- a/src/apps/cli/adapters/NodeVaultAdapter.ts
+++ b/src/apps/cli/adapters/NodeVaultAdapter.ts
@@ -66,8 +66,8 @@ export class NodeVaultAdapter implements IVaultAdapter<NodeFile> {
             path: p as any,
             stat: {
                 size: stat.size,
-                mtime: stat.mtimeMs,
-                ctime: stat.ctimeMs,
+                mtime: Math.floor(stat.mtimeMs),
+                ctime: Math.floor(stat.ctimeMs),
                 type: "file",
             },
         };
@@ -89,8 +89,8 @@ export class NodeVaultAdapter implements IVaultAdapter<NodeFile> {
             path: p as any,
             stat: {
                 size: stat.size,
-                mtime: stat.mtimeMs,
-                ctime: stat.ctimeMs,
+                mtime: Math.floor(stat.mtimeMs),
+                ctime: Math.floor(stat.ctimeMs),
                 type: "file",
             },
         };

--- a/src/apps/cli/commands/runCommand.ts
+++ b/src/apps/cli/commands/runCommand.ts
@@ -83,8 +83,8 @@ export async function runCommand(options: CLIOptions, context: CLICommandContext
         console.log(`[Command] push ${sourcePath} -> ${destinationDatabasePath}`);
 
         await core.serviceModules.storageAccess.writeFileAuto(destinationDatabasePath, toArrayBuffer(sourceData), {
-            mtime: sourceStat.mtimeMs,
-            ctime: sourceStat.ctimeMs,
+            mtime: Math.floor(sourceStat.mtimeMs),
+            ctime: Math.floor(sourceStat.ctimeMs),
         });
         const destinationPathWithPrefix = destinationDatabasePath as FilePathWithPrefix;
         const stored = await core.serviceModules.fileHandler.storeFileToDB(destinationPathWithPrefix, true);


### PR DESCRIPTION
## Problem

The headless `livesync-cli` on Linux stores Node's `fs.Stats.mtimeMs` and `ctimeMs` raw, producing CouchDB document timestamps like `1778511180024.462`. Linux's nanosecond-precision filesystem mtime makes these floats; GUI plugins on other platforms write integer milliseconds.

Mobile clients on LiveSync 0.25.60 have been observed to crash when processing change-feed updates carrying these non-integer millisecond timestamps from CLI-written documents; whether older mobile versions are also affected hasn't been investigated. The crash reproduces both on startup (catching up a backlog) and mid-session (single incoming edit). PC and tablet writes don't trigger it because they write integer milliseconds — only the CLI on Linux exposes the issue.

Workaround until patched: open mobile Obsidian while the device can't reach CouchDB (wifi off, airplane mode, etc.), let it fully initialize, then restore connectivity. This avoids the startup-burst crash but not mid-session crashes from new CLI writes.

## Fix

`Math.floor()` applied at every site where `stat.mtimeMs` / `stat.ctimeMs` is read into a `NodeStat`:

- `src/apps/cli/adapters/NodeVaultAdapter.ts` — 2 sites
- `src/apps/cli/adapters/NodeFileSystemAdapter.ts` — 2 sites
- `src/apps/cli/adapters/NodeStorageAdapter.ts` — 1 site
- `src/apps/cli/commands/runCommand.ts` — 1 site (`push` subcommand)

4 files, 12+/12-. No behavioral change on Windows or macOS (`mtimeMs` already integer-valued there).

Existing documents with fractional mtimes self-heal after the patched CLI restarts: the mirror cycle sees that the integer mtime from disk no longer matches the stored float and re-uploads with integer mtime. Mobile clients catching up via `_changes` see only the latest rev per doc, so historical fractional revs become invisible without explicit cleanup.

## Verification

Document written by CLI before patch:
```
"mtime": 1778511180024.462
```

Document written by CLI after patch:
```
"mtime": 1778556566277
```

Mobile app no longer crashes on incoming CLI writes against a real CouchDB + mobile LiveSync 0.25.60 deployment.