### PR TITLE
Fix S3 client with custom headers and strict server

### DIFF
--- a/src/modules/essentialObsidian/APILib/ObsHttpHandler.ts
+++ b/src/modules/essentialObsidian/APILib/ObsHttpHandler.ts
@@ -5,13 +5,23 @@
 
 import { FetchHttpHandler, type FetchHttpHandlerOptions } from "@smithy/fetch-http-handler";
 import { HttpRequest, HttpResponse, type HttpHandlerOptions } from "@smithy/protocol-http";
-//@ts-ignore
-import { requestTimeout } from "@smithy/fetch-http-handler/dist-es/request-timeout";
 import { buildQueryString } from "@smithy/querystring-builder";
 import { requestUrl, type RequestUrlParam } from "../../../deps.ts";
 ////////////////////////////////////////////////////////////////////////////////
 // special handler using Obsidian requestUrl
 ////////////////////////////////////////////////////////////////////////////////
+
+function requestTimeout(timeoutInMs: number = 0): Promise<never> {
+    return new Promise((_, reject) => {
+        if (timeoutInMs) {
+            window.setTimeout(() => {
+                const timeoutError = new Error(`Request did not complete within ${timeoutInMs} ms`);
+                timeoutError.name = "TimeoutError";
+                reject(timeoutError);
+            }, timeoutInMs);
+        }
+    });
+}
 
 /**
  * This is close to origin implementation of FetchHttpHandler

--- a/updates.md
+++ b/updates.md
@@ -3,6 +3,12 @@ Since 19th July, 2025 (beta1 in 0.25.0-beta1, 13th July, 2025)
 
 The head note of 0.25 is now in [updates_old.md](https://github.com/vrtmrz/obsidian-livesync/blob/main/updates_old.md). Because 0.25 got a lot of updates, thankfully, compatibility is kept and we do not need breaking changes! In other words, when get enough stabled. The next version will be v1.0.0. Even though it my hope.
 
+## Unreleased
+
+### Fixed
+- Now S3 connection with custom headers works properly.
+  - Previously, custom headers injected for proxy authentication were incorrectly included in the AWS Signature v4 calculation. This led to a '400 Bad Request' error (such as 'signed header is not present') on strict S3 backends (for example, Garage), or when reverse proxies modified, renamed, or stripped these headers before they reached the storage service.
+
 ## 0.25.75
 
 13th June, 2026

--- a/updates.md
+++ b/updates.md
@@ -6,7 +6,7 @@ The head note of 0.25 is now in [updates_old.md](https://github.com/vrtmrz/obsid
 ## Unreleased
 
 ### Fixed
-- Now the S3 connection with custom headers works properly.
+- Now the S3 connection with custom headers works properly (#875).
   - Previously, custom headers injected for proxy authentication were incorrectly included in the AWS Signature v4 calculation. This led to a '400 Bad Request' error (such as 'signed header is not present') on strict S3 backends (for example, Garage), or when reverse proxies modified, renamed, or stripped these headers before they reached the storage service.
 
 ## 0.25.75

--- a/updates.md
+++ b/updates.md
@@ -6,7 +6,7 @@ The head note of 0.25 is now in [updates_old.md](https://github.com/vrtmrz/obsid
 ## Unreleased
 
 ### Fixed
-- Now S3 connection with custom headers works properly.
+- Now the S3 connection with custom headers works properly.
   - Previously, custom headers injected for proxy authentication were incorrectly included in the AWS Signature v4 calculation. This led to a '400 Bad Request' error (such as 'signed header is not present') on strict S3 backends (for example, Garage), or when reverse proxies modified, renamed, or stripped these headers before they reached the storage service.
 
 ## 0.25.75


### PR DESCRIPTION
### Fixed
- Now the S3 connection with custom headers works properly (#875).
  - Previously, custom headers injected for proxy authentication were incorrectly included in the AWS Signature v4 calculation. This led to a '400 Bad Request' error (such as 'signed header is not present') on strict S3 backends (for example, Garage), or when reverse proxies modified, renamed, or stripped these headers before they reached the storage service.