### PR TITLE
fix: use true conflict ancestor for auto merge

### DIFF
--- a/src/features/HiddenFileSync/CmdHiddenFileSync.ts
+++ b/src/features/HiddenFileSync/CmdHiddenFileSync.ts
@@ -721,13 +721,11 @@ Offline Changed files: ${processFiles.length}`;
 
                 if (path.endsWith(".json")) {
                     const conflictedRev = conflicts[0];
-                    const conflictedRevNo = Number(conflictedRev.split("-")[0]);
-                    //Search
-                    const revFrom = await this.localDatabase.getRaw<MetaEntry>(id, { revs_info: true });
-                    const commonBase =
-                        revFrom._revs_info
-                            ?.filter((e) => e.status == "available" && Number(e.rev.split("-")[0]) < conflictedRevNo)
-                            .first()?.rev ?? "";
+                    const commonBase = await this.localDatabase.managers.conflictManager.findCommonAncestorRevById(
+                        id,
+                        doc._rev,
+                        conflictedRev
+                    );
                     const result = await this.localDatabase.managers.conflictManager.mergeObject(
                         doc.path,
                         commonBase,


### PR DESCRIPTION
## Summary
- update commonlib to the conflict ancestor fix from vrtmrz/livesync-commonlib#39
- use the same true common-ancestor lookup for hidden JSON file conflict merging
- prevent stale device branches from being auto-merged as deletions of newer edits

## Test
- npm run test:unit -- src/lib/src/managers/ConflictManager.unit.spec.ts
- npm run tsc-check
- npx prettier --config ./.prettierrc.mjs --check src/lib/src/managers/ConflictManager.ts src/lib/src/managers/ConflictManager.unit.spec.ts src/features/HiddenFileSync/CmdHiddenFileSync.ts
- npx eslint src/lib/src/managers/ConflictManager.ts src/lib/src/managers/ConflictManager.unit.spec.ts src/features/HiddenFileSync/CmdHiddenFileSync.ts

Depends on vrtmrz/livesync-commonlib#39 for the submodule commit.