### PR TITLE
feat: opt-in desktop setting to keep replication active in the background

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -488,6 +488,11 @@ Automatically Sync all files when opening Obsidian.
 Setting key: syncAfterMerge
 Sync automatically after merging files
 
+#### Keep replication active in the background
+
+Setting key: keepReplicationActiveInBackground
+Desktop only; uses more battery and network.
+
 ### 3. Update thinning
 
 #### Batch database update

--- a/src/modules/essentialObsidian/ModuleObsidianEvents.ts
+++ b/src/modules/essentialObsidian/ModuleObsidianEvents.ts
@@ -2,7 +2,7 @@ import { AbstractObsidianModule } from "../AbstractObsidianModule.ts";
 import { EVENT_FILE_RENAMED, EVENT_LEAF_ACTIVE_CHANGED, eventHub } from "../../common/events.js";
 import { LOG_LEVEL_NOTICE, LOG_LEVEL_VERBOSE } from "octagonal-wheels/common/logger";
 import { scheduleTask } from "octagonal-wheels/concurrency/task";
-import { Platform, type TFile } from "../../deps.ts";
+import type { TFile } from "../../deps.ts";
 import { fireAndForget } from "octagonal-wheels/promises";
 import { type FilePathWithPrefix } from "../../lib/src/common/types.ts";
 import { reactive, reactiveSource, type ReactiveSource } from "octagonal-wheels/dataobject/reactive";
@@ -146,7 +146,7 @@ export class ModuleObsidianEvents extends AbstractObsidianModule {
         const keepActiveInBackground =
             this.settings.keepReplicationActiveInBackground &&
             (this.settings.liveSync || this.settings.periodicReplication) &&
-            Platform.isDesktopApp;
+            !this.services.API.isMobile();
 
         if (isHidden) {
             if (!keepActiveInBackground) await this.services.appLifecycle.onSuspending();

--- a/src/modules/essentialObsidian/ModuleObsidianEvents.ts
+++ b/src/modules/essentialObsidian/ModuleObsidianEvents.ts
@@ -2,7 +2,7 @@ import { AbstractObsidianModule } from "../AbstractObsidianModule.ts";
 import { EVENT_FILE_RENAMED, EVENT_LEAF_ACTIVE_CHANGED, eventHub } from "../../common/events.js";
 import { LOG_LEVEL_NOTICE, LOG_LEVEL_VERBOSE } from "octagonal-wheels/common/logger";
 import { scheduleTask } from "octagonal-wheels/concurrency/task";
-import { type TFile } from "../../deps.ts";
+import { Platform, type TFile } from "../../deps.ts";
 import { fireAndForget } from "octagonal-wheels/promises";
 import { type FilePathWithPrefix } from "../../lib/src/common/types.ts";
 import { reactive, reactiveSource, type ReactiveSource } from "octagonal-wheels/dataobject/reactive";
@@ -138,12 +138,38 @@ export class ModuleObsidianEvents extends AbstractObsidianModule {
 
         await this.services.fileProcessing.commitPendingFileEvents();
 
+        // Desktop opt-in (LiveSync/Periodic only): keep the background channel running while the
+        // window is hidden, instead of suspending on hide. On hide we skip the suspend for both
+        // modes (LiveSync's continuous replication and Periodic's timer both stall otherwise);
+        // becoming visible reopens normally, and for LiveSync additionally forces a teardown first
+        // (see the resume branch) so a stalled continuous channel is always replaced.
+        const keepActiveInBackground =
+            this.settings.keepReplicationActiveInBackground &&
+            (this.settings.liveSync || this.settings.periodicReplication) &&
+            Platform.isDesktopApp;
+
         if (isHidden) {
-            await this.services.appLifecycle.onSuspending();
+            if (!keepActiveInBackground) await this.services.appLifecycle.onSuspending();
         } else {
             // suspend all temporary.
             if (this.services.appLifecycle.isSuspended()) return;
-            // Do not block resume by focus state here; visibility recovery should be enough.
+            // Only the continuous (LiveSync) channel can go stalled-but-not-terminated: PouchDB
+            // emits paused/retry while the replicator keeps its AbortController set, so the reopen
+            // below would no-op on exactly the channel that needs replacing. Force a teardown first
+            // so becoming visible always re-establishes a fresh channel (restoring the default's
+            // reset-on-visibility). Periodic mode has no such channel — its timer just resumes via
+            // the normal path below — so this teardown is gated on liveSync to avoid needlessly
+            // bouncing it. The teardown's closeReplication() aborts synchronously while the reopen is
+            // deferred (fireAndForget + awaited isReplicationReady/initializeDatabaseForReplication),
+            // so the aborted continuousReplication run (and its shareRunningResult lock) unwinds in
+            // microtasks before the reopen runs: it neither double-opens nor gets swallowed by the
+            // still-registered shared run.
+            if (keepActiveInBackground && this.settings.liveSync) {
+                await this.services.appLifecycle.onSuspending();
+            }
+            // Resume is not gated on focus in this branch, but note the top-of-handler check
+            // (isLastHidden && !hasFocus) still defers the whole handler when the window becomes
+            // visible again while unfocused; in that case recovery happens on the next focus.
             await this.services.appLifecycle.onResuming();
             await this.services.appLifecycle.onResumed();
         }

--- a/src/modules/essentialObsidian/ModuleObsidianEvents.unit.spec.ts
+++ b/src/modules/essentialObsidian/ModuleObsidianEvents.unit.spec.ts
@@ -1,11 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 
-// Unit tests stub out `obsidian`, so deps.ts (which re-exports from it) can't be loaded for real.
-// ModuleObsidianEvents only needs `Platform` from deps at runtime; provide a mutable stub so each
-// test can choose desktop vs mobile.
-vi.mock("../../deps.ts", () => ({ Platform: { isDesktopApp: true } }));
-
-import { Platform } from "../../deps.ts";
 import { ModuleObsidianEvents } from "./ModuleObsidianEvents";
 import { DEFAULT_SETTINGS, REMOTE_COUCHDB } from "@lib/common/types";
 
@@ -15,6 +9,8 @@ type SetupOptions = {
     isLastHidden?: boolean;
     hasFocus?: boolean;
     isSuspended?: boolean;
+    // Platform is read via services.API.isMobile(); default desktop (false) so the feature applies.
+    isMobile?: boolean;
 };
 
 function setup(opts: SetupOptions) {
@@ -35,6 +31,7 @@ function setup(opts: SetupOptions) {
                 registerWindow: vi.fn(),
                 addRibbonIcon: vi.fn(),
                 registerProtocolHandler: vi.fn(),
+                isMobile: vi.fn(() => opts.isMobile ?? false),
             },
             setting: { saveSettingData: vi.fn(async () => undefined) },
             appLifecycle,
@@ -60,15 +57,10 @@ function setup(opts: SetupOptions) {
 }
 
 describe("watchWindowVisibilityAsync — keepReplicationActiveInBackground", () => {
-    beforeEach(() => {
-        (Platform as any).isDesktopApp = true;
-    });
-
     afterEach(() => {
-        // The handler reads a global `activeWindow`; the Platform mock is module-scoped. Both would
-        // otherwise leak into sibling spec files running in the same worker, so reset them here.
+        // The handler reads a global `activeWindow`; clear it so it doesn't leak into sibling spec
+        // files running in the same worker.
         delete (globalThis as any).activeWindow;
-        (Platform as any).isDesktopApp = true;
     });
 
     it("does NOT suspend on hide when enabled in LiveSync mode on the desktop app", async () => {
@@ -162,11 +154,11 @@ describe("watchWindowVisibilityAsync — keepReplicationActiveInBackground", () 
         expect(appLifecycle.onResumed).toHaveBeenCalledTimes(1);
     });
 
-    it("does not apply on a non-desktop app even if the flag is set", async () => {
-        (Platform as any).isDesktopApp = false;
+    it("does not apply on mobile even if the flag is set", async () => {
         const { module, appLifecycle } = setup({
             settings: { keepReplicationActiveInBackground: true, liveSync: true },
             hidden: true,
+            isMobile: true,
         });
         await module.watchWindowVisibilityAsync();
         expect(appLifecycle.onSuspending).toHaveBeenCalledTimes(1);

--- a/src/modules/essentialObsidian/ModuleObsidianEvents.unit.spec.ts
+++ b/src/modules/essentialObsidian/ModuleObsidianEvents.unit.spec.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Unit tests stub out `obsidian`, so deps.ts (which re-exports from it) can't be loaded for real.
+// ModuleObsidianEvents only needs `Platform` from deps at runtime; provide a mutable stub so each
+// test can choose desktop vs mobile.
+vi.mock("../../deps.ts", () => ({ Platform: { isDesktopApp: true } }));
+
+import { Platform } from "../../deps.ts";
+import { ModuleObsidianEvents } from "./ModuleObsidianEvents";
+import { DEFAULT_SETTINGS, REMOTE_COUCHDB } from "@lib/common/types";
+
+type SetupOptions = {
+    settings?: Partial<typeof DEFAULT_SETTINGS>;
+    hidden: boolean;
+    isLastHidden?: boolean;
+    hasFocus?: boolean;
+    isSuspended?: boolean;
+};
+
+function setup(opts: SetupOptions) {
+    const appLifecycle = {
+        isReady: vi.fn(() => true),
+        isSuspended: vi.fn(() => opts.isSuspended ?? false),
+        onSuspending: vi.fn(async () => true),
+        onResuming: vi.fn(async () => true),
+        onResumed: vi.fn(async () => true),
+    };
+    const fileProcessing = { commitPendingFileEvents: vi.fn(async () => true) };
+
+    const core = {
+        _services: {
+            API: {
+                addLog: vi.fn(),
+                addCommand: vi.fn(),
+                registerWindow: vi.fn(),
+                addRibbonIcon: vi.fn(),
+                registerProtocolHandler: vi.fn(),
+            },
+            setting: { saveSettingData: vi.fn(async () => undefined) },
+            appLifecycle,
+            fileProcessing,
+        },
+        settings: {
+            ...DEFAULT_SETTINGS,
+            remoteType: REMOTE_COUCHDB,
+            isConfigured: true,
+            ...opts.settings,
+        },
+    } as any;
+    Object.defineProperty(core, "services", { get: () => core._services });
+
+    const module = new ModuleObsidianEvents({} as any, core);
+    module.isLastHidden = opts.isLastHidden ?? false;
+    module.hasFocus = opts.hasFocus ?? true;
+
+    // The handler reads `activeWindow.document.hidden`.
+    (globalThis as any).activeWindow = { document: { hidden: opts.hidden } };
+
+    return { module, appLifecycle, fileProcessing };
+}
+
+describe("watchWindowVisibilityAsync — keepReplicationActiveInBackground", () => {
+    beforeEach(() => {
+        (Platform as any).isDesktopApp = true;
+    });
+
+    afterEach(() => {
+        // The handler reads a global `activeWindow`; the Platform mock is module-scoped. Both would
+        // otherwise leak into sibling spec files running in the same worker, so reset them here.
+        delete (globalThis as any).activeWindow;
+        (Platform as any).isDesktopApp = true;
+    });
+
+    it("does NOT suspend on hide when enabled in LiveSync mode on the desktop app", async () => {
+        const { module, appLifecycle } = setup({
+            settings: { keepReplicationActiveInBackground: true, liveSync: true },
+            hidden: true,
+        });
+        await module.watchWindowVisibilityAsync();
+        expect(appLifecycle.onSuspending).not.toHaveBeenCalled();
+    });
+
+    it("suspends on hide by default (setting off)", async () => {
+        const { module, appLifecycle } = setup({
+            settings: { keepReplicationActiveInBackground: false, liveSync: true },
+            hidden: true,
+        });
+        await module.watchWindowVisibilityAsync();
+        expect(appLifecycle.onSuspending).toHaveBeenCalledTimes(1);
+    });
+
+    it("forces onSuspending before the resume on becoming visible when enabled (LiveSync teardown)", async () => {
+        const { module, appLifecycle } = setup({
+            settings: { keepReplicationActiveInBackground: true, liveSync: true },
+            hidden: false,
+            isLastHidden: true, // hidden -> visible transition
+        });
+        await module.watchWindowVisibilityAsync();
+        // Decision-logic only: on visible + enabled + LiveSync the handler calls onSuspending (the
+        // forced teardown) before onResuming. The actual stalled-channel replacement is exercised by
+        // the manual integration test, not here.
+        expect(appLifecycle.onSuspending).toHaveBeenCalledTimes(1);
+        expect(appLifecycle.onResuming).toHaveBeenCalledTimes(1);
+        expect(appLifecycle.onResumed).toHaveBeenCalledTimes(1);
+        expect(appLifecycle.onSuspending.mock.invocationCallOrder[0]).toBeLessThan(
+            appLifecycle.onResuming.mock.invocationCallOrder[0]
+        );
+    });
+
+    it("does not force a teardown on becoming visible by default (setting off)", async () => {
+        const { module, appLifecycle } = setup({
+            settings: { keepReplicationActiveInBackground: false, liveSync: true },
+            hidden: false,
+            isLastHidden: true,
+        });
+        await module.watchWindowVisibilityAsync();
+        expect(appLifecycle.onSuspending).not.toHaveBeenCalled();
+        expect(appLifecycle.onResumed).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not apply in On-Events mode even if the flag is set (no scope leak)", async () => {
+        const { module, appLifecycle } = setup({
+            settings: {
+                keepReplicationActiveInBackground: true,
+                liveSync: false,
+                periodicReplication: false,
+            },
+            hidden: true,
+        });
+        await module.watchWindowVisibilityAsync();
+        expect(appLifecycle.onSuspending).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT suspend on hide when enabled in Periodic mode (the periodic timer also stalls otherwise)", async () => {
+        const { module, appLifecycle } = setup({
+            settings: {
+                keepReplicationActiveInBackground: true,
+                liveSync: false,
+                periodicReplication: true,
+            },
+            hidden: true,
+        });
+        await module.watchWindowVisibilityAsync();
+        expect(appLifecycle.onSuspending).not.toHaveBeenCalled();
+    });
+
+    it("does NOT force a teardown on becoming visible in Periodic mode (only the continuous channel can stall)", async () => {
+        const { module, appLifecycle } = setup({
+            settings: {
+                keepReplicationActiveInBackground: true,
+                liveSync: false,
+                periodicReplication: true,
+            },
+            hidden: false,
+            isLastHidden: true,
+        });
+        await module.watchWindowVisibilityAsync();
+        // The teardown is gated on liveSync: a periodic timer doesn't go half-open, so bouncing it
+        // on every restore would be needless churn. Resume still runs normally.
+        expect(appLifecycle.onSuspending).not.toHaveBeenCalled();
+        expect(appLifecycle.onResuming).toHaveBeenCalledTimes(1);
+        expect(appLifecycle.onResumed).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not apply on a non-desktop app even if the flag is set", async () => {
+        (Platform as any).isDesktopApp = false;
+        const { module, appLifecycle } = setup({
+            settings: { keepReplicationActiveInBackground: true, liveSync: true },
+            hidden: true,
+        });
+        await module.watchWindowVisibilityAsync();
+        expect(appLifecycle.onSuspending).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/modules/features/SettingDialogue/PaneSyncSettings.ts
+++ b/src/modules/features/SettingDialogue/PaneSyncSettings.ts
@@ -11,6 +11,7 @@ import { EVENT_REQUEST_COPY_SETUP_URI, eventHub } from "../../../common/events.t
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";
 import type { PageFunctions } from "./SettingPane.ts";
 import { visibleOnly } from "./SettingPane.ts";
+import { Platform } from "../../../deps.ts";
 export function paneSyncSettings(
     this: ObsidianLiveSyncSettingTab,
     paneEl: HTMLElement,
@@ -189,6 +190,16 @@ export function paneSyncSettings(
         new Setting(paneEl).setClass("wizardHidden").autoWireToggle("syncOnFileOpen", { onUpdate: onlyOnNonLiveSync });
         new Setting(paneEl).setClass("wizardHidden").autoWireToggle("syncOnStart", { onUpdate: onlyOnNonLiveSync });
         new Setting(paneEl).setClass("wizardHidden").autoWireToggle("syncAfterMerge", { onUpdate: onlyOnNonLiveSync });
+        // Desktop app only, and only for the sync modes that keep a background replication channel
+        // (LiveSync and Periodic). Ignored on mobile, where suspending preserves battery. The
+        // visibility predicate mirrors the runtime guard in ModuleObsidianEvents.
+        if (Platform.isDesktopApp) {
+            new Setting(paneEl).setClass("wizardHidden").autoWireToggle("keepReplicationActiveInBackground", {
+                onUpdate: visibleOnly(
+                    () => this.isConfiguredAs("syncMode", "LIVESYNC") || this.isConfiguredAs("syncMode", "PERIODIC")
+                ),
+            });
+        }
     });
 
     void addPanel(

--- a/src/modules/features/SettingDialogue/PaneSyncSettings.ts
+++ b/src/modules/features/SettingDialogue/PaneSyncSettings.ts
@@ -11,7 +11,6 @@ import { EVENT_REQUEST_COPY_SETUP_URI, eventHub } from "../../../common/events.t
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";
 import type { PageFunctions } from "./SettingPane.ts";
 import { visibleOnly } from "./SettingPane.ts";
-import { Platform } from "../../../deps.ts";
 export function paneSyncSettings(
     this: ObsidianLiveSyncSettingTab,
     paneEl: HTMLElement,
@@ -193,7 +192,7 @@ export function paneSyncSettings(
         // Desktop app only, and only for the sync modes that keep a background replication channel
         // (LiveSync and Periodic). Ignored on mobile, where suspending preserves battery. The
         // visibility predicate mirrors the runtime guard in ModuleObsidianEvents.
-        if (Platform.isDesktopApp) {
+        if (!this.services.API.isMobile()) {
             new Setting(paneEl).setClass("wizardHidden").autoWireToggle("keepReplicationActiveInBackground", {
                 onUpdate: visibleOnly(
                     () => this.isConfiguredAs("syncMode", "LIVESYNC") || this.isConfiguredAs("syncMode", "PERIODIC")


### PR DESCRIPTION
Implements #939. The commonlib setting definition merged in vrtmrz/livesync-commonlib#51; `src/lib` is bumped to commonlib main (`e98d929`, the #51 merge) so this branch builds against current upstream.

## Summary

On desktop, replication is suspended as soon as the Obsidian window becomes hidden (`document.hidden === true`, i.e. minimised) and only resumes when the window is shown again. For the modes that maintain a background channel this stalls background sync: edits made elsewhere do not arrive until the user focuses Obsidian, and local edits can sit unsynced while minimised.

This adds an opt-in, desktop-only setting, **Keep replication active in the background** (`keepReplicationActiveInBackground`, default `false`). When enabled on desktop, window visibility stops driving the replication suspend/resume lifecycle, so replication keeps running while the window is minimised or hidden. Default behaviour is unchanged, and the setting is ignored on mobile (where suspend-on-hidden preserves battery).

## Which modes this affects

`watchWindowVisibilityAsync()` calls `appLifecycle.onSuspending()` on hide. That suspends:

- LiveSync (continuous): closes the live replication connection.
- Periodic: stops the periodic timer.
- On-Events: no background channel, so nothing meaningful is suspended.

So the stall affects LiveSync and Periodic. The setting is general, and the UI shows it only for those two modes.

## Approach

Opt-in guard in `watchWindowVisibilityAsync()`. Pending file events are still committed (file handling unchanged). On hide the suspend is skipped so the channel keeps running. On becoming visible a teardown then reopen is forced, so a stalled background channel is always replaced:

```ts
await this.services.fileProcessing.commitPendingFileEvents();

const keepActiveInBackground =
    this.settings.keepReplicationActiveInBackground &&
    (this.settings.liveSync || this.settings.periodicReplication) &&
    !this.services.API.isMobile();

if (isHidden) {
    if (!keepActiveInBackground) await this.services.appLifecycle.onSuspending();
} else {
    if (this.services.appLifecycle.isSuspended()) return;
    // Only the continuous (LiveSync) channel can stall but stay non-terminal: PouchDB emits
    // paused/retry while the replicator keeps `this.controller` set, so a plain reopen no-ops
    // (openContinuousReplication early-returns). Force a teardown first so becoming visible always
    // re-establishes a fresh channel. Gated on liveSync because Periodic mode has no such channel.
    if (keepActiveInBackground && this.settings.liveSync) {
        await this.services.appLifecycle.onSuspending();
    }
    await this.services.appLifecycle.onResuming();
    await this.services.appLifecycle.onResumed();
}
```

Design notes:

- The guard is in the visibility handler only. `onSuspending()` is also called by `ControlService.applySettings()` and real lifecycle suspends; guarding here scopes the change to the window-hidden trigger and leaves manual suspend, settings-apply, and shutdown/unload untouched.
- Why force a teardown on becoming visible. Continuous replication runs PouchDB `{ live: true, retry: true, heartbeat: 30000 }`, so transient drops self-heal. A non-terminal stall (PouchDB paused/retrying, or a half-open socket after sleep or NAT rebind) keeps the `for await` loop alive, so `this.controller` stays set and `openContinuousReplication` early-returns. A plain reopen would no-op on exactly the channel that needs replacing. Default behaviour resets this implicitly by closing on every hide; since this feature skips that, the resume forces the teardown so visibility recovery is never worse than default. The teardown is gated on `liveSync` only, since the periodic timer has no half-open state and just resumes normally.
- Why the same-tick teardown then reopen does not double-open. `closeReplication()` aborts and nulls the controller synchronously (`controller.abort(); this.controller = undefined`), and the abort is observed by the replicator's `for await` loop even when stalled (the signal is raced into the inbox `pick()`, so a half-open iterator is woken and its `finally` calls `sync.cancel()`). The reopen is deferred: `_everyAfterResumeProcess` wraps it in `fireAndForget(async () => { await isReplicationReady(...); openReplication(...) })`, and `openReplication` awaits `initializeDatabaseForReplication()` before creating a new sync. So the synchronous teardown always completes before a new channel exists. This is the same suspend, guard, resume sequence `ControlService.applySettings()` already runs.
- Latent sharp edge, noted but not changed here. `processSync`'s `finally` clears the shared `this.controller` rather than the local one it created, so in principle an old sync's teardown finishing after a reopen has set a new controller could abort the fresh channel. In this flow the two awaited gates above make the old (microtask-only) teardown win the race in practice, so the PR does not introduce a regression. It is a pre-existing robustness wrinkle in `processSync` worth a separate optional hardening (have the `finally` clear only the controller it owns). The manual test below asserts exactly one live sync after rapid restore cycles.
- Known limitation, documented. While the window stays hidden there is no visible transition to trigger recovery, so a stall during a long hidden period is repaired on the next focus, which is parity with today. Covering that fully would need a liveness watchdog, left as a deliberate follow-up to keep this change small. Most transient drops recover on their own via `retry: true`; only a rare non-terminal stall needs the focus boundary.

## Changes

- `ModuleObsidianEvents.ts`: the opt-in guard above. Platform is read through `services.API.isMobile()` (the plugin's own service layer), not `Platform` directly.
- `PaneSyncSettings.ts`: desktop-only toggle in the Sync settings pane, shown only for LiveSync and Periodic. Same `services.API.isMobile()` check, matching the existing call in `ObsidianLiveSyncSettingTab`.
- `docs/settings.md`: document the setting under Sync Settings.
- `ModuleObsidianEvents.unit.spec.ts`: 8 tests covering the suspend-skip (LiveSync and Periodic), the liveSync-only forced teardown on becoming visible, and the default / On-Events / non-desktop paths. This module layer was previously untested because unit tests stub `obsidian`; the spec mocks `deps.ts` bare (the module needs no runtime value from it now) and drives the platform through the `services.API.isMobile()` mock, cleaning up the `activeWindow` global in `afterEach`.
- `src/lib`: submodule bump to commonlib main (`e98d929`, the #51 merge).

`docs/settings_ja.md` and `updates.md` are left to you (translation and release-note stamping). i18n needs no message-catalog change, since the setting name and description follow the existing literal-string `SettingInformation` convention.

## Testing

Verified on Windows 11 (26200), Obsidian 1.12.7, LiveSync mode, CouchDB remote, two desktop clients, measured objectively by reading the local vault file on disk:

- Background sync (setting ON, minimised): a remote edit landed locally in ~3s with the window minimised. With the setting OFF the same edit did not arrive until focus (~1m40s later), reproducing the stall.
- Stalled-channel recovery (setting ON): with the live channel blocked at the network layer for ~2.5 min (past the 30s heartbeat, so the socket went half-open), a remote edit made during the block did not self-heal while hidden and then landed within ~1s of focusing, confirming the forced teardown-on-visible re-establishes the channel.

The code path is platform-identical (single `services.API.isMobile()` gate, no OS branching). Periodic-mode behaviour is asserted from code and the unit tests. A manual Periodic and macOS pass are easy to add if you want them on record.

## Safety / scope

- Default (setting off) behaviour is unchanged apart from one guarded early-return.
- Mobile is unaffected (`services.API.isMobile()` runtime gate plus UI hidden on mobile).
- File-event commit and shutdown/unload paths are untouched.
- No protocol or data-format change; interoperates with stock clients on the same database.
- The setting key is excluded from setup-URI / QR encoding, so it is never pushed to other (possibly mobile) devices.

Passes the repo's prettier, eslint and tsc on the changed files.

## Open questions

1. Setting name and placement (currently Sync pane, shown for LiveSync and Periodic).
2. Any objection to forcing the teardown on becoming visible, or would you gate it differently?
3. Want the `processSync` `finally` hardening as a follow-up in this PR, or tracked separately?

---

This PR was drafted by Claude Code, directed and reviewed by me (Miguel Ferreira).
