### PR TITLE
fix: resolve build error with @smithy/util-retry in vite config

### DIFF
--- a/src/apps/cli/vite.config.ts
+++ b/src/apps/cli/vite.config.ts
@@ -14,6 +14,7 @@ const defaultExternal = [
     "chokidar",
     "punycode",
     "werift",
+    "@smithy/util-retry",
 ];
 // Polyfill FileReader at the very top of the CJS bundle. octagonal-wheels uses
 // FileReader for base64 conversion when Uint8Array.toBase64 (TC39 proposal) is


### PR DESCRIPTION
**Description**

This PR addresses a build failure in the obsidian-livesync CLI when building via Docker. The build process was failing with an error indicating that Vite could not resolve the @smithy/util-retry dependency imported by JournalSyncMinio.ts.

**Changes**
 - src/apps/cli/vite.config.ts: Added @smithy/util-retry to the defaultExternal array.

**Impact**
This ensures that Vite treats @smithy/util-retry as an external runtime dependency rather than attempting to bundle it, which resolves the module resolution error during the CLI build process and aligns with the existing configuration for other external Node.js dependencies.

**Verification**
 - Reproduced the build error locally.
 - Applied the fix to vite.config.ts.
 - Verified that npm run build completes successfully.

Use following script to verify a failure

```
#!/bin/bash
set -e

# Configuration
REPO_URL="https://github.com/vrtmrz/obsidian-livesync.git"
TAG="main"
IMAGE_NAME="obsidian-livesync-cli:cli-sync-SNAPSHOT"
BUILD_DIR="tmp-build-repo"

echo "--- Starting build for $IMAGE_NAME ---"

# Cleanup any previous failed attempts
rm -rf "$BUILD_DIR"

# 1. Clone the specific tag with submodules (CRITICAL for src/lib)
echo "Cloning $TAG with submodules from $REPO_URL..."
git clone --depth 1 --branch "$TAG" --recurse-submodules --shallow-submodules "$REPO_URL" "$BUILD_DIR"

# 2. Build using the official Dockerfile from the repo root
echo "Building Docker image..."
cd "$BUILD_DIR"
docker build -f src/apps/cli/Dockerfile -t "$IMAGE_NAME" .

# 3. Cleanup
echo "Cleaning up build files..."
cd ..
rm -rf "$BUILD_DIR"

echo "--- Build Complete: $IMAGE_NAME is now available locally ---"
```

Fails with
```
> vite build

4:07:53 AM [vite-plugin-svelte] no Svelte config found at /build/src/apps/cli - using default configuration.
vite v7.3.3 building client environment for production...
transforming...
✓ 179 modules transformed.
✗ Build failed in 986ms
error during build:
[vite]: Rollup failed to resolve import "@smithy/util-retry" from "/build/src/lib/src/replication/journal/objectstore/JournalSyncMinio.ts".
This is most likely unintended because it can break your application at runtime.
If you do want to externalize this module explicitly add it to
`build.rollupOptions.external`
    at viteLog (file:///build/node_modules/vite/dist/node/chunks/config.js:33655:57)
    at onRollupLog (file:///build/node_modules/vite/dist/node/chunks/config.js:33685:7)
    at onLog (file:///build/node_modules/vite/dist/node/chunks/config.js:33487:4)
    at file:///build/node_modules/rollup/dist/es/shared/node-entry.js:21390:32
    at Object.logger [as onLog] (file:///build/node_modules/rollup/dist/es/shared/node-entry.js:23385:9)
    at ModuleLoader.handleInvalidResolvedId (file:///build/node_modules/rollup/dist/es/shared/node-entry.js:22129:26)
    at file:///build/node_modules/rollup/dist/es/shared/node-entry.js:22087:26
The command '/bin/sh -c cd src/apps/cli && npm run build' returned a non-zero code: 1
```