### PR TITLE
Fix configuration serialisation

### DIFF
--- a/updates.md
+++ b/updates.md
@@ -3,6 +3,12 @@ Since 19th July, 2025 (beta1 in 0.25.0-beta1, 13th July, 2025)
 
 The head note of 0.25 is now in [updates_old.md](https://github.com/vrtmrz/obsidian-livesync/blob/main/updates_old.md). Because 0.25 got a lot of updates, thankfully, compatibility is kept and we do not need breaking changes! In other words, when get enough stabled. The next version will be v1.0.0. Even though it my hope.
 
+## Unreleased
+
+### Fixed
+
+- No longer connection information of the P2P synchronisation is broken on the specific platform (#956).
+
 ## 0.25.75
 
 13th June, 2026


### PR DESCRIPTION
- No longer connection information of the P2P synchronisation is broken on the specific platform (#956).