### PR TITLE
fix: adjust CouchDB's database name checking to its specification 

### DIFF
--- a/src/modules/features/SetupWizard/dialogs/SetupRemoteCouchDB.svelte
+++ b/src/modules/features/SetupWizard/dialogs/SetupRemoteCouchDB.svelte
@@ -180,7 +180,7 @@
         autocapitalize="off"
         spellcheck="false"
         required
-        pattern="^[a-z0-9][a-z0-9_]*$"
+        pattern="^[a-z][a-z0-9_$()+/-]*$"
         bind:value={syncSetting.couchDB_DBNAME}
     />
 </InputRow>

--- a/updates.md
+++ b/updates.md
@@ -3,6 +3,12 @@ Since 19th July, 2025 (beta1 in 0.25.0-beta1, 13th July, 2025)
 
 The head note of 0.25 is now in [updates_old.md](https://github.com/vrtmrz/obsidian-livesync/blob/main/updates_old.md). Because 0.25 got a lot of updates, thankfully, compatibility is kept and we do not need breaking changes! In other words, when get enough stabled. The next version will be v1.0.0. Even though it my hope.
 
+## Unreleased
+
+### Fixed
+
+- Adjust CouchDB's database name checking to its specification (#926).
+
 ## ~~0.25.71~~ 0.25.72
 
 0.25.71 was cancelled due to the fixes needed (Object Storage related)


### PR DESCRIPTION
### Fixed

- Adjust CouchDB's database name checking to its specification (#926).