### PR TITLE
0.25.69: Fix P2P, add diag feature

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "obsidian-livesync",
     "name": "Self-hosted LiveSync",
-    "version": "0.25.68",
+    "version": "0.25.69",
     "minAppVersion": "1.7.2",
     "description": "Community implementation of self-hosted livesync. Reflect your vault changes to some other devices immediately. Please make sure to disable other synchronize solutions to avoid content corruption or duplication.",
     "author": "vorotamoroz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "obsidian-livesync",
-    "version": "0.25.68",
+    "version": "0.25.69",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "obsidian-livesync",
-            "version": "0.25.68",
+            "version": "0.25.69",
             "license": "MIT",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "obsidian-livesync",
-    "version": "0.25.68",
+    "version": "0.25.69",
     "description": "Reflect your vault changes to some other devices immediately. Please make sure to disable other synchronize solutions to avoid content corruption or duplication.",
     "main": "main.js",
     "type": "module",

--- a/src/features/P2PSync/P2PReplicator/P2PServerStatusCard.svelte
+++ b/src/features/P2PSync/P2PReplicator/P2PServerStatusCard.svelte
@@ -24,6 +24,7 @@
     let serverInfo = $state<P2PServerInfo | undefined>(undefined);
     let replicatorStatus = $state<P2PReplicatorStatus | undefined>(undefined);
     let roomSuffix = $state<string>(extractP2PRoomSuffix(core?.services.setting.currentSettings()?.P2P_roomID ?? ""));
+    let useDiagRTC = $state<boolean>(core?.services.setting.currentSettings()?.P2P_useDiagRTC ?? false);
 
     async function requestServerStatus() {
         await Promise.resolve(liveSyncReplicator.requestStatus());
@@ -48,6 +49,18 @@
         }
     }
 
+    async function toggleDiagRTC() {
+        if (!core) {
+            return;
+        }
+        const next = !useDiagRTC;
+        await core.services.setting.updateSettings((settings) => {
+            settings.P2P_useDiagRTC = next;
+            return settings;
+        }, true);
+        useDiagRTC = next;
+    }
+
     onMount(() => {
         const unsubscribe = eventHub.onEvent(EVENT_SERVER_STATUS, (status) => {
             serverInfo = status;
@@ -58,6 +71,7 @@
         });
         const unsubscribeSettings = eventHub.onEvent(EVENT_SETTING_SAVED, (settings) => {
             roomSuffix = extractP2PRoomSuffix(settings?.P2P_roomID ?? "");
+            useDiagRTC = settings?.P2P_useDiagRTC ?? false;
         });
 
         fireAndForget(async () => {
@@ -131,6 +145,48 @@
         </button>
     </div>
     {/if}
+
+    {#if core}
+    <div class="status-item status-action diag-toggle-row">
+        <label class="broadcast-label" for="diag-toggle">
+            🕵️ Diag
+        </label>
+        <button
+            id="diag-toggle"
+            class="broadcast-button {useDiagRTC ? 'is-on' : 'is-off'}"
+            onclick={toggleDiagRTC}
+            title={useDiagRTC
+                ? 'Diagnostic RTCPeerConnection is enabled'
+                : 'Use Diagnostic RTCPeerConnection for statistics'}
+        >
+            {useDiagRTC ? 'On' : 'Off'}
+        </button>
+    </div>
+    {/if}
+
+    {#if serverInfo}
+        <div class="diag-section">
+            <h4>Stats</h4>
+            <div class="diag-grid">
+                <div class="diag-item">
+                    <span>Incoming:</span>
+                    <span>{serverInfo.diag.totalNewConnections}</span>
+                </div>
+                <div class="diag-item">
+                    <span>Connected:</span>
+                    <span>{serverInfo.diag.totalSuccessfulConnections}</span>
+                </div>
+                <div class="diag-item">
+                    <span>Failed:</span>
+                    <span>{serverInfo.diag.totalFailedConnections}</span>
+                </div>
+                <div class="diag-item">
+                    <span>Closed:</span>
+                    <span>{serverInfo.diag.totalClosedConnections}</span>
+                </div>
+            </div>
+        </div>
+    {/if}
 </div>
 
 <style>
@@ -190,6 +246,11 @@
         margin-top: 0.25rem;
     }
 
+    .diag-toggle-row {
+        align-items: center;
+        margin-top: 0.25rem;
+    }
+
     .broadcast-label {
         font-size: 0.9rem;
         color: var(--text-normal);
@@ -220,5 +281,30 @@
     .broadcast-button.is-off:hover {
         background-color: var(--interactive-hover);
         color: var(--text-normal);
+    }
+
+    .diag-section {
+        border-top: 1px solid var(--divider-color);
+        margin-top: 0.75rem;
+        padding-top: 0.75rem;
+    }
+
+    .diag-section h4 {
+        margin: 0 0 0.5rem 0;
+        font-size: 0.9rem;
+        font-weight: 600;
+    }
+
+    .diag-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+        gap: 0.35rem 0.75rem;
+    }
+
+    .diag-item {
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.85rem;
+        gap: 0.5rem;
     }
 </style>

--- a/src/modules/features/SetupManager.ts
+++ b/src/modules/features/SetupManager.ts
@@ -7,7 +7,7 @@ import {
     REMOTE_MINIO,
     REMOTE_P2P,
 } from "../../lib/src/common/types.ts";
-import { generatePatchObj, isObjectDifferent } from "../../lib/src/common/utils.ts";
+import { isObjectDifferent } from "@lib/common/utils.ts";
 import Intro from "./SetupWizard/dialogs/Intro.svelte";
 import SelectMethodNewUser from "./SetupWizard/dialogs/SelectMethodNewUser.svelte";
 import SelectMethodExisting from "./SetupWizard/dialogs/SelectMethodExisting.svelte";
@@ -23,6 +23,7 @@ import SetupRemoteP2P from "./SetupWizard/dialogs/SetupRemoteP2P.svelte";
 import SetupRemoteE2EE from "./SetupWizard/dialogs/SetupRemoteE2EE.svelte";
 import { decodeSettingsFromQRCodeData } from "../../lib/src/API/processSetting.ts";
 import { AbstractModule } from "../AbstractModule.ts";
+import { ConnectionStringParser } from "@lib/common/ConnectionString.ts";
 
 /**
  * User modes for onboarding and setup
@@ -194,8 +195,24 @@ export class SetupManager extends AbstractModule {
             return await this.onOnboard(userMode);
         }
         const newSetting = { ...currentSetting, ...p2pConf } as ObsidianLiveSyncSettings;
+        // Apply remoteConfigurations
+        if (newSetting.P2P_ActiveRemoteConfigurationId) {
+            const id = newSetting.P2P_ActiveRemoteConfigurationId;
+            const merged = {
+                ...newSetting,
+                ...p2pConf,
+            } as ObsidianLiveSyncSettings;
+            const uri = ConnectionStringParser.serialize({ type: "p2p", settings: merged });
+            newSetting.remoteConfigurations[id] = {
+                ...newSetting.remoteConfigurations[id],
+                uri,
+                isEncrypted: false,
+            };
+            newSetting.P2P_ActiveRemoteConfigurationId = id;
+        }
         if (activate) {
             newSetting.remoteType = REMOTE_P2P;
+            newSetting.activeConfigurationId = newSetting.P2P_ActiveRemoteConfigurationId;
         }
         return await this.onConfirmApplySettingsFromWizard(newSetting, userMode, activate);
     }
@@ -285,9 +302,9 @@ export class SetupManager extends AbstractModule {
                 this._log("No changes in settings detected. Skipping applying settings from wizard.", LOG_LEVEL_NOTICE);
                 return true;
             }
-            const patch = generatePatchObj(this.settings, newConf);
-            console.log(`Changes:`);
-            console.dir(patch);
+            // const patch = generatePatchObj(this.settings, newConf);
+            // console.log(`Changes:`);
+            // console.dir(patch);
             if (!activate) {
                 extra();
                 await this.applySetting(newConf, UserMode.ExistingUser);

--- a/updates.md
+++ b/updates.md
@@ -3,7 +3,7 @@ Since 19th July, 2025 (beta1 in 0.25.0-beta1, 13th July, 2025)
 
 The head note of 0.25 is now in [updates_old.md](https://github.com/vrtmrz/obsidian-livesync/blob/main/updates_old.md). Because 0.25 got a lot of updates, thankfully, compatibility is kept and we do not need breaking changes! In other words, when get enough stabled. The next version will be v1.0.0. Even though it my hope.
 
-## Unreleased
+## 0.25.69
 
 22nd May, 2026
 

--- a/updates.md
+++ b/updates.md
@@ -8,12 +8,12 @@ The head note of 0.25 is now in [updates_old.md](https://github.com/vrtmrz/obsid
 22nd May, 2026
 
 ### Fixed
-- No longer the P2P passphrase mismatch causes a server shutdown.
+- No longer does the P2P passphrase mismatch cause a server shutdown.
 - Settings related to P2P synchronisation are now correctly applied on start-up and no longer reverted.
 
 ### New features
 - Diagnostic P2P connection stats are now available.
-  - These stats indicate the number of connection trials, successes, and, failures.
+  - These stats indicate the number of connection trials, successes, and failures.
 
 ## 0.25.68
 

--- a/updates.md
+++ b/updates.md
@@ -3,6 +3,18 @@ Since 19th July, 2025 (beta1 in 0.25.0-beta1, 13th July, 2025)
 
 The head note of 0.25 is now in [updates_old.md](https://github.com/vrtmrz/obsidian-livesync/blob/main/updates_old.md). Because 0.25 got a lot of updates, thankfully, compatibility is kept and we do not need breaking changes! In other words, when get enough stabled. The next version will be v1.0.0. Even though it my hope.
 
+## Unreleased
+
+22nd May, 2026
+
+### Fixed
+- No longer the P2P passphrase mismatch causes a server shutdown.
+- Settings related to P2P synchronisation are now correctly applied on start-up and no longer reverted.
+
+### New features
+- Diagnostic P2P connection stats are now available.
+  - These stats indicate the number of connection trials, successes, and, failures.
+
 ## 0.25.68
 
 22nd May, 2026


### PR DESCRIPTION
## 0.25.69

22nd May, 2026

### Fixed
- No longer does the P2P passphrase mismatch cause a server shutdown.
- Settings related to P2P synchronisation are now correctly applied on start-up and no longer reverted.

### New features
- Diagnostic P2P connection stats are now available.
  - These stats indicate the number of connection trials, successes, and failures.