### PR TITLE
bugfix: Add package-lock.json into docker build

### DIFF
--- a/src/apps/cli/Dockerfile
+++ b/src/apps/cli/Dockerfile
@@ -60,7 +60,7 @@ RUN apt-get update \
 WORKDIR /build
 
 # Install workspace dependencies first (layer-cache friendly)
-COPY package.json ./
+COPY package.json package-lock.json ./
 RUN npm install
 
 # Copy the full source tree and build the CLI bundle


### PR DESCRIPTION
Add lock file to allow the docker to stick with the dependencies and not to drift and pick latest ones.

This prevents failures like this due to a recent update in `@smithy/*`

```
[1/3] STEP 7/7: RUN cd src/apps/cli && npm run build

> self-hosted-livesync-cli@0.0.0 prebuild
> node scripts/check-submodule.mjs


> self-hosted-livesync-cli@0.0.0 build
> vite build

6:09:54 AM [vite-plugin-svelte] no Svelte config found at /build/src/apps/cli - using default configuration.
vite v7.3.3 building client environment for production...
transforming...
✓ 308 modules transformed.
✗ Build failed in 630ms
error during build:
[vite:load-fallback] Could not load /build/node_modules/@smithy/util-retry (imported by ../../lib/src/replication/journal/objectstore/JournalSyncMinio.ts): ENOENT: no such file or directory, open '/build/node_modules/@smithy/util-retry'
    at async open (node:internal/fs/promises:639:25)
    at async Object.readFile (node:internal/fs/promises:1249:14)
    at async Object.handler (file:///build/node_modules/vite/dist/node/chunks/config.js:33189:21)
    at async PluginDriver.hookFirstAndGetPlugin (file:///build/node_modules/rollup/dist/es/shared/node-entry.js:22870:28)
    at async file:///build/node_modules/rollup/dist/es/shared/node-entry.js:21854:33
    at async Queue.work (file:///build/node_modules/rollup/dist/es/shared/node-entry.js:23098:32)
Error: building at STEP "RUN cd src/apps/cli && npm run build": while running runtime: exit status 1
```