### PR TITLE
fixed: fixed unexpected error during startup

### DIFF
--- a/src/modules/main/ModuleLiveSyncMain.ts
+++ b/src/modules/main/ModuleLiveSyncMain.ts
@@ -61,10 +61,12 @@ export class ModuleLiveSyncMain extends AbstractModule {
         eventHub.onEvent(EVENT_SETTING_SAVED, (settings: ObsidianLiveSyncSettings) => {
             fireAndForget(async () => {
                 try {
-                    await this.core.services.control.applySettings();
-                    const lang = this.core.services.setting.currentSettings()?.displayLanguage ?? undefined;
+                    const lang = this.core.services.setting.currentSettings()?.displayLanguage;
                     if (lang !== undefined) {
-                        setLang(this.core.services.setting.currentSettings()?.displayLanguage);
+                        setLang(lang);
+                    }
+                    if (this.core.services.database.isDatabaseReady()) {
+                        await this.core.services.control.applySettings();
                     }
                     eventHub.emitEvent(EVENT_REQUEST_RELOAD_SETTING_TAB);
                 } catch (e) {

--- a/updates.md
+++ b/updates.md
@@ -3,6 +3,11 @@ Since 19th July, 2025 (beta1 in 0.25.0-beta1, 13th July, 2025)
 
 The head note of 0.25 is now in [updates_old.md](https://github.com/vrtmrz/obsidian-livesync/blob/main/updates_old.md). Because 0.25 got a lot of updates, thankfully, compatibility is kept and we do not need breaking changes! In other words, when get enough stabled. The next version will be v1.0.0. Even though it my hope.
 
+## Unreleased
+
+### Fixed
+- No longer baffling errors occur when setting-update is triggered during the early stage of initialisation.
+
 ## 0.25.60
 
 29th April, 2026


### PR DESCRIPTION
Minor fix:

- No longer baffling errors occur when the setting update is triggered during the early stage of initialisation.