### PR TITLE
Releasing v0.25.78

### DIFF
--- a/_types/src/LiveSyncBaseCore.d.ts
+++ b/_types/src/LiveSyncBaseCore.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { SimpleStore } from "octagonal-wheels/databases/SimpleStoreBase";
 import type { HasSettings, ObsidianLiveSyncSettings, EntryDoc } from "@lib/common/types";
 import type { Confirm } from "@lib/interfaces/Confirm";

--- a/_types/src/common/KeyValueDB.d.ts
+++ b/_types/src/common/KeyValueDB.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { KeyValueDatabase } from "@lib/interfaces/KeyValueDatabase.ts";
 export { OpenKeyValueDatabase } from "./KeyValueDBv2.ts";
 export declare const _OpenKeyValueDatabase: (dbKey: string) => Promise<KeyValueDatabase>;

--- a/_types/src/common/KeyValueDBv2.d.ts
+++ b/_types/src/common/KeyValueDBv2.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { KeyValueDatabase } from "@lib/interfaces/KeyValueDatabase";
 import { type IDBPDatabase } from "idb";
 export declare function OpenKeyValueDatabase(dbKey: string): Promise<KeyValueDatabase>;

--- a/_types/src/common/PeriodicProcessor.d.ts
+++ b/_types/src/common/PeriodicProcessor.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";
 type PeriodicProcessorHost = NecessaryServices<"API" | "control", never>;
 export declare class PeriodicProcessor {

--- a/_types/src/common/SvelteItemView.d.ts
+++ b/_types/src/common/SvelteItemView.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { ItemView } from "@/deps.ts";
 import { type mount } from "svelte";
 export declare abstract class SvelteItemView extends ItemView {

--- a/_types/src/common/events.d.ts
+++ b/_types/src/common/events.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { eventHub } from "@lib/hub/hub";
 export declare const EVENT_PLUGIN_LOADED = "plugin-loaded";
 export declare const EVENT_PLUGIN_UNLOADED = "plugin-unloaded";

--- a/_types/src/common/obsidianEvents.d.ts
+++ b/_types/src/common/obsidianEvents.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { TFile } from "@/deps";
 import type { FilePathWithPrefix, LoadedEntry } from "@lib/common/types";
 export declare const EVENT_REQUEST_SHOW_HISTORY = "show-history";

--- a/_types/src/common/reportTool.d.ts
+++ b/_types/src/common/reportTool.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ObsidianLiveSyncSettings } from "@lib/common/models/setting.type";
 import type { LiveSyncBaseCore } from "@/LiveSyncBaseCore";
 export declare function generateReport(settings: ObsidianLiveSyncSettings, core: LiveSyncBaseCore): Promise<{

--- a/_types/src/common/stores.d.ts
+++ b/_types/src/common/stores.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { PersistentMap } from "octagonal-wheels/dataobject/PersistentMap";
 export declare let sameChangePairs: PersistentMap<number[]>;
 export declare function initializeStores(vaultName: string): void;

--- a/_types/src/common/types.d.ts
+++ b/_types/src/common/types.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type PluginManifest, TFile } from "@/deps.ts";
 import { type DatabaseEntry, type EntryBody, type FilePath } from "@lib/common/types.ts";
 export type { CacheData, FileEventItem } from "@lib/common/types.ts";

--- a/_types/src/common/utils.d.ts
+++ b/_types/src/common/utils.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { TAbstractFile } from "@/deps.ts";
 import { type AnyEntry, type CouchDBCredentials, type DocumentID, type EntryHasPath, type FilePath, type FilePathWithPrefix, type UXFileInfo, type UXFileInfoStub } from "@lib/common/types.ts";
 export { ICHeader, ICXHeader } from "./types.ts";

--- a/_types/src/deps.d.ts
+++ b/_types/src/deps.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type FilePath } from "@lib/common/types.ts";
 export { addIcon, App, debounce, Editor, FuzzySuggestModal, MarkdownRenderer, MarkdownView, Modal, Notice, Platform, Plugin, PluginSettingTab, requestUrl, sanitizeHTMLToDom, Setting, stringifyYaml, TAbstractFile, TextAreaComponent, TFile, TFolder, parseYaml, ItemView, WorkspaceLeaf, Menu, request, getLanguage, ButtonComponent, TextComponent, ToggleComponent, DropdownComponent, Component, } from "obsidian";
 export type { DataWriteOptions, PluginManifest, RequestUrlParam, RequestUrlResponse, MarkdownFileInfo, ListedFiles, ValueComponent, Stat, Command, ViewCreator, } from "obsidian";

--- a/_types/src/features/ConfigSync/CmdConfigSync.d.ts
+++ b/_types/src/features/ConfigSync/CmdConfigSync.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type PluginManifest } from "@/deps.ts";
 import type { EntryDoc, LoadedEntry, FilePathWithPrefix, FilePath, AnyEntry } from "@lib/common/types.ts";
 import { LiveSyncCommands } from "@/features/LiveSyncCommands.ts";

--- a/_types/src/features/ConfigSync/PluginDialogModal.d.ts
+++ b/_types/src/features/ConfigSync/PluginDialogModal.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { mount } from "svelte";
 import { App, Modal } from "@/deps.ts";
 import ObsidianLiveSyncPlugin from "@/main.ts";

--- a/_types/src/features/HiddenFileCommon/JsonResolveModal.d.ts
+++ b/_types/src/features/HiddenFileCommon/JsonResolveModal.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { App, Modal } from "@/deps.ts";
 import { type FilePath, type LoadedEntry } from "@lib/common/types.ts";
 import { mount } from "svelte";

--- a/_types/src/features/HiddenFileSync/CmdHiddenFileSync.d.ts
+++ b/_types/src/features/HiddenFileSync/CmdHiddenFileSync.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type LoadedEntry, type FilePathWithPrefix, type FilePath, type DocumentID, type UXFileInfo, type UXStat, type MetaEntry, type UXDataWriteOptions } from "@lib/common/types.ts";
 import { type InternalFileInfo } from "@/common/types.ts";
 import { type CustomRegExp } from "@lib/common/utils.ts";

--- a/_types/src/features/LiveSyncCommands.d.ts
+++ b/_types/src/features/LiveSyncCommands.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type AnyEntry, type DocumentID, type FilePath, type FilePathWithPrefix, type LOG_LEVEL } from "@lib/common/types.ts";
 import type ObsidianLiveSyncPlugin from "@/main.ts";
 import type { LiveSyncCore } from "@/main.ts";

--- a/_types/src/features/LocalDatabaseMainte/CmdLocalDatabaseMainte.d.ts
+++ b/_types/src/features/LocalDatabaseMainte/CmdLocalDatabaseMainte.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type DocumentID, type EntryDoc, type EntryLeaf } from "@lib/common/types";
 import { LiveSyncCommands } from "@/features/LiveSyncCommands";
 type ChunkID = DocumentID;

--- a/_types/src/features/P2PSync/P2PReplicator/P2POpenReplicationModal.d.ts
+++ b/_types/src/features/P2PSync/P2PReplicator/P2POpenReplicationModal.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { App, Modal } from "@/deps.ts";
 import { mount } from "svelte";
 import type { LiveSyncTrysteroReplicator } from "@lib/replication/trystero/LiveSyncTrysteroReplicator";

--- a/_types/src/features/P2PSync/P2PReplicator/P2PReplicationUI.d.ts
+++ b/_types/src/features/P2PSync/P2PReplicator/P2PReplicationUI.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { App } from "@/deps.ts";
 import type { LiveSyncTrysteroReplicator } from "@lib/replication/trystero/LiveSyncTrysteroReplicator";
 /**

--- a/_types/src/features/P2PSync/P2PReplicator/P2PReplicatorPaneView.d.ts
+++ b/_types/src/features/P2PSync/P2PReplicator/P2PReplicatorPaneView.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { Menu, WorkspaceLeaf } from "@/deps.ts";
 import { SvelteItemView } from "@/common/SvelteItemView.ts";
 import { type PeerStatus } from "@lib/replication/trystero/P2PReplicatorPaneCommon.ts";

--- a/_types/src/features/P2PSync/P2PReplicator/P2PServerStatusPaneView.d.ts
+++ b/_types/src/features/P2PSync/P2PReplicator/P2PServerStatusPaneView.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { WorkspaceLeaf } from "@/deps.ts";
 import { SvelteItemView } from "@/common/SvelteItemView.ts";
 import type { LiveSyncBaseCore } from "@/LiveSyncBaseCore.ts";

--- a/_types/src/lib/src/API/DirectFileManipulator.d.ts
+++ b/_types/src/lib/src/API/DirectFileManipulator.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export { DirectFileManipulator } from "./DirectFileManipulatorV2.ts";
 export type { DirectFileManipulatorOptions } from "./DirectFileManipulatorV2.ts";

--- a/_types/src/lib/src/API/processSetting.d.ts
+++ b/_types/src/lib/src/API/processSetting.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type ObsidianLiveSyncSettings } from "@lib/common/types";
 /**
  * Encode settings to a tiny array to encode in QRCode,

--- a/_types/src/lib/src/ContentSplitter/ContentSplitter.d.ts
+++ b/_types/src/lib/src/ContentSplitter/ContentSplitter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 /**
  * Content-Splitter for Self-hosted LiveSync.
  * Splits content into manageable chunks for efficient storage and synchronisation.

--- a/_types/src/lib/src/ContentSplitter/ContentSplitterBase.d.ts
+++ b/_types/src/lib/src/ContentSplitter/ContentSplitterBase.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type SavingEntry } from "@lib/common/types.ts";
 import { type ContentSplitterOptions, type SplitOptions } from "./ContentSplitter.ts";
 export declare abstract class ContentSplitterCore {

--- a/_types/src/lib/src/ContentSplitter/ContentSplitterRabinKarp.d.ts
+++ b/_types/src/lib/src/ContentSplitter/ContentSplitterRabinKarp.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ContentSplitterOptions, SplitOptions } from "./ContentSplitter.ts";
 import { ContentSplitterBase } from "./ContentSplitterBase.ts";
 /**

--- a/_types/src/lib/src/ContentSplitter/ContentSplitterV1.d.ts
+++ b/_types/src/lib/src/ContentSplitter/ContentSplitterV1.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ContentSplitterOptions, SplitOptions } from "./ContentSplitter";
 import { ContentSplitterBase } from "./ContentSplitterBase";
 /**

--- a/_types/src/lib/src/ContentSplitter/ContentSplitterV2.d.ts
+++ b/_types/src/lib/src/ContentSplitter/ContentSplitterV2.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ContentSplitterOptions, SplitOptions } from "./ContentSplitter.ts";
 import { ContentSplitterBase } from "./ContentSplitterBase.ts";
 /**

--- a/_types/src/lib/src/ContentSplitter/ContentSplitters.d.ts
+++ b/_types/src/lib/src/ContentSplitter/ContentSplitters.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { SavingEntry } from "@lib/common/types";
 import type { ContentSplitterOptions } from "./ContentSplitter";
 import { ContentSplitterCore, type ContentSplitterBase } from "./ContentSplitterBase";

--- a/_types/src/lib/src/UI/svelteDialog.d.ts
+++ b/_types/src/lib/src/UI/svelteDialog.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export type { HasSetResult, HasGetInitialData, ComponentHasResult, GuestDialogProps, DialogSvelteComponentBaseProps, DialogControlBase, } from "@lib/services/implements/base/SvelteDialog.ts";
 export { CONTEXT_DIALOG_CONTROLS, setupDialogContext, getDialogContext, SvelteDialogManagerBase, } from "@lib/services/implements/base/SvelteDialog.ts";

--- a/_types/src/lib/src/bureau/bureau.d.ts
+++ b/_types/src/lib/src/bureau/bureau.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type SlipBoard } from "octagonal-wheels/bureau/SlipBoard";
 declare global {
     interface Slips extends LSSlips {

--- a/_types/src/lib/src/common/ConnectionString.d.ts
+++ b/_types/src/lib/src/common/ConnectionString.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { CouchDBConnection, BucketSyncSetting, P2PConnectionInfo } from "./models/setting.type";
 export type RemoteConfigurationResult = {
     type: "couchdb";

--- a/_types/src/lib/src/common/LSError.d.ts
+++ b/_types/src/lib/src/common/LSError.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { Constructor } from "@lib/common/utils.type";
 interface ErrorWithCause extends Error {
     cause?: unknown;

--- a/_types/src/lib/src/common/configForDoc.d.ts
+++ b/_types/src/lib/src/common/configForDoc.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { Confirm } from "@lib/interfaces/Confirm";
 import { type ObsidianLiveSyncSettings } from "./types";
 declare enum ConditionType {

--- a/_types/src/lib/src/common/coreEnvFunctions.d.ts
+++ b/_types/src/lib/src/common/coreEnvFunctions.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { getLanguage as ObsidianGetLanguage } from "obsidian";
 export declare function setGetLanguage(func: typeof ObsidianGetLanguage): void;
 export declare function getLanguage(): string;

--- a/_types/src/lib/src/common/coreEnvVars.d.ts
+++ b/_types/src/lib/src/common/coreEnvVars.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 declare const manifestVersion: string;
 declare const packageVersion: string;
 export { manifestVersion, packageVersion };

--- a/_types/src/lib/src/common/i18n.d.ts
+++ b/_types/src/lib/src/common/i18n.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { AllMessageKeys, I18N_LANGS } from "./rosetta";
 import type { TaggedType } from "./types";
 export declare let currentLang: I18N_LANGS;

--- a/_types/src/lib/src/common/logger.d.ts
+++ b/_types/src/lib/src/common/logger.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export * from "octagonal-wheels/common/logger";
 export type * from "octagonal-wheels/common/logger";

--- a/_types/src/lib/src/common/messages/combinedMessages.dev.d.ts
+++ b/_types/src/lib/src/common/messages/combinedMessages.dev.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { PartialMessages as def } from "./def.ts";
 import { type MESSAGE } from "@lib/common/rosetta.ts";
 type MessageKeys = keyof typeof def.def;

--- a/_types/src/lib/src/common/messages/combinedMessages.prod.d.ts
+++ b/_types/src/lib/src/common/messages/combinedMessages.prod.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare const allMessages: {
     readonly "(Active)": {
         readonly def: "(Active)";

--- a/_types/src/lib/src/common/messages/de.d.ts
+++ b/_types/src/lib/src/common/messages/de.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare const PartialMessages: {
     readonly de: {
         "(Active)": string;

--- a/_types/src/lib/src/common/messages/def.d.ts
+++ b/_types/src/lib/src/common/messages/def.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare const PartialMessages: {
     readonly def: {
         "(Active)": string;

--- a/_types/src/lib/src/common/messages/es.d.ts
+++ b/_types/src/lib/src/common/messages/es.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare const PartialMessages: {
     readonly es: {
         "(Active)": string;

--- a/_types/src/lib/src/common/messages/fr.d.ts
+++ b/_types/src/lib/src/common/messages/fr.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare const PartialMessages: {
     readonly fr: {
         "(BETA) Always overwrite with a newer file": string;

--- a/_types/src/lib/src/common/messages/he.d.ts
+++ b/_types/src/lib/src/common/messages/he.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare const PartialMessages: {
     readonly he: {
         "(BETA) Always overwrite with a newer file": string;

--- a/_types/src/lib/src/common/messages/ja.d.ts
+++ b/_types/src/lib/src/common/messages/ja.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare const PartialMessages: {
     readonly ja: {
         "(Active)": string;

--- a/_types/src/lib/src/common/messages/ko.d.ts
+++ b/_types/src/lib/src/common/messages/ko.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare const PartialMessages: {
     readonly ko: {
         "(Active)": string;

--- a/_types/src/lib/src/common/messages/ru.d.ts
+++ b/_types/src/lib/src/common/messages/ru.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare const PartialMessages: {
     readonly ru: {
         "(Active)": string;

--- a/_types/src/lib/src/common/messages/zh-tw.d.ts
+++ b/_types/src/lib/src/common/messages/zh-tw.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare const PartialMessages: {
     readonly "zh-tw": {
         "(Active)": string;

--- a/_types/src/lib/src/common/messages/zh.d.ts
+++ b/_types/src/lib/src/common/messages/zh.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare const PartialMessages: {
     readonly zh: {
         "(Active)": string;

--- a/_types/src/lib/src/common/models/auth.type.d.ts
+++ b/_types/src/lib/src/common/models/auth.type.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export type CouchDBCredentials = BasicCredentials | JWTCredentials;
 export type JWTAlgorithm = "HS256" | "HS512" | "ES256" | "ES512" | "";
 export type Credential = {

--- a/_types/src/lib/src/common/models/db.const.d.ts
+++ b/_types/src/lib/src/common/models/db.const.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { DocumentID } from "./db.type";
 export declare const VERSIONING_DOCID: DocumentID;
 export declare const MILESTONE_DOCID: DocumentID;

--- a/_types/src/lib/src/common/models/db.definition.d.ts
+++ b/_types/src/lib/src/common/models/db.definition.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { MILESTONE_DOCID, NODEINFO_DOCID } from "./db.const";
 import type { AnyEntry, ChunkVersionRange, DatabaseEntry, EntryChunkPack, EntryLeaf, EntryTypes, EntryVersionInfo, InternalFileEntry, LoadedEntry, MetaEntry, NewEntry, NoteEntry, PlainEntry } from "./db.type";
 import type { TweakValues } from "./tweak.definition";

--- a/_types/src/lib/src/common/models/db.type.d.ts
+++ b/_types/src/lib/src/common/models/db.type.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { TaggedType } from "octagonal-wheels/common/types";
 import type { EntryTypes, SYNCINFO_ID } from "./db.const";
 export type FilePath = TaggedType<string, "FilePath">;

--- a/_types/src/lib/src/common/models/diff.definition.d.ts
+++ b/_types/src/lib/src/common/models/diff.definition.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { AUTO_MERGED, CANCELLED, MISSING_OR_ERROR, NOT_CONFLICTED } from "./shared.const.symbols";
 export type diff_result_leaf = {
     rev: string;

--- a/_types/src/lib/src/common/models/fileaccess.const.d.ts
+++ b/_types/src/lib/src/common/models/fileaccess.const.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare const CHeader = "h:";
 export declare const PSCHeader = "ps:";
 export declare const PSCHeaderEnd = "ps;";

--- a/_types/src/lib/src/common/models/fileaccess.type.d.ts
+++ b/_types/src/lib/src/common/models/fileaccess.type.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { FilePath, FilePathWithPrefix } from "./db.type";
 export type UXStat = {
     size: number;

--- a/_types/src/lib/src/common/models/redflag.const.d.ts
+++ b/_types/src/lib/src/common/models/redflag.const.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { FilePath } from "./db.type";
 export declare const PREFIXMD_LOGFILE = "livesync_log_";
 export declare const PREFIXMD_LOGFILE_UC = "LIVESYNC_LOG_";

--- a/_types/src/lib/src/common/models/setting.const.d.ts
+++ b/_types/src/lib/src/common/models/setting.const.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare const SETTING_VERSION_INITIAL = 0;
 export declare const SETTING_VERSION_SUPPORT_CASE_INSENSITIVE = 10;
 export declare const CURRENT_SETTING_VERSION = 10;

--- a/_types/src/lib/src/common/models/setting.const.defaults.d.ts
+++ b/_types/src/lib/src/common/models/setting.const.defaults.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type ObsidianLiveSyncSettings, type P2PSyncSetting } from "./setting.type";
 export declare const P2P_DEFAULT_SETTINGS: P2PSyncSetting;
 export declare const DEFAULT_SETTINGS: ObsidianLiveSyncSettings;

--- a/_types/src/lib/src/common/models/setting.const.preferred.d.ts
+++ b/_types/src/lib/src/common/models/setting.const.preferred.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ObsidianLiveSyncSettings } from "./setting.type";
 export declare const PREFERRED_BASE: Partial<ObsidianLiveSyncSettings>;
 export declare const PREFERRED_SETTING_CLOUDANT: Partial<ObsidianLiveSyncSettings>;

--- a/_types/src/lib/src/common/models/setting.const.qr.d.ts
+++ b/_types/src/lib/src/common/models/setting.const.qr.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ObsidianLiveSyncSettings } from "./setting.type";
 export declare const KeyIndexOfSettings: Record<keyof ObsidianLiveSyncSettings, number>;

--- a/_types/src/lib/src/common/models/setting.type.d.ts
+++ b/_types/src/lib/src/common/models/setting.type.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ChunkAlgorithms, E2EEAlgorithms, HashAlgorithms, MODE_AUTOMATIC, MODE_PAUSED, MODE_SELECTIVE, MODE_SHINY, RemoteTypes } from "./setting.const";
 import type { I18N_LANGS } from "@lib/common/rosetta";
 import type { CustomRegExpSourceList } from "./shared.type.util";

--- a/_types/src/lib/src/common/models/shared.const.behabiour.d.ts
+++ b/_types/src/lib/src/common/models/shared.const.behabiour.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare const MAX_DOC_SIZE = 1000;
 export declare const MAX_DOC_SIZE_BIN = 102400;
 export declare const VER = 12;

--- a/_types/src/lib/src/common/models/shared.const.d.ts
+++ b/_types/src/lib/src/common/models/shared.const.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare const SETTING_KEY_P2P_DEVICE_NAME = "p2p_device_name";
 export declare const configURIBase = "obsidian://setuplivesync?settings=";
 export declare const configURIBaseQR = "obsidian://setuplivesync?settingsQR=";

--- a/_types/src/lib/src/common/models/shared.const.symbols.d.ts
+++ b/_types/src/lib/src/common/models/shared.const.symbols.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare const CANCELLED: unique symbol;
 export declare const AUTO_MERGED: unique symbol;
 export declare const NOT_CONFLICTED: unique symbol;

--- a/_types/src/lib/src/common/models/shared.definition.configNames.d.ts
+++ b/_types/src/lib/src/common/models/shared.definition.configNames.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ObsidianLiveSyncSettings } from "./setting.type";
 export declare const LEVEL_ADVANCED = "ADVANCED";
 export declare const LEVEL_POWER_USER = "POWER_USER";

--- a/_types/src/lib/src/common/models/shared.definition.d.ts
+++ b/_types/src/lib/src/common/models/shared.definition.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare const DatabaseConnectingStatuses: {
     readonly STARTED: "STARTED";
     readonly NOT_CONNECTED: "NOT_CONNECTED";

--- a/_types/src/lib/src/common/models/shared.type.util.d.ts
+++ b/_types/src/lib/src/common/models/shared.type.util.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { TaggedType } from "octagonal-wheels/common/types";
 export type { TaggedType };
 export type CustomRegExpSource = TaggedType<string, "CustomRegExp">;

--- a/_types/src/lib/src/common/models/sync.definition.d.ts
+++ b/_types/src/lib/src/common/models/sync.definition.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { EntryTypes } from "./db.const";
 import type { DatabaseEntry, DocumentID } from "./db.type";
 export declare const ProtocolVersions: {

--- a/_types/src/lib/src/common/models/tweak.definition.d.ts
+++ b/_types/src/lib/src/common/models/tweak.definition.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ObsidianLiveSyncSettings } from "./setting.type";
 export declare const TweakValuesShouldMatchedTemplate: Partial<ObsidianLiveSyncSettings>;
 type TweakKeys = keyof TweakValues;

--- a/_types/src/lib/src/common/rosetta.d.ts
+++ b/_types/src/lib/src/common/rosetta.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 /**
 # Rosetta stone
 - To localise messages to your language, please write a translation to this file and submit a PR.

--- a/_types/src/lib/src/common/settingConstants.d.ts
+++ b/_types/src/lib/src/common/settingConstants.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type ConfigurationItem, type ObsidianLiveSyncSettings } from "./types.ts";
 type ExtractPropertiesByType<T, U> = {
     [K in keyof T as T[K] extends U ? K : never]: T[K] extends U ? K : never;

--- a/_types/src/lib/src/common/typeUtils.d.ts
+++ b/_types/src/lib/src/common/typeUtils.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { DocumentID, FilePath, FilePathWithPrefix } from "./models/db.type";
 import type { UXFileInfoStub } from "./types";
 /**

--- a/_types/src/lib/src/common/types.d.ts
+++ b/_types/src/lib/src/common/types.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export type { TaggedType } from "./models/shared.type.util.ts";
 export { LOG_LEVEL_DEBUG, LOG_LEVEL_INFO, LOG_LEVEL_NOTICE, LOG_LEVEL_URGENT, LOG_LEVEL_VERBOSE, } from "octagonal-wheels/common/logger";
 export type { LOG_LEVEL } from "octagonal-wheels/common/logger";

--- a/_types/src/lib/src/common/utils.d.ts
+++ b/_types/src/lib/src/common/utils.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type AnyEntry, type DatabaseEntry, type EntryLeaf, type SyncInfo, type LoadedEntry, type SavingEntry, type NewEntry, type PlainEntry, type CustomRegExpSource, type ParsedCustomRegExp, type CustomRegExpSourceList, type ObsidianLiveSyncSettings, type RemoteDBSettings, type P2PConnectionInfo, type BucketSyncSetting, type CouchDBConnection, type EncryptionSettings } from "./types.ts";
 import { replaceAll, replaceAllPairs } from "octagonal-wheels/string";
 export { replaceAll, replaceAllPairs };

--- a/_types/src/lib/src/common/utils.doc.d.ts
+++ b/_types/src/lib/src/common/utils.doc.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare function isErrorOf(ex: unknown, statusCode: number): boolean;
 /**
  * Checks if the error is effectively a 404 error from CouchDB or PouchDB.

--- a/_types/src/lib/src/common/utils.object.d.ts
+++ b/_types/src/lib/src/common/utils.object.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare function asCopy<T>(obj: T): T;
 export declare function ensureError(error: unknown): Error;

--- a/_types/src/lib/src/common/utils.patch.d.ts
+++ b/_types/src/lib/src/common/utils.patch.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare function generatePatchObj(from: Record<string | number | symbol, unknown>, to: Record<string | number | symbol, unknown>): Record<string | number | symbol, unknown>;
 export declare function applyPatch(from: Record<string | number | symbol, unknown>, patch: Record<string | number | symbol, unknown>): Record<string | number | symbol, unknown>;
 export declare function mergeObject(objA: Record<string | number | symbol, unknown> | [unknown], objB: Record<string | number | symbol, unknown> | [unknown]): unknown[] | {

--- a/_types/src/lib/src/common/utils.type.d.ts
+++ b/_types/src/lib/src/common/utils.type.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export type Constructor<T> = new (...args: any[]) => T; // eslint-disable-line @typescript-eslint/no-explicit-any -- Only type declaration

--- a/_types/src/lib/src/dataobject/StoredMap.d.ts
+++ b/_types/src/lib/src/dataobject/StoredMap.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { SimpleStore } from "octagonal-wheels/databases/SimpleStoreBase";
 export declare class StoredMapLike<U> {
     _store: SimpleStore<U>;

--- a/_types/src/lib/src/dev/checks.d.ts
+++ b/_types/src/lib/src/dev/checks.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 interface InstanceHaveOnBindFunction<T> {
     onBindFunction: (...params: T[]) => void;
 }

--- a/_types/src/lib/src/encryption/encryptHKDF.d.ts
+++ b/_types/src/lib/src/encryption/encryptHKDF.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { encryptHKDFWorker, decryptHKDFWorker } from "@lib/worker/bgWorker.ts";
 export declare const encryptHKDF: typeof encryptHKDFWorker;
 export declare const decryptHKDF: typeof decryptHKDFWorker;

--- a/_types/src/lib/src/encryption/stringEncryption.d.ts
+++ b/_types/src/lib/src/encryption/stringEncryption.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 /**
  * Encrypts a string using a passphrase, unless the string is already encrypted.
  *

--- a/_types/src/lib/src/events/coreEvents.d.ts
+++ b/_types/src/lib/src/events/coreEvents.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { FilePathWithPrefix, ObsidianLiveSyncSettings } from "@lib/common/types";
 export declare const EVENT_LAYOUT_READY = "layout-ready";
 export declare const EVENT_PLUGIN_LOADED = "plugin-loaded";

--- a/_types/src/lib/src/hub/hub.d.ts
+++ b/_types/src/lib/src/hub/hub.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { EventHub } from "octagonal-wheels/events";
 declare global {
     interface LSEvents {

--- a/_types/src/lib/src/index.d.ts
+++ b/_types/src/lib/src/index.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export { DirectFileManipulator, type DirectFileManipulatorOptions } from "./API/DirectFileManipulator.ts";

--- a/_types/src/lib/src/interfaces/Confirm.d.ts
+++ b/_types/src/lib/src/interfaces/Confirm.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export interface Confirm {
     askYesNo(message: string): Promise<"yes" | "no">;
     askString(title: string, key: string, placeholder: string, isPassword?: boolean): Promise<string | false>;

--- a/_types/src/lib/src/interfaces/DatabaseFileAccess.d.ts
+++ b/_types/src/lib/src/interfaces/DatabaseFileAccess.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { FilePathWithPrefix, LoadedEntry, MetaEntry, UXFileInfo, UXFileInfoStub } from "@lib/common/types";
 export interface DatabaseFileAccess {
     delete: (file: UXFileInfoStub | FilePathWithPrefix, rev?: string) => Promise<boolean>;

--- a/_types/src/lib/src/interfaces/DatabaseRebuilder.d.ts
+++ b/_types/src/lib/src/interfaces/DatabaseRebuilder.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export interface Rebuilder {
     $performRebuildDB(method: "localOnly" | "remoteOnly" | "rebuildBothByThisDevice" | "localOnlyWithChunks"): Promise<void>;
     $rebuildRemote(): Promise<void>;

--- a/_types/src/lib/src/interfaces/FileHandler.d.ts
+++ b/_types/src/lib/src/interfaces/FileHandler.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { FilePath, FilePathWithPrefix, MetaEntry } from "@lib/common/models/db.type";
 import type { UXFileInfo, UXFileInfoStub, UXInternalFileInfoStub } from "@lib/common/models/fileaccess.type";
 export interface IFileHandler {

--- a/_types/src/lib/src/interfaces/KeyValueDatabase.d.ts
+++ b/_types/src/lib/src/interfaces/KeyValueDatabase.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export interface KeyValueDatabase {
     get<T>(key: IDBValidKey): Promise<T>;
     set<T>(key: IDBValidKey, value: T): Promise<IDBValidKey>;

--- a/_types/src/lib/src/interfaces/ServiceModule.d.ts
+++ b/_types/src/lib/src/interfaces/ServiceModule.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { DatabaseFileAccess } from "@lib/interfaces/DatabaseFileAccess";
 import type { Rebuilder } from "@lib/interfaces/DatabaseRebuilder";
 import type { IFileHandler } from "@lib/interfaces/FileHandler";

--- a/_types/src/lib/src/interfaces/StorageAccess.d.ts
+++ b/_types/src/lib/src/interfaces/StorageAccess.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { FilePath, FilePathWithPrefix, UXDataWriteOptions, UXFileInfo, UXFileInfoStub, UXFolderInfo, UXStat } from "@lib/common/types";
 import type { CustomRegExp } from "@lib/common/utils";
 import type { FileWithFileStat, FileWithStatAsProp } from "@lib/common/models/fileaccess.type";

--- a/_types/src/lib/src/interfaces/StorageEventManager.d.ts
+++ b/_types/src/lib/src/interfaces/StorageEventManager.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { FileEventType, FilePath, UXFileInfoStub, UXInternalFileInfoStub } from "@lib/common/types";
 export type FileEvent = {
     type: FileEventType;

--- a/_types/src/lib/src/managers/ChangeManager.d.ts
+++ b/_types/src/lib/src/managers/ChangeManager.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { FallbackWeakRef } from "octagonal-wheels/common/polyfill";
 /**
  * Options for configuring the ChangeManager.

--- a/_types/src/lib/src/managers/ChunkFetcher.d.ts
+++ b/_types/src/lib/src/managers/ChunkFetcher.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type DocumentID } from "@lib/common/types.ts";
 import { type ChunkManager } from "./ChunkManager.ts";
 import type { IReplicatorService, ISettingService } from "@lib/services/base/IService.ts";

--- a/_types/src/lib/src/managers/ChunkManager.d.ts
+++ b/_types/src/lib/src/managers/ChunkManager.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { LayeredChunkManager } from "./LayeredChunkManager";
 export { LayeredChunkManager as ChunkManager };

--- a/_types/src/lib/src/managers/ConflictManager.d.ts
+++ b/_types/src/lib/src/managers/ConflictManager.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type Diff } from "diff-match-patch";
 import { type EntryDoc, type FilePathWithPrefix, type diff_result_leaf, type LoadedEntry, type DIFF_CHECK_RESULT_AUTO } from "@lib/common/types.ts";
 import type { EntryManager } from "@lib/managers/EntryManager/EntryManager.ts";

--- a/_types/src/lib/src/managers/EntryManager/EntryManager.d.ts
+++ b/_types/src/lib/src/managers/EntryManager/EntryManager.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type FilePathWithPrefix, type FilePath, type LoadedEntry, type EntryDoc, type SavingEntry, type MetaEntry } from "@lib/common/types";
 import type { ChunkManager } from "@lib/managers/ChunkManager";
 import type { ContentSplitter } from "@lib/ContentSplitter/ContentSplitters";

--- a/_types/src/lib/src/managers/EntryManager/EntryManagerImpls.d.ts
+++ b/_types/src/lib/src/managers/EntryManager/EntryManagerImpls.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type SavingEntry, type DocumentID, type EntryDoc, type EntryBase, type FilePath, type FilePathWithPrefix, type LoadedEntry, type ObsidianLiveSyncSettings, type MetaEntry } from "@lib/common/types";
 import type { ContentSplitter } from "@lib/ContentSplitter/ContentSplitters";
 import type { HashManager } from "@lib/managers/HashManager/HashManager";

--- a/_types/src/lib/src/managers/HashManager/HashManager.d.ts
+++ b/_types/src/lib/src/managers/HashManager/HashManager.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { HashAlgorithm } from "@lib/common/models/setting.type.ts";
 import { HashManagerCore, type HashManagerCoreOptions } from "./HashManagerCore.ts";
 /**

--- a/_types/src/lib/src/managers/HashManager/HashManagerCore.d.ts
+++ b/_types/src/lib/src/managers/HashManager/HashManagerCore.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ISettingService } from "@lib/services/base/IService.ts";
 import type { HashAlgorithm } from "@lib/common/models/setting.type.ts";
 /**

--- a/_types/src/lib/src/managers/HashManager/PureJSHashManager.d.ts
+++ b/_types/src/lib/src/managers/HashManager/PureJSHashManager.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { HashManagerCore } from "./HashManagerCore.ts";
 import type { HashAlgorithm } from "@lib/common/models/setting.type.ts";
 /**

--- a/_types/src/lib/src/managers/HashManager/XXHashHashManager.d.ts
+++ b/_types/src/lib/src/managers/HashManager/XXHashHashManager.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { HashManagerCore, type HashManagerCoreOptions } from "./HashManagerCore.ts";
 import type { XXHashAPI } from "xxhash-wasm-102";
 import type { HashAlgorithm } from "@lib/common/models/setting.type.ts";

--- a/_types/src/lib/src/managers/LayeredChunkManager.d.ts
+++ b/_types/src/lib/src/managers/LayeredChunkManager.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { DocumentID, EntryDoc, EntryLeaf } from "@lib/common/types.ts";
 import type { ChangeManager } from "@lib/managers/ChangeManager.ts";
 import type { ChunkManagerEventMap, ChunkManagerOptions, ChunkReadOptions, ChunkWriteOptions, WriteResult } from "./LayeredChunkManager/types.ts";

--- a/_types/src/lib/src/managers/LayeredChunkManager/ArrivalWaitLayer.d.ts
+++ b/_types/src/lib/src/managers/LayeredChunkManager/ArrivalWaitLayer.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { DocumentID, EntryLeaf } from "@lib/common/types";
 import type { IReadLayer } from "./ChunkLayerInterfaces";
 import type { ChunkReadOptions } from "./types.ts";

--- a/_types/src/lib/src/managers/LayeredChunkManager/CacheLayer.d.ts
+++ b/_types/src/lib/src/managers/LayeredChunkManager/CacheLayer.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { DocumentID, EntryLeaf } from "@lib/common/types";
 import type { IReadLayer, IWriteLayer } from "./ChunkLayerInterfaces";
 import type { ChunkReadOptions, ChunkWriteOptions, WriteResult } from "./types.ts";

--- a/_types/src/lib/src/managers/LayeredChunkManager/ChunkLayerInterfaces.d.ts
+++ b/_types/src/lib/src/managers/LayeredChunkManager/ChunkLayerInterfaces.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { DocumentID, EntryLeaf } from "@lib/common/types.ts";
 import type { ChunkReadOptions, ChunkWriteOptions, WriteResult } from "./types.ts";
 /**

--- a/_types/src/lib/src/managers/LayeredChunkManager/DatabaseReadLayer.d.ts
+++ b/_types/src/lib/src/managers/LayeredChunkManager/DatabaseReadLayer.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { EntryLeaf, DocumentID, EntryDoc } from "@lib/common/types";
 import type { IReadLayer } from "./ChunkLayerInterfaces";
 import type { ChunkReadOptions } from "./types.ts";

--- a/_types/src/lib/src/managers/LayeredChunkManager/DatabaseWriteLayer.d.ts
+++ b/_types/src/lib/src/managers/LayeredChunkManager/DatabaseWriteLayer.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { EntryLeaf, DocumentID, EntryDoc } from "@lib/common/types";
 import type { IWriteLayer } from "./ChunkLayerInterfaces";
 import type { ChunkWriteOptions, WriteResult } from "./types.ts";

--- a/_types/src/lib/src/managers/LayeredChunkManager/HotPackLayer.d.ts
+++ b/_types/src/lib/src/managers/LayeredChunkManager/HotPackLayer.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { EntryLeaf, DocumentID } from "@lib/common/types";
 import type { IWriteLayer } from "./ChunkLayerInterfaces";
 import type { ChunkWriteOptions, WriteResult } from "./types.ts";

--- a/_types/src/lib/src/managers/LayeredChunkManager/types.d.ts
+++ b/_types/src/lib/src/managers/LayeredChunkManager/types.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { EntryDoc } from "@lib/common/models/db.definition";
 import type { DocumentID, EntryLeaf } from "@lib/common/models/db.type";
 import type { ISettingService } from "@lib/services/base/IService";

--- a/_types/src/lib/src/managers/LiveSyncManagers.d.ts
+++ b/_types/src/lib/src/managers/LiveSyncManagers.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type EntryDoc } from "@lib/common/types";
 import { ContentSplitter } from "@lib/ContentSplitter/ContentSplitters.ts";
 import { ChangeManager } from "@lib/managers/ChangeManager.ts";

--- a/_types/src/lib/src/managers/StorageEventManager.d.ts
+++ b/_types/src/lib/src/managers/StorageEventManager.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type FileEventType, type FilePath, type UXFileInfoStub, type UXFolderInfo, type UXInternalFileInfoStub } from "@lib/common/types.ts";
 import { type FileEventItem } from "@lib/common/types.ts";
 import type { IStorageAccessManager } from "@lib/interfaces/StorageAccess.ts";

--- a/_types/src/lib/src/managers/StorageProcessingManager.d.ts
+++ b/_types/src/lib/src/managers/StorageProcessingManager.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { FilePathWithPrefix } from "@lib/common/models/db.type";
 import type { UXFileInfoStub } from "@lib/common/models/fileaccess.type";
 import type { IStorageAccessManager } from "@lib/interfaces/StorageAccess";

--- a/_types/src/lib/src/managers/adapters/IStorageEventConverterAdapter.d.ts
+++ b/_types/src/lib/src/managers/adapters/IStorageEventConverterAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { FilePath, UXFileInfoStub, UXInternalFileInfoStub } from "@lib/common/types";
 /**
  * Adapter interface for converting platform-specific file types to UX types

--- a/_types/src/lib/src/managers/adapters/IStorageEventManagerAdapter.d.ts
+++ b/_types/src/lib/src/managers/adapters/IStorageEventManagerAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { IStorageEventTypeGuardAdapter } from "./IStorageEventTypeGuardAdapter";
 import type { IStorageEventPersistenceAdapter } from "./IStorageEventPersistenceAdapter";
 import type { IStorageEventWatchAdapter } from "./IStorageEventWatchAdapter";

--- a/_types/src/lib/src/managers/adapters/IStorageEventPersistenceAdapter.d.ts
+++ b/_types/src/lib/src/managers/adapters/IStorageEventPersistenceAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { FileEventItem } from "@lib/common/types";
 import type { FileEventItemSentinel } from "@lib/managers/StorageEventManager";
 /**

--- a/_types/src/lib/src/managers/adapters/IStorageEventStatusAdapter.d.ts
+++ b/_types/src/lib/src/managers/adapters/IStorageEventStatusAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 /**
  * Adapter interface for status update operations
  */

--- a/_types/src/lib/src/managers/adapters/IStorageEventTypeGuardAdapter.d.ts
+++ b/_types/src/lib/src/managers/adapters/IStorageEventTypeGuardAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 /**
  * Adapter interface for type guard operations in StorageEventManager
  *

--- a/_types/src/lib/src/managers/adapters/IStorageEventWatchAdapter.d.ts
+++ b/_types/src/lib/src/managers/adapters/IStorageEventWatchAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { FilePath } from "@lib/common/types";
 /**
  * Event handlers for storage events

--- a/_types/src/lib/src/managers/adapters/index.d.ts
+++ b/_types/src/lib/src/managers/adapters/index.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export type { IStorageEventTypeGuardAdapter } from "./IStorageEventTypeGuardAdapter";
 export type { IStorageEventPersistenceAdapter } from "./IStorageEventPersistenceAdapter";
 export type { IStorageEventWatchAdapter, IStorageEventWatchHandlers } from "./IStorageEventWatchAdapter";

--- a/_types/src/lib/src/mock_and_interop/stores.d.ts
+++ b/_types/src/lib/src/mock_and_interop/stores.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { LOG_LEVEL } from "@lib/common/types.ts";
 export type LockStats = {
     pending: string[];

--- a/_types/src/lib/src/mock_and_interop/wrapper.d.ts
+++ b/_types/src/lib/src/mock_and_interop/wrapper.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare class WrappedNotice {
     constructor(message: string | DocumentFragment, timeout?: number);
     setMessage(message: string | DocumentFragment): this;

--- a/_types/src/lib/src/mods.d.ts
+++ b/_types/src/lib/src/mods.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare function getWebCrypto(): Promise<Crypto>;

--- a/_types/src/lib/src/pouchdb/LiveSyncDBFunctions.d.ts
+++ b/_types/src/lib/src/pouchdb/LiveSyncDBFunctions.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type EntryDoc, type EntryMilestoneInfo, type RemoteDBSettings, type ChunkVersionRange, type TweakValues, type DeviceInfo } from "@lib/common/types.ts";
 export type ENSURE_DB_RESULT = "OK" | "INCOMPATIBLE" | "LOCKED" | "NODE_LOCKED" | "NODE_CLEANED" | ["MISMATCHED", TweakValues];
 /**

--- a/_types/src/lib/src/pouchdb/LiveSyncLocalDB.d.ts
+++ b/_types/src/lib/src/pouchdb/LiveSyncLocalDB.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type EntryDoc, type EntryLeaf, type Credential, type RemoteDBSettings, type DocumentID, type FilePathWithPrefix, type FilePath, type DatabaseEntry, type LoadedEntry, type MetaEntry, type SavingEntry, type diff_result_leaf } from "@lib/common/types.ts";
 import { eventHub } from "@lib/hub/hub.ts";
 import { LiveSyncManagers } from "@lib/managers/LiveSyncManagers.ts";

--- a/_types/src/lib/src/pouchdb/ReplicatorShim.d.ts
+++ b/_types/src/lib/src/pouchdb/ReplicatorShim.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export type SomeDocument<T extends object> = PouchDB.Core.ExistingDocument<T> & PouchDB.Core.ChangesMeta;
 /**
  * Minimal subset of the PouchDB public API required by {@link replicateShim}.

--- a/_types/src/lib/src/pouchdb/StreamingFetch.d.ts
+++ b/_types/src/lib/src/pouchdb/StreamingFetch.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { EntryDoc } from "@lib/common/models/db.definition";
 import type { AnyEntry, EntryLeaf } from "@lib/common/models/db.type";
 type DBSequence = number | string;

--- a/_types/src/lib/src/pouchdb/StreamingFetch.integration.spec.d.ts
+++ b/_types/src/lib/src/pouchdb/StreamingFetch.integration.spec.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export {};

--- a/_types/src/lib/src/pouchdb/chunks.d.ts
+++ b/_types/src/lib/src/pouchdb/chunks.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { CouchDBConnection } from "@lib/common/types";
 export declare function purgeUnreferencedChunks(db: PouchDB.Database, dryRun: boolean, connSetting?: CouchDBConnection, performCompact?: boolean): Promise<number>;
 export declare function transferChunks(key: string, label: string, dbFrom: PouchDB.Database, dbTo: PouchDB.Database, items: {

--- a/_types/src/lib/src/pouchdb/compress.d.ts
+++ b/_types/src/lib/src/pouchdb/compress.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import * as fflate from "fflate";
 import type { EntryDoc } from "@lib/common/types";
 export declare function _compressText(text: string): Promise<string>;

--- a/_types/src/lib/src/pouchdb/encryption.d.ts
+++ b/_types/src/lib/src/pouchdb/encryption.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type EntryDoc, type AnyEntry, type EntryLeaf, type DocumentID, type E2EEAlgorithm } from "@lib/common/types";
 import { encryptWorker, decryptWorker, encryptHKDFWorker, decryptHKDFWorker } from "@lib/worker/bgWorker.ts";
 export declare const encrypt: typeof encryptWorker;

--- a/_types/src/lib/src/pouchdb/negotiation.d.ts
+++ b/_types/src/lib/src/pouchdb/negotiation.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare const checkRemoteVersion: (db: PouchDB.Database, migrate: (from: number, to: number) => Promise<boolean>, barrier?: number) => Promise<boolean>;
 export declare const bumpRemoteVersion: (db: PouchDB.Database, barrier?: number) => Promise<boolean>;
 export declare const checkSyncInfo: (db: PouchDB.Database) => Promise<boolean>;

--- a/_types/src/lib/src/pouchdb/pouchdb-browser.d.ts
+++ b/_types/src/lib/src/pouchdb/pouchdb-browser.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import PouchDB from "pouchdb-core";
 export { PouchDB };

--- a/_types/src/lib/src/pouchdb/pouchdb-http.d.ts
+++ b/_types/src/lib/src/pouchdb/pouchdb-http.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import PouchDB from "pouchdb-core";
 export { PouchDB };

--- a/_types/src/lib/src/pouchdb/pouchdb-test.d.ts
+++ b/_types/src/lib/src/pouchdb/pouchdb-test.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import PouchDB from "pouchdb-core";
 export { PouchDB };

--- a/_types/src/lib/src/pouchdb/utils_couchdb.d.ts
+++ b/_types/src/lib/src/pouchdb/utils_couchdb.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare const isValidRemoteCouchDBURI: (uri: string) => boolean;
 export declare function isCloudantURI(uri: string): boolean;
 export declare function isErrorOfMissingDoc(ex: unknown): boolean;

--- a/_types/src/lib/src/replication/LiveSyncAbstractReplicator.d.ts
+++ b/_types/src/lib/src/replication/LiveSyncAbstractReplicator.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type EntryDoc, type DatabaseConnectingStatus, type RemoteDBSettings, type EntryLeaf, type TweakValues, type NodeData } from "@lib/common/types.ts";
 import type { RequiredServices } from "@lib/interfaces/ServiceModule";
 export type ReplicationCallback = (e: PouchDB.Core.ExistingDocument<EntryDoc>[]) => Promise<boolean> | boolean;

--- a/_types/src/lib/src/replication/SyncParamsHandler.d.ts
+++ b/_types/src/lib/src/replication/SyncParamsHandler.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { SyncParameters } from "@lib/common/types.ts";
 import { LiveSyncError } from "@lib/common/LSError.ts";
 /**

--- a/_types/src/lib/src/replication/couchdb/LiveSyncReplicator.d.ts
+++ b/_types/src/lib/src/replication/couchdb/LiveSyncReplicator.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type EntryDoc, type RemoteDBSettings, type EntryLeaf, type TweakValues, type SyncParameters, type DatabaseEntry, type NodeData } from "@lib/common/types.ts";
 import { LiveSyncAbstractReplicator, type LiveSyncReplicatorEnv, type RemoteDBStatus } from "@lib/replication/LiveSyncAbstractReplicator.ts";
 import type { ServiceHub } from "@lib/services/ServiceHub.ts";

--- a/_types/src/lib/src/replication/httplib.d.ts
+++ b/_types/src/lib/src/replication/httplib.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { CouchDBCredentials, JWTCredentials, JWTHeader, JWTParams, JWTPayload, PreparedJWT, RemoteDBSettings } from "@lib/common/types";
 import { Computed } from "octagonal-wheels/dataobject/Computed";
 /**

--- a/_types/src/lib/src/replication/journal/JournalSyncCore.d.ts
+++ b/_types/src/lib/src/replication/journal/JournalSyncCore.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type EntryDoc, type SyncParameters, type BucketSyncSetting, type RemoteDBSettings } from "@lib/common/types.ts";
 import type { ReplicationCallback, ReplicationStat } from "@lib/replication/LiveSyncAbstractReplicator.ts";
 import { type SimpleStore } from "@lib/common/utils.ts";

--- a/_types/src/lib/src/replication/journal/JournalSyncTypes.d.ts
+++ b/_types/src/lib/src/replication/journal/JournalSyncTypes.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export type CheckPointInfo = {
     lastLocalSeq: number | string;
     journalEpoch: string;

--- a/_types/src/lib/src/replication/journal/LiveSyncJournalReplicator.d.ts
+++ b/_types/src/lib/src/replication/journal/LiveSyncJournalReplicator.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type RemoteDBSettings, type EntryLeaf, type ChunkVersionRange, type TweakValues, type NodeData } from "@lib/common/types.ts";
 import { JournalSyncCore } from "./JournalSyncCore.ts";
 import { LiveSyncAbstractReplicator, type RemoteDBStatus } from "@lib/replication/LiveSyncAbstractReplicator.ts";

--- a/_types/src/lib/src/replication/journal/LiveSyncJournalReplicatorEnv.d.ts
+++ b/_types/src/lib/src/replication/journal/LiveSyncJournalReplicatorEnv.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { LiveSyncReplicatorEnv } from "@lib/replication/LiveSyncAbstractReplicator";
 export interface LiveSyncJournalReplicatorEnv extends LiveSyncReplicatorEnv { // eslint-disable-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface -- Empty interface
 }

--- a/_types/src/lib/src/replication/journal/objectstore/JournalStorageAdapter.d.ts
+++ b/_types/src/lib/src/replication/journal/objectstore/JournalStorageAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { RemoteDBStatus } from "@lib/replication/LiveSyncAbstractReplicator.ts";
 import type { BucketSyncSetting } from "@lib/common/types.ts";
 export interface IJournalStorage {

--- a/_types/src/lib/src/replication/journal/objectstore/MinioStorageAdapter.d.ts
+++ b/_types/src/lib/src/replication/journal/objectstore/MinioStorageAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { S3 } from "@aws-sdk/client-s3";
 import { type BucketSyncSetting } from "@lib/common/types.ts";
 import type { RemoteDBStatus } from "@lib/replication/LiveSyncAbstractReplicator.ts";

--- a/_types/src/lib/src/replication/journal/objectstore/MinioStorageAdapter.integration.spec.d.ts
+++ b/_types/src/lib/src/replication/journal/objectstore/MinioStorageAdapter.integration.spec.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export {};

--- a/_types/src/lib/src/replication/trystero/LiveSyncTrysteroReplicator.d.ts
+++ b/_types/src/lib/src/replication/trystero/LiveSyncTrysteroReplicator.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type RemoteDBSettings, type EntryLeaf, type TweakValues, type LOG_LEVEL, type NodeData } from "@lib/common/types";
 import { LiveSyncAbstractReplicator, type LiveSyncReplicatorEnv, type RemoteDBStatus } from "@lib/replication/LiveSyncAbstractReplicator";
 import { TrysteroReplicator } from "./TrysteroReplicator";

--- a/_types/src/lib/src/replication/trystero/P2PLogCollector.d.ts
+++ b/_types/src/lib/src/replication/trystero/P2PLogCollector.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { P2PReplicationProgress } from "./TrysteroReplicator";
 export declare class P2PLogCollector {
     constructor();

--- a/_types/src/lib/src/replication/trystero/P2PReplicatorBase.d.ts
+++ b/_types/src/lib/src/replication/trystero/P2PReplicatorBase.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { LOG_LEVEL } from "octagonal-wheels/common/logger";
 import type { SimpleStore } from "octagonal-wheels/databases/SimpleStoreBase";
 import type { ReactiveSource } from "octagonal-wheels/dataobject/reactive_v2";

--- a/_types/src/lib/src/replication/trystero/P2PReplicatorCore.d.ts
+++ b/_types/src/lib/src/replication/trystero/P2PReplicatorCore.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";
 import type { P2PPaneParams } from "./UseP2PReplicatorResult";
 export type P2PViewFactory = (leaf: unknown) => unknown;

--- a/_types/src/lib/src/replication/trystero/P2PReplicatorPaneCommon.d.ts
+++ b/_types/src/lib/src/replication/trystero/P2PReplicatorPaneCommon.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { InjectableServiceHub } from "@lib/services/InjectableServices.ts";
 export declare const EVENT_P2P_PEER_SHOW_EXTRA_MENU = "p2p-peer-show-extra-menu";
 export declare enum AcceptedStatus {

--- a/_types/src/lib/src/replication/trystero/ProxiedDB.d.ts
+++ b/_types/src/lib/src/replication/trystero/ProxiedDB.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type ReplicatorHostEnv } from "./types";
 import type { EntryDoc } from "@lib/common/models/db.definition";
 export declare function createHostingDB(env: ReplicatorHostEnv): {

--- a/_types/src/lib/src/replication/trystero/TrysteroReplicator.d.ts
+++ b/_types/src/lib/src/replication/trystero/TrysteroReplicator.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type EntryDoc, type ObsidianLiveSyncSettings } from "@lib/common/types";
 import { type ProgressInfo } from "@lib/pouchdb/ReplicatorShim";
 import type { Confirm } from "@lib/interfaces/Confirm";

--- a/_types/src/lib/src/replication/trystero/TrysteroReplicatorP2PClient.d.ts
+++ b/_types/src/lib/src/replication/trystero/TrysteroReplicatorP2PClient.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { PouchDBShim, SomeDocument } from "@lib/pouchdb/ReplicatorShim";
 import type { TrysteroReplicatorP2PServer } from "./TrysteroReplicatorP2PServer";
 import { type BindableObject, type NonPrivateMethodKeys, type Response } from "./types";

--- a/_types/src/lib/src/replication/trystero/TrysteroReplicatorP2PConnection.d.ts
+++ b/_types/src/lib/src/replication/trystero/TrysteroReplicatorP2PConnection.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { TrysteroReplicatorP2PServer } from "./TrysteroReplicatorP2PServer";
 export { TrysteroReplicatorP2PServer as TrysteroConnection };

--- a/_types/src/lib/src/replication/trystero/TrysteroReplicatorP2PServer.d.ts
+++ b/_types/src/lib/src/replication/trystero/TrysteroReplicatorP2PServer.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type ActionSender, type Room } from "@trystero-p2p/nostr";
 import { type P2PSyncSetting } from "@lib/common/types";
 import { type ReplicatorHostEnv, type FullFilledDeviceInfo, type Request, type Response, type Payload, type Advertisement, type BindableObject, type BindableFunction } from "./types";

--- a/_types/src/lib/src/replication/trystero/UseP2PReplicatorResult.d.ts
+++ b/_types/src/lib/src/replication/trystero/UseP2PReplicatorResult.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ReactiveSource } from "octagonal-wheels/dataobject/reactive_v2";
 import type { LiveSyncTrysteroReplicator } from "./LiveSyncTrysteroReplicator";
 import type { P2PLogCollector } from "./P2PLogCollector";

--- a/_types/src/lib/src/replication/trystero/addP2PEventHandlers.d.ts
+++ b/_types/src/lib/src/replication/trystero/addP2PEventHandlers.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { LiveSyncTrysteroReplicator } from "./LiveSyncTrysteroReplicator";
 import type { Advertisement } from "./types";
 /**

--- a/_types/src/lib/src/replication/trystero/rpcCompat.d.ts
+++ b/_types/src/lib/src/replication/trystero/rpcCompat.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare function toRpcMethodName(method: string): string;

--- a/_types/src/lib/src/replication/trystero/types.d.ts
+++ b/_types/src/lib/src/replication/trystero/types.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { JsonLike } from "@lib/rpc";
 import type { P2PSyncSetting, EntryDoc } from "@lib/common/types";
 import type { SimpleStore } from "@lib/common/utils";

--- a/_types/src/lib/src/replication/trystero/useP2PReplicatorCommands.d.ts
+++ b/_types/src/lib/src/replication/trystero/useP2PReplicatorCommands.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";
 import type { UseP2PReplicatorResult } from "./UseP2PReplicatorResult";
 /**

--- a/_types/src/lib/src/replication/trystero/useP2PReplicatorFeature.d.ts
+++ b/_types/src/lib/src/replication/trystero/useP2PReplicatorFeature.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";
 import { LiveSyncTrysteroReplicator } from "./LiveSyncTrysteroReplicator";
 import { type UseP2PReplicatorResult } from "./UseP2PReplicatorResult";

--- a/_types/src/lib/src/rpc/RpcRoom.d.ts
+++ b/_types/src/lib/src/rpc/RpcRoom.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { RpcSession } from "./RpcSession";
 import { type JsonLike, type RpcMethodHandler, type RpcRegisterOptions, type RpcRoomOptions } from "./types";
 export declare class RpcRoom {

--- a/_types/src/lib/src/rpc/RpcSession.d.ts
+++ b/_types/src/lib/src/rpc/RpcSession.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { JsonLike } from "./types";
 import type { RpcRoom } from "./RpcRoom";
 export declare class RpcSession {

--- a/_types/src/lib/src/rpc/chunking.d.ts
+++ b/_types/src/lib/src/rpc/chunking.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare function estimateBytes(text: string): number;
 export declare function splitIntoChunks(payload: string, maxBytes: number): string[];
 export declare class IncomingChunkBuffer {

--- a/_types/src/lib/src/rpc/errors.d.ts
+++ b/_types/src/lib/src/rpc/errors.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { JsonLike, RpcErrorCode, RpcErrorShape } from "./types";
 export declare class RpcError extends Error {
     code: RpcErrorCode;

--- a/_types/src/lib/src/rpc/index.d.ts
+++ b/_types/src/lib/src/rpc/index.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export { RpcRoom } from "./RpcRoom";
 export { RpcSession } from "./RpcSession";
 export { RpcError } from "./errors";

--- a/_types/src/lib/src/rpc/pouchdb/RpcPouchDBProxy.d.ts
+++ b/_types/src/lib/src/rpc/pouchdb/RpcPouchDBProxy.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { RpcSession } from "@lib/rpc/RpcSession";
 /**
  * A PouchDB-compatible proxy that forwards all database operations to a remote

--- a/_types/src/lib/src/rpc/pouchdb/RpcPouchDBServer.d.ts
+++ b/_types/src/lib/src/rpc/pouchdb/RpcPouchDBServer.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { RpcRoom } from "@lib/rpc/RpcRoom";
 /**
  * Exposes a PouchDB database as a set of RPC methods registered on an

--- a/_types/src/lib/src/rpc/transports/DiagRTCPeerConnections.d.ts
+++ b/_types/src/lib/src/rpc/transports/DiagRTCPeerConnections.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { DiagRTCStats, DiagRTCFailureDiagnosis } from "./DiagRTCPeerConnections.types";
 /**
  * Subscribes to connection status updates. The callback will be called with the latest connection statistics whenever there is a change in the connection status of any RTCPeerConnection instance.

--- a/_types/src/lib/src/rpc/transports/DiagRTCPeerConnections.types.d.ts
+++ b/_types/src/lib/src/rpc/transports/DiagRTCPeerConnections.types.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export type DiagRTCConnectionStatus = {
     connectionState: RTCPeerConnection["connectionState"];
     iceConnectionState: RTCPeerConnection["iceConnectionState"];

--- a/_types/src/lib/src/rpc/transports/DiagRTCPeerConnections.utils.d.ts
+++ b/_types/src/lib/src/rpc/transports/DiagRTCPeerConnections.utils.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type DiagRTCPeerConnectionInternalStateHistory, type DiagRTCFailureDiagnosis, type DiagRTCPeerConnectionMetrics, type DiagRTCFailureStats } from "./DiagRTCPeerConnections.types";
 /**
  * Diagnoses the failure reason of a failed RTCPeerConnection based on its internal state history and selected candidate pair information.

--- a/_types/src/lib/src/rpc/transports/TrysteroTransport.d.ts
+++ b/_types/src/lib/src/rpc/transports/TrysteroTransport.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type Room } from "@trystero-p2p/nostr";
 import { RpcRoom } from "@lib/rpc/RpcRoom";
 import { RpcPouchDBProxy } from "@lib/rpc/pouchdb/RpcPouchDBProxy";

--- a/_types/src/lib/src/rpc/transports/trysteroUtils.d.ts
+++ b/_types/src/lib/src/rpc/transports/trysteroUtils.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { BaseRoomConfig } from "@trystero-p2p/nostr";
 import type { P2PConnectionInfo } from "@lib/common/models/setting.type";
 export declare function generateJoinRoomOptions(settings: P2PConnectionInfo): BaseRoomConfig;

--- a/_types/src/lib/src/rpc/types.d.ts
+++ b/_types/src/lib/src/rpc/types.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare const RPC_VERSION_MAJOR = 1;
 export declare const RPC_VERSION_MINOR = 0;
 export type JsonLike = null | boolean | number | string | JsonLike[] | {

--- a/_types/src/lib/src/serviceFeatures/checkRemoteSize.d.ts
+++ b/_types/src/lib/src/serviceFeatures/checkRemoteSize.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { createInstanceLogFunction, type LogFunction } from "@lib/services/lib/logUtils";
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";
 /**

--- a/_types/src/lib/src/serviceFeatures/offlineScanner.d.ts
+++ b/_types/src/lib/src/serviceFeatures/offlineScanner.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type FilePathWithPrefix, type FilePathWithPrefixLC, type MetaEntry, type UXFileInfoStub, type ObsidianLiveSyncSettings, type LOG_LEVEL } from "@lib/common/types";
 import { type LogFunction } from "@lib/services/lib/logUtils";
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";

--- a/_types/src/lib/src/serviceFeatures/prepareDatabaseForUse.d.ts
+++ b/_types/src/lib/src/serviceFeatures/prepareDatabaseForUse.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";
 import { UnresolvedErrorManager } from "@lib/services/base/UnresolvedErrorManager";
 import { type LogFunction } from "@lib/services/lib/logUtils";

--- a/_types/src/lib/src/serviceFeatures/remoteConfig.d.ts
+++ b/_types/src/lib/src/serviceFeatures/remoteConfig.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type LOG_LEVEL } from "@lib/common/logger";
 import type { ObsidianLiveSyncSettings } from "@lib/common/models/setting.type";
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";

--- a/_types/src/lib/src/serviceFeatures/setupObsidian/qrCode.d.ts
+++ b/_types/src/lib/src/serviceFeatures/setupObsidian/qrCode.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";
 import type { SetupFeatureHost } from "./types";
 export declare function encodeSetupSettingsAsQR(host: SetupFeatureHost): Promise<string>;

--- a/_types/src/lib/src/serviceFeatures/setupObsidian/setupUri.d.ts
+++ b/_types/src/lib/src/serviceFeatures/setupObsidian/setupUri.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { LogFunction } from "@lib/services/lib/logUtils";
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";
 import type { SetupFeatureHost } from "./types";

--- a/_types/src/lib/src/serviceFeatures/setupObsidian/types.d.ts
+++ b/_types/src/lib/src/serviceFeatures/setupObsidian/types.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";
 export type SetupFeatureHost = NecessaryServices<"API" | "UI" | "setting", never>;

--- a/_types/src/lib/src/serviceFeatures/targetFilter.d.ts
+++ b/_types/src/lib/src/serviceFeatures/targetFilter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type UXFileInfoStub } from "@lib/common/types";
 import { type LogFunction } from "@lib/services/lib/logUtils";
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";

--- a/_types/src/lib/src/serviceModules/FileAccessBase.d.ts
+++ b/_types/src/lib/src/serviceModules/FileAccessBase.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { FilePath, UXDataWriteOptions, UXFileInfoStub, UXFolderInfo } from "@lib/common/types.ts";
 import type { IStorageAccessManager } from "@lib/interfaces/StorageAccess.ts";
 import type { IAPIService, IPathService, ISettingService, IVaultService } from "@lib/services/base/IService.ts";

--- a/_types/src/lib/src/serviceModules/Rebuilder.d.ts
+++ b/_types/src/lib/src/serviceModules/Rebuilder.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { IFileHandler } from "@lib/interfaces/FileHandler";
 import type { APIService } from "@lib/services/base/APIService";
 import type { AppLifecycleService } from "@lib/services/base/AppLifecycleService";

--- a/_types/src/lib/src/serviceModules/ServiceDatabaseFileAccessBase.d.ts
+++ b/_types/src/lib/src/serviceModules/ServiceDatabaseFileAccessBase.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { UXFileInfoStub, FilePathWithPrefix, UXFileInfo, MetaEntry, LoadedEntry, FilePath } from "@lib/common/types";
 import type { DatabaseFileAccess } from "@lib/interfaces/DatabaseFileAccess";
 import type { StorageAccess } from "@lib/interfaces/StorageAccess";

--- a/_types/src/lib/src/serviceModules/ServiceFileAccessBase.d.ts
+++ b/_types/src/lib/src/serviceModules/ServiceFileAccessBase.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { FilePath, FilePathWithPrefix, UXDataWriteOptions, UXFileInfo, UXFileInfoStub, UXFolderInfo, UXStat } from "@lib/common/types";
 import { ServiceModuleBase } from "@lib/serviceModules/ServiceModuleBase";
 import type { APIService } from "@lib/services/base/APIService";

--- a/_types/src/lib/src/serviceModules/ServiceFileHandlerBase.d.ts
+++ b/_types/src/lib/src/serviceModules/ServiceFileHandlerBase.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { AnyEntry, FilePath, FilePathWithPrefix, MetaEntry, UXFileInfo, UXFileInfoStub, UXInternalFileInfoStub } from "@lib/common/types";
 import type { IFileHandler } from "@lib/interfaces/FileHandler.ts";
 import { ServiceModuleBase } from "@lib/serviceModules/ServiceModuleBase";

--- a/_types/src/lib/src/serviceModules/ServiceModuleBase.d.ts
+++ b/_types/src/lib/src/serviceModules/ServiceModuleBase.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { APIService } from "@lib/services/base/APIService";
 import { createInstanceLogFunction } from "@lib/services/lib/logUtils";
 export interface ServiceModuleBaseDependencies {

--- a/_types/src/lib/src/serviceModules/adapters/IConversionAdapter.d.ts
+++ b/_types/src/lib/src/serviceModules/adapters/IConversionAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { UXFileInfoStub, UXFolderInfo } from "@lib/common/types.ts";
 /**
  * Conversion adapter interface

--- a/_types/src/lib/src/serviceModules/adapters/IFileSystemAdapter.d.ts
+++ b/_types/src/lib/src/serviceModules/adapters/IFileSystemAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { FilePath, UXStat } from "@lib/common/types.ts";
 import type { IPathAdapter } from "./IPathAdapter.ts";
 import type { ITypeGuardAdapter } from "./ITypeGuardAdapter.ts";

--- a/_types/src/lib/src/serviceModules/adapters/IPathAdapter.d.ts
+++ b/_types/src/lib/src/serviceModules/adapters/IPathAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { FilePath } from "@lib/common/types.ts";
 /**
  * Path operations adapter interface

--- a/_types/src/lib/src/serviceModules/adapters/IStorageAdapter.d.ts
+++ b/_types/src/lib/src/serviceModules/adapters/IStorageAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { UXDataWriteOptions, UXStat } from "@lib/common/types.ts";
 /**
  * Storage adapter interface

--- a/_types/src/lib/src/serviceModules/adapters/ITypeGuardAdapter.d.ts
+++ b/_types/src/lib/src/serviceModules/adapters/ITypeGuardAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 /**
  * Type guard adapter interface
  * Provides runtime type checking for native file system objects

--- a/_types/src/lib/src/serviceModules/adapters/IVaultAdapter.d.ts
+++ b/_types/src/lib/src/serviceModules/adapters/IVaultAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { UXDataWriteOptions } from "@lib/common/types.ts";
 /**
  * Vault adapter interface

--- a/_types/src/lib/src/serviceModules/adapters/index.d.ts
+++ b/_types/src/lib/src/serviceModules/adapters/index.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export type { IPathAdapter } from "./IPathAdapter.ts";
 export type { ITypeGuardAdapter } from "./ITypeGuardAdapter.ts";
 export type { IConversionAdapter } from "./IConversionAdapter.ts";

--- a/_types/src/lib/src/services/BrowserServices.d.ts
+++ b/_types/src/lib/src/services/BrowserServices.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { InjectableVaultServiceCompat } from "@lib/services/implements/injectable/InjectableVaultService";
 import { ServiceContext } from "@lib/services/base/ServiceBase";
 import { InjectableServiceHub } from "@lib/services/implements/injectable/InjectableServiceHub";

--- a/_types/src/lib/src/services/HeadlessServices.d.ts
+++ b/_types/src/lib/src/services/HeadlessServices.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { ServiceContext } from "@lib/services/base/ServiceBase";
 import { InjectableServiceHub } from "@lib/services/implements/injectable/InjectableServiceHub";
 import type { DatabaseService } from "@lib/services/base/DatabaseService.ts";

--- a/_types/src/lib/src/services/InjectableServices.d.ts
+++ b/_types/src/lib/src/services/InjectableServices.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export { InjectableServiceHub } from "@lib/services/implements/injectable/InjectableServiceHub.ts";

--- a/_types/src/lib/src/services/ServiceHub.d.ts
+++ b/_types/src/lib/src/services/ServiceHub.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { UIService } from "./implements/base/UIService.ts";
 import type { ConfigService } from "@lib/services/base/ConfigService.ts";
 import type { TestService } from "@lib/services/base/TestService.ts";

--- a/_types/src/lib/src/services/base/APIService.d.ts
+++ b/_types/src/lib/src/services/base/APIService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { FetchHttpHandler } from "@smithy/fetch-http-handler";
 import type { LOG_LEVEL } from "@lib/common/logger";
 import type { IAPIService, ICommandCompat } from "./IService";

--- a/_types/src/lib/src/services/base/AppLifecycleService.d.ts
+++ b/_types/src/lib/src/services/base/AppLifecycleService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { IAppLifecycleService, ISettingService } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";
 export interface AppLifecycleServiceDependencies {

--- a/_types/src/lib/src/services/base/ConfigService.d.ts
+++ b/_types/src/lib/src/services/base/ConfigService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { IConfigService } from "@lib/services/base/IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";
 export declare abstract class ConfigService<T extends ServiceContext = ServiceContext> extends ServiceBase<T> implements IConfigService {

--- a/_types/src/lib/src/services/base/ConflictService.d.ts
+++ b/_types/src/lib/src/services/base/ConflictService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { FilePathWithPrefix, MISSING_OR_ERROR, AUTO_MERGED } from "@lib/common/types";
 import type { IConflictService } from "@lib/services/base/IService";
 import { ServiceBase } from "@lib/services/base/ServiceBase";

--- a/_types/src/lib/src/services/base/ControlService.d.ts
+++ b/_types/src/lib/src/services/base/ControlService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { createInstanceLogFunction } from "@lib/services/lib/logUtils";
 import type { APIService } from "./APIService";
 import type { DatabaseService } from "./DatabaseService";

--- a/_types/src/lib/src/services/base/DatabaseEventService.d.ts
+++ b/_types/src/lib/src/services/base/DatabaseEventService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { IDatabaseEventService } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";
 /**

--- a/_types/src/lib/src/services/base/DatabaseService.d.ts
+++ b/_types/src/lib/src/services/base/DatabaseService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { IDatabaseService, IPathService, IVaultService, openDatabaseParameters } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";
 import { LiveSyncLocalDB } from "@lib/pouchdb/LiveSyncLocalDB";

--- a/_types/src/lib/src/services/base/FileProcessingService.d.ts
+++ b/_types/src/lib/src/services/base/FileProcessingService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { IFileProcessingService } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";
 /**

--- a/_types/src/lib/src/services/base/IService.d.ts
+++ b/_types/src/lib/src/services/base/IService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { FetchHttpHandler } from "@smithy/fetch-http-handler";
 import { type LOG_LEVEL } from "octagonal-wheels/common/logger";
 import type { AnyEntry, AUTO_MERGED, CouchDBCredentials, diff_result, DocumentID, EntryDoc, EntryHasPath, FileEventItem, FilePath, FilePathWithPrefix, LoadedEntry, MetaEntry, MISSING_OR_ERROR, ObsidianLiveSyncSettings, RemoteDBSettings, TweakValues, UXFileInfo, UXFileInfoStub } from "@lib/common/types";

--- a/_types/src/lib/src/services/base/KeyValueDBService.d.ts
+++ b/_types/src/lib/src/services/base/KeyValueDBService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { SimpleStore } from "@lib/common/utils";
 import type { IKeyValueDBService, IVaultService } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";

--- a/_types/src/lib/src/services/base/PathService.d.ts
+++ b/_types/src/lib/src/services/base/PathService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { DocumentID, EntryHasPath, FilePathWithPrefix, FilePath, AnyEntry, UXFileInfo, UXFileInfoStub } from "@lib/common/types";
 import type { IPathService, ISettingService } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";

--- a/_types/src/lib/src/services/base/RemoteService.d.ts
+++ b/_types/src/lib/src/services/base/RemoteService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { CouchDBCredentials, EntryDoc } from "@lib/common/types";
 import type { IRemoteService } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";

--- a/_types/src/lib/src/services/base/ReplicationService.d.ts
+++ b/_types/src/lib/src/services/base/ReplicationService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type LOG_LEVEL } from "@lib/common/types";
 import type { IAPIService, IDatabaseService, IFileProcessingService, IReplicationService, IReplicatorService, ISettingService } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";

--- a/_types/src/lib/src/services/base/ReplicatorService.d.ts
+++ b/_types/src/lib/src/services/base/ReplicatorService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { LiveSyncAbstractReplicator } from "@lib/replication/LiveSyncAbstractReplicator";
 import type { IReplicatorService } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";

--- a/_types/src/lib/src/services/base/ServiceBase.d.ts
+++ b/_types/src/lib/src/services/base/ServiceBase.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare class ServiceContext {
 }
 export declare abstract class ServiceBase<T extends ServiceContext> {

--- a/_types/src/lib/src/services/base/SettingService.d.ts
+++ b/_types/src/lib/src/services/base/SettingService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type ObsidianLiveSyncSettings } from "@lib/common/types";
 import type { IAPIService, ISettingService } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";

--- a/_types/src/lib/src/services/base/TestService.d.ts
+++ b/_types/src/lib/src/services/base/TestService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ITestService } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";
 /**

--- a/_types/src/lib/src/services/base/TweakValueService.d.ts
+++ b/_types/src/lib/src/services/base/TweakValueService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { RemoteDBSettings, TweakValues } from "@lib/common/types";
 import type { ITweakValueService } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";

--- a/_types/src/lib/src/services/base/UnresolvedErrorManager.d.ts
+++ b/_types/src/lib/src/services/base/UnresolvedErrorManager.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type LOG_LEVEL } from "octagonal-wheels/common/logger";
 import type { AppLifecycleService } from "./AppLifecycleService";
 export declare class UnresolvedErrorManager {

--- a/_types/src/lib/src/services/base/VaultService.d.ts
+++ b/_types/src/lib/src/services/base/VaultService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { FilePath } from "@lib/common/types";
 import type { IAPIService, ISettingService, IVaultService } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";

--- a/_types/src/lib/src/services/implements/base/UIService.d.ts
+++ b/_types/src/lib/src/services/implements/base/UIService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { Confirm } from "@lib/interfaces/Confirm";
 import type { ComponentHasResult, SvelteDialogManagerBase } from "@lib/UI/svelteDialog";
 import type { IAPIService, IUIService } from "@lib/services/base/IService";

--- a/_types/src/lib/src/services/implements/browser/BrowserAPIService.d.ts
+++ b/_types/src/lib/src/services/implements/browser/BrowserAPIService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 import { InjectableAPIService } from "@lib/services/implements/injectable/InjectableAPIService";
 import type { FetchHttpHandler } from "@smithy/fetch-http-handler";

--- a/_types/src/lib/src/services/implements/browser/BrowserConfirm.d.ts
+++ b/_types/src/lib/src/services/implements/browser/BrowserConfirm.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { Confirm } from "@lib/interfaces/Confirm";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 export declare class BrowserConfirm<T extends ServiceContext> implements Confirm {

--- a/_types/src/lib/src/services/implements/browser/BrowserDatabaseService.d.ts
+++ b/_types/src/lib/src/services/implements/browser/BrowserDatabaseService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 import { KeyValueDBService } from "@lib/services/base/KeyValueDBService";
 import { DatabaseService } from "@lib/services/base/DatabaseService.ts";

--- a/_types/src/lib/src/services/implements/browser/BrowserUIService.d.ts
+++ b/_types/src/lib/src/services/implements/browser/BrowserUIService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { UIService } from "@lib/services/implements/base/UIService";
 import type { ConfigService } from "@lib/services/base/ConfigService";
 import type { AppLifecycleService } from "@lib/services/base/AppLifecycleService";

--- a/_types/src/lib/src/services/implements/browser/ConfigServiceBrowserCompat.d.ts
+++ b/_types/src/lib/src/services/implements/browser/ConfigServiceBrowserCompat.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { ConfigService } from "@lib/services/base/ConfigService";
 import type { IAPIService, ISettingService } from "@lib/services/base/IService";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";

--- a/_types/src/lib/src/services/implements/browser/Menu.d.ts
+++ b/_types/src/lib/src/services/implements/browser/Menu.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type PromiseWithResolvers } from "octagonal-wheels/promises";
 export declare class MenuItem {
     type: string;

--- a/_types/src/lib/src/services/implements/browser/ui/renderMessageMarkdown.d.ts
+++ b/_types/src/lib/src/services/implements/browser/ui/renderMessageMarkdown.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare function renderMessageMarkdown(message: string): string;

--- a/_types/src/lib/src/services/implements/headless/HeadlessAPIService.d.ts
+++ b/_types/src/lib/src/services/implements/headless/HeadlessAPIService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 import { InjectableAPIService } from "@lib/services/implements/injectable/InjectableAPIService";
 import type { FetchHttpHandler } from "@smithy/fetch-http-handler";

--- a/_types/src/lib/src/services/implements/headless/HeadlessDatabaseService.d.ts
+++ b/_types/src/lib/src/services/implements/headless/HeadlessDatabaseService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { KeyValueDBService } from "@lib/services/base/KeyValueDBService";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 import { DatabaseService } from "@lib/services/base/DatabaseService.ts";

--- a/_types/src/lib/src/services/implements/injectable/InjectableAPIService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableAPIService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { APIService } from "@lib/services/base/APIService";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 export declare abstract class InjectableAPIService<T extends ServiceContext> extends APIService<T> {

--- a/_types/src/lib/src/services/implements/injectable/InjectableAppLifecycleService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableAppLifecycleService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { AppLifecycleService } from "@lib/services/base/AppLifecycleService";
 import type { IAppLifecycleService } from "@lib/services/base/IService";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";

--- a/_types/src/lib/src/services/implements/injectable/InjectableConflictService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableConflictService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { ConflictService } from "@lib/services/base/ConflictService";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 export declare class InjectableConflictService<T extends ServiceContext> extends ConflictService<T> {

--- a/_types/src/lib/src/services/implements/injectable/InjectableDatabaseEventService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableDatabaseEventService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { DatabaseEventService } from "@lib/services/base/DatabaseEventService";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 export declare class InjectableDatabaseEventService<T extends ServiceContext> extends DatabaseEventService<T> {

--- a/_types/src/lib/src/services/implements/injectable/InjectableFileProcessingService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableFileProcessingService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { FileProcessingService } from "@lib/services/base/FileProcessingService";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 export declare class InjectableFileProcessingService<T extends ServiceContext> extends FileProcessingService<T> {

--- a/_types/src/lib/src/services/implements/injectable/InjectablePathService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectablePathService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { UXFileInfo, AnyEntry, UXFileInfoStub, FilePathWithPrefix } from "@lib/common/types";
 import { PathService } from "@lib/services/base/PathService";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";

--- a/_types/src/lib/src/services/implements/injectable/InjectableRemoteService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableRemoteService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { RemoteService } from "@lib/services/base/RemoteService";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 export declare class InjectableRemoteService<T extends ServiceContext> extends RemoteService<T> {

--- a/_types/src/lib/src/services/implements/injectable/InjectableReplicationService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableReplicationService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { ReplicationService } from "@lib/services/base/ReplicationService";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 export declare class InjectableReplicationService<T extends ServiceContext> extends ReplicationService<T> {

--- a/_types/src/lib/src/services/implements/injectable/InjectableReplicatorService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableReplicatorService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { ReplicatorService } from "@lib/services/base/ReplicatorService";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 export declare class InjectableReplicatorService<T extends ServiceContext> extends ReplicatorService<T> {

--- a/_types/src/lib/src/services/implements/injectable/InjectableServiceHub.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableServiceHub.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ConfigService } from "@lib/services/base/ConfigService";
 import { ControlService } from "@lib/services/base/ControlService";
 import type { KeyValueDBService } from "@lib/services/base/KeyValueDBService";

--- a/_types/src/lib/src/services/implements/injectable/InjectableServices.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableServices.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type ServiceInstances } from "@lib/services/ServiceHub.ts";
 import type { UIService } from "@lib/services/implements/base/UIService.ts";
 import type { ConfigService } from "@lib/services/base/ConfigService.ts";

--- a/_types/src/lib/src/services/implements/injectable/InjectableSettingService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableSettingService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 import { SettingService, type SettingServiceDependencies } from "@lib/services/base/SettingService";
 import type { ObsidianLiveSyncSettings } from "@lib/common/types";

--- a/_types/src/lib/src/services/implements/injectable/InjectableTestService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableTestService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 import { TestService } from "@lib/services/base/TestService";
 export declare class InjectableTestService<T extends ServiceContext> extends TestService<T> {

--- a/_types/src/lib/src/services/implements/injectable/InjectableTweakValueService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableTweakValueService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 import { TweakValueService } from "@lib/services/base/TweakValueService";
 export declare class InjectableTweakValueService<T extends ServiceContext> extends TweakValueService<T> {

--- a/_types/src/lib/src/services/implements/injectable/InjectableVaultService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableVaultService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 import { VaultService } from "@lib/services/base/VaultService";
 export declare abstract class InjectableVaultService<T extends ServiceContext> extends VaultService<T> {

--- a/_types/src/lib/src/services/implements/obsidian/ObsidianServiceContext.d.ts
+++ b/_types/src/lib/src/services/implements/obsidian/ObsidianServiceContext.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { ServiceContext } from "@lib/services/base/ServiceBase";
 import type ObsidianLiveSyncPlugin from "@/main";
 import type { App, Plugin } from "@/deps";

--- a/_types/src/lib/src/services/lib/HandlerUtils.d.ts
+++ b/_types/src/lib/src/services/lib/HandlerUtils.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 /**
  * A function type that can be used as a handler.
  */

--- a/_types/src/lib/src/services/lib/logUtils.d.ts
+++ b/_types/src/lib/src/services/lib/logUtils.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type LOG_LEVEL } from "octagonal-wheels/common/logger";
 import type { IAPIService } from "@lib/services/base/IService";
 export declare const MARK_LOG_SEPARATOR = "\u200A";

--- a/_types/src/lib/src/string_and_binary/chunks.d.ts
+++ b/_types/src/lib/src/string_and_binary/chunks.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare function splitPiecesTextV2(dataSrc: string | string[], pieceSize: number, minimumChunkSize: number): () => Generator<string>;
 export declare function binaryTextSplit(data: string, pieceSize: number, minimumChunkSize: number): () => Generator<string>;
 export declare function splitPiecesText(dataSrc: string | string[], pieceSize: number, plainSplit: boolean, minimumChunkSize: number, useSegmenter: boolean): () => Generator<string>;

--- a/_types/src/lib/src/string_and_binary/convert.d.ts
+++ b/_types/src/lib/src/string_and_binary/convert.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { arrayBufferToBase64, base64ToArrayBuffer, base64ToArrayBufferInternalBrowser, readString, writeString, tryConvertBase64ToArrayBuffer } from "octagonal-wheels/binary";
 export { arrayBufferToBase64, base64ToArrayBuffer, base64ToArrayBufferInternalBrowser, readString, writeString, tryConvertBase64ToArrayBuffer, };
 export declare function arrayBufferToBase64Single(buffer: Uint8Array | ArrayBuffer): Promise<string>;

--- a/_types/src/lib/src/string_and_binary/hash.d.ts
+++ b/_types/src/lib/src/string_and_binary/hash.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export * from "octagonal-wheels/hash/xxhash.js";
 export type * from "octagonal-wheels/hash/xxhash.js";

--- a/_types/src/lib/src/string_and_binary/path.d.ts
+++ b/_types/src/lib/src/string_and_binary/path.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type AnyEntry, type DocumentID, type EntryHasPath, type FilePath, type FilePathWithPrefix } from "@lib/common/types.ts";
 export declare function isValidFilenameInWidows(filename: string): boolean;
 export declare function isValidFilenameInDarwin(filename: string): boolean;

--- a/_types/src/lib/src/system/wakelock.d.ts
+++ b/_types/src/lib/src/system/wakelock.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 /**
  * Run callback with screen wake lock held.
  * @param callback Callback to run with wake lock held

--- a/_types/src/lib/src/worker/bg.common.d.ts
+++ b/_types/src/lib/src/worker/bg.common.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { END_OF_DATA } from "./universalTypes.ts";
 export declare function postBack(key: number, seq: number, data: string | END_OF_DATA): void;

--- a/_types/src/lib/src/worker/bg.worker.d.ts
+++ b/_types/src/lib/src/worker/bg.worker.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export {};

--- a/_types/src/lib/src/worker/bg.worker.encryption.d.ts
+++ b/_types/src/lib/src/worker/bg.worker.encryption.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { EncryptHKDFArguments } from "./universalTypes.ts";
 import type { EncryptArguments } from "./universalTypes.ts";
 /**

--- a/_types/src/lib/src/worker/bg.worker.splitting.d.ts
+++ b/_types/src/lib/src/worker/bg.worker.splitting.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { SplitArguments } from "./universalTypes.ts";
 /**
  * Processes the splitting of data into chunks.

--- a/_types/src/lib/src/worker/bgWorker.d.ts
+++ b/_types/src/lib/src/worker/bgWorker.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { EncryptArguments, EncryptHKDFArguments, EncryptHKDFProcessItem, EncryptProcessItem, ProcessItem, SplitArguments, SplitProcessItem } from "./universalTypes.ts";
 export type WorkerInstance = {
     worker: Worker;

--- a/_types/src/lib/src/worker/bgWorker.encryption.d.ts
+++ b/_types/src/lib/src/worker/bgWorker.encryption.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type EncryptHKDFProcessItem, type ResultPayload } from "./universalTypes.ts";
 import { type EncryptProcessItem } from "./universalTypes.ts";
 import { type EncryptHKDFArguments } from "./universalTypes.ts";

--- a/_types/src/lib/src/worker/bgWorker.mock.d.ts
+++ b/_types/src/lib/src/worker/bgWorker.mock.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { EncryptHKDFProcessItem, EncryptProcessItem, SplitProcessItem, ProcessItem } from "./universalTypes.ts";
 export type SplitArguments = {
     key: number;

--- a/_types/src/lib/src/worker/bgWorker.splitting.d.ts
+++ b/_types/src/lib/src/worker/bgWorker.splitting.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type ResultPayloadWithSeq, type SplitProcessItem } from "./universalTypes";
 /**
  * Splits data into pieces using a worker.

--- a/_types/src/lib/src/worker/universalTypes.d.ts
+++ b/_types/src/lib/src/worker/universalTypes.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { PromiseWithResolvers } from "octagonal-wheels/promises";
 export type EncryptArguments = {
     key: number;

--- a/_types/src/main.d.ts
+++ b/_types/src/main.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { Plugin, type App, type PluginManifest } from "./deps";
 import { LiveSyncCommands } from "./features/LiveSyncCommands.ts";
 import type { ObsidianServiceContext } from "@lib/services/implements/obsidian/ObsidianServiceContext.ts";

--- a/_types/src/managers/ObsidianStorageEventManagerAdapter.d.ts
+++ b/_types/src/managers/ObsidianStorageEventManagerAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { TFile, TFolder } from "@/deps";
 import type { FilePath, UXFileInfoStub, UXInternalFileInfoStub } from "@lib/common/types";
 import type { FileEventItem } from "@lib/common/types";

--- a/_types/src/managers/StorageEventManagerObsidian.d.ts
+++ b/_types/src/managers/StorageEventManagerObsidian.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { FilePath } from "@lib/common/types";
 import type ObsidianLiveSyncPlugin from "@/main";
 import type { LiveSyncCore } from "@/main";

--- a/_types/src/modules/AbstractModule.d.ts
+++ b/_types/src/modules/AbstractModule.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { AnyEntry, FilePathWithPrefix } from "@lib/common/types";
 import type { IMinimumLiveSyncCommands, LiveSyncBaseCore } from "@/LiveSyncBaseCore";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";

--- a/_types/src/modules/AbstractObsidianModule.d.ts
+++ b/_types/src/modules/AbstractObsidianModule.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { LiveSyncCore } from "@/main";
 import type ObsidianLiveSyncPlugin from "@/main";
 import { AbstractModule } from "./AbstractModule.ts";

--- a/_types/src/modules/core/ModulePeriodicProcess.d.ts
+++ b/_types/src/modules/core/ModulePeriodicProcess.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { PeriodicProcessor } from "@/common/PeriodicProcessor";
 import type { LiveSyncCore } from "@/main";
 import { AbstractModule } from "@/modules/AbstractModule";

--- a/_types/src/modules/core/ModuleReplicator.d.ts
+++ b/_types/src/modules/core/ModuleReplicator.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { AbstractModule } from "@/modules/AbstractModule";
 import { type EntryDoc, type RemoteType } from "@lib/common/types";
 import type { LiveSyncCore } from "@/main";

--- a/_types/src/modules/core/ModuleReplicatorCouchDB.d.ts
+++ b/_types/src/modules/core/ModuleReplicatorCouchDB.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type RemoteDBSettings } from "@lib/common/types";
 import type { LiveSyncAbstractReplicator } from "@lib/replication/LiveSyncAbstractReplicator";
 import { AbstractModule } from "@/modules/AbstractModule";

--- a/_types/src/modules/core/ModuleReplicatorMinIO.d.ts
+++ b/_types/src/modules/core/ModuleReplicatorMinIO.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type RemoteDBSettings } from "@lib/common/types";
 import type { LiveSyncAbstractReplicator } from "@lib/replication/LiveSyncAbstractReplicator";
 import type { LiveSyncCore } from "@/main";

--- a/_types/src/modules/core/ReplicateResultProcessor.d.ts
+++ b/_types/src/modules/core/ReplicateResultProcessor.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type AnyEntry, type EntryDoc, type LoadedEntry, type MetaEntry } from "@lib/common/types";
 import type { ModuleReplicator } from "./ModuleReplicator";
 import type { ReactiveSource } from "octagonal-wheels/dataobject/reactive_v2";

--- a/_types/src/modules/coreFeatures/ModuleConflictChecker.d.ts
+++ b/_types/src/modules/coreFeatures/ModuleConflictChecker.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { AbstractModule } from "@/modules/AbstractModule.ts";
 import { type FilePathWithPrefix } from "@lib/common/types";
 import { QueueProcessor } from "octagonal-wheels/concurrency/processor";

--- a/_types/src/modules/coreFeatures/ModuleConflictResolver.d.ts
+++ b/_types/src/modules/coreFeatures/ModuleConflictResolver.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { AbstractModule } from "@/modules/AbstractModule.ts";
 import { type diff_check_result, type FilePathWithPrefix } from "@lib/common/types";
 import type { InjectableServiceHub } from "@lib/services/InjectableServices.ts";

--- a/_types/src/modules/coreFeatures/ModuleResolveMismatchedTweaks.d.ts
+++ b/_types/src/modules/coreFeatures/ModuleResolveMismatchedTweaks.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type TweakValues, type ObsidianLiveSyncSettings, type RemoteDBSettings } from "@lib/common/types.ts";
 import { AbstractModule } from "@/modules/AbstractModule.ts";
 import type { InjectableServiceHub } from "@lib/services/InjectableServices.ts";

--- a/_types/src/modules/coreObsidian/UILib/dialogs.d.ts
+++ b/_types/src/modules/coreObsidian/UILib/dialogs.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { ButtonComponent } from "@/deps.ts";
 import { App, FuzzySuggestModal, Modal, Plugin, Component } from "@/deps.ts";
 import { type CompatIntervalHandle } from "@lib/common/coreEnvFunctions.ts";

--- a/_types/src/modules/coreObsidian/storageLib/utilObsidian.d.ts
+++ b/_types/src/modules/coreObsidian/storageLib/utilObsidian.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { TFile, type TAbstractFile, type TFolder } from "@/deps.ts";
 import type { FilePathWithPrefix, UXFileInfo, UXFileInfoStub, UXFolderInfo, UXInternalFileInfoStub } from "@lib/common/types.ts";
 import type { LiveSyncCore } from "@/main.ts";

--- a/_types/src/modules/essential/ModuleBasicMenu.d.ts
+++ b/_types/src/modules/essential/ModuleBasicMenu.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { LiveSyncCore } from "@/main";
 import { AbstractModule } from "@/modules/AbstractModule";
 export declare class ModuleBasicMenu extends AbstractModule {

--- a/_types/src/modules/essential/ModuleMigration.d.ts
+++ b/_types/src/modules/essential/ModuleMigration.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { AbstractModule } from "@/modules/AbstractModule.ts";
 import type { LiveSyncCore } from "@/main.ts";
 export declare class ModuleMigration extends AbstractModule {

--- a/_types/src/modules/essentialObsidian/APILib/ObsHttpHandler.d.ts
+++ b/_types/src/modules/essentialObsidian/APILib/ObsHttpHandler.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { FetchHttpHandler, type FetchHttpHandlerOptions } from "@smithy/fetch-http-handler";
 import { HttpRequest, HttpResponse, type HttpHandlerOptions } from "@smithy/protocol-http";
 /**

--- a/_types/src/modules/essentialObsidian/ModuleObsidianEvents.d.ts
+++ b/_types/src/modules/essentialObsidian/ModuleObsidianEvents.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { AbstractObsidianModule } from "@/modules/AbstractObsidianModule.ts";
 import type { TFile } from "@/deps.ts";
 import { type ReactiveSource } from "octagonal-wheels/dataobject/reactive";

--- a/_types/src/modules/essentialObsidian/ModuleObsidianMenu.d.ts
+++ b/_types/src/modules/essentialObsidian/ModuleObsidianMenu.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { LiveSyncCore } from "@/main.ts";
 import { AbstractModule } from "@/modules/AbstractModule.ts";
 export declare class ModuleObsidianMenu extends AbstractModule {

--- a/_types/src/modules/features/DocumentHistory/DocumentHistoryModal.d.ts
+++ b/_types/src/modules/features/DocumentHistory/DocumentHistoryModal.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { TFile, Modal, App } from "@/deps.ts";
 import ObsidianLiveSyncPlugin from "@/main.ts";
 import { type DocumentID, type FilePathWithPrefix, type LoadedEntry } from "@lib/common/types.ts";

--- a/_types/src/modules/features/GlobalHistory/GlobalHistoryView.d.ts
+++ b/_types/src/modules/features/GlobalHistory/GlobalHistoryView.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { WorkspaceLeaf } from "@/deps.ts";
 import type ObsidianLiveSyncPlugin from "@/main.ts";
 import { SvelteItemView } from "@/common/SvelteItemView.ts";

--- a/_types/src/modules/features/InteractiveConflictResolving/ConflictResolveModal.d.ts
+++ b/_types/src/modules/features/InteractiveConflictResolving/ConflictResolveModal.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { App, Modal } from "@/deps.ts";
 import { CANCELLED, LEAVE_TO_SUBSEQUENT, type diff_result } from "@lib/common/types.ts";
 import { eventHub } from "@/common/events.ts";

--- a/_types/src/modules/features/Log/LogPaneView.d.ts
+++ b/_types/src/modules/features/Log/LogPaneView.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { WorkspaceLeaf } from "@/deps.ts";
 import type ObsidianLiveSyncPlugin from "@/main.ts";
 import { SvelteItemView } from "@/common/SvelteItemView.ts";

--- a/_types/src/modules/features/ModuleGlobalHistory.d.ts
+++ b/_types/src/modules/features/ModuleGlobalHistory.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { AbstractObsidianModule } from "@/modules/AbstractObsidianModule.ts";
 export declare class ModuleObsidianGlobalHistory extends AbstractObsidianModule {
     _everyOnloadStart(): Promise<boolean>;

--- a/_types/src/modules/features/ModuleInteractiveConflictResolver.d.ts
+++ b/_types/src/modules/features/ModuleInteractiveConflictResolver.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type FilePathWithPrefix, type diff_result } from "@lib/common/types.ts";
 import { AbstractObsidianModule } from "@/modules/AbstractObsidianModule.ts";
 import type { LiveSyncCore } from "@/main.ts";

--- a/_types/src/modules/features/ModuleLog.d.ts
+++ b/_types/src/modules/features/ModuleLog.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type ReactiveValue } from "octagonal-wheels/dataobject/reactive";
 import { type LOG_LEVEL } from "@lib/common/types.ts";
 import { AbstractObsidianModule } from "@/modules/AbstractObsidianModule.ts";

--- a/_types/src/modules/features/ModuleObsidianDocumentHistory.d.ts
+++ b/_types/src/modules/features/ModuleObsidianDocumentHistory.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type TFile } from "@/deps.ts";
 import type { FilePathWithPrefix, DocumentID } from "@lib/common/types.ts";
 import { AbstractObsidianModule } from "@/modules/AbstractObsidianModule.ts";

--- a/_types/src/modules/features/ModuleObsidianSettingAsMarkdown.d.ts
+++ b/_types/src/modules/features/ModuleObsidianSettingAsMarkdown.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type ObsidianLiveSyncSettings } from "@lib/common/types";
 import { AbstractModule } from "@/modules/AbstractModule.ts";
 import type { ServiceContext } from "@lib/services/base/ServiceBase.ts";

--- a/_types/src/modules/features/ModuleObsidianSettingTab.d.ts
+++ b/_types/src/modules/features/ModuleObsidianSettingTab.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { ObsidianLiveSyncSettingTab } from "./SettingDialogue/ObsidianLiveSyncSettingTab.ts";
 import { AbstractObsidianModule } from "@/modules/AbstractObsidianModule.ts";
 import type { LiveSyncCore } from "@/main.ts";

--- a/_types/src/modules/features/SettingDialogue/LiveSyncSetting.d.ts
+++ b/_types/src/modules/features/SettingDialogue/LiveSyncSetting.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { Setting, TextComponent, type ToggleComponent, type DropdownComponent, ButtonComponent, type TextAreaComponent, type ValueComponent } from "@/deps.ts";
 import { type ConfigurationItem } from "@lib/common/types.ts";
 import { type ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";

--- a/_types/src/modules/features/SettingDialogue/ObsidianLiveSyncSettingTab.d.ts
+++ b/_types/src/modules/features/SettingDialogue/ObsidianLiveSyncSettingTab.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { App, Component, PluginSettingTab } from "@/deps.ts";
 import { type ObsidianLiveSyncSettings } from "@lib/common/types.ts";
 import ObsidianLiveSyncPlugin from "@/main.ts";

--- a/_types/src/modules/features/SettingDialogue/PaneAdvanced.d.ts
+++ b/_types/src/modules/features/SettingDialogue/PaneAdvanced.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";
 import type { PageFunctions } from "./SettingPane.ts";
 export declare function paneAdvanced(this: ObsidianLiveSyncSettingTab, paneEl: HTMLElement, { addPanel }: PageFunctions): void;

--- a/_types/src/modules/features/SettingDialogue/PaneChangeLog.d.ts
+++ b/_types/src/modules/features/SettingDialogue/PaneChangeLog.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";
 export declare function paneChangeLog(this: ObsidianLiveSyncSettingTab, paneEl: HTMLElement): void;

--- a/_types/src/modules/features/SettingDialogue/PaneCustomisationSync.d.ts
+++ b/_types/src/modules/features/SettingDialogue/PaneCustomisationSync.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";
 import type { PageFunctions } from "./SettingPane.ts";
 export declare function paneCustomisationSync(this: ObsidianLiveSyncSettingTab, paneEl: HTMLElement, { addPanel }: PageFunctions): void;

--- a/_types/src/modules/features/SettingDialogue/PaneGeneral.d.ts
+++ b/_types/src/modules/features/SettingDialogue/PaneGeneral.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";
 import type { PageFunctions } from "./SettingPane.ts";
 export declare function paneGeneral(this: ObsidianLiveSyncSettingTab, paneEl: HTMLElement, { addPanel, addPane }: PageFunctions): void;

--- a/_types/src/modules/features/SettingDialogue/PaneHatch.d.ts
+++ b/_types/src/modules/features/SettingDialogue/PaneHatch.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";
 import type { PageFunctions } from "./SettingPane.ts";
 export declare function paneHatch(this: ObsidianLiveSyncSettingTab, paneEl: HTMLElement, { addPanel }: PageFunctions): void;

--- a/_types/src/modules/features/SettingDialogue/PaneMaintenance.d.ts
+++ b/_types/src/modules/features/SettingDialogue/PaneMaintenance.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab";
 import { type PageFunctions } from "./SettingPane";
 export declare function paneMaintenance(this: ObsidianLiveSyncSettingTab, paneEl: HTMLElement, { addPanel }: PageFunctions): void;

--- a/_types/src/modules/features/SettingDialogue/PanePatches.d.ts
+++ b/_types/src/modules/features/SettingDialogue/PanePatches.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";
 import type { PageFunctions } from "./SettingPane.ts";
 export declare function panePatches(this: ObsidianLiveSyncSettingTab, paneEl: HTMLElement, { addPanel }: PageFunctions): void;

--- a/_types/src/modules/features/SettingDialogue/PanePowerUsers.d.ts
+++ b/_types/src/modules/features/SettingDialogue/PanePowerUsers.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";
 import type { PageFunctions } from "./SettingPane.ts";
 export declare function panePowerUsers(this: ObsidianLiveSyncSettingTab, paneEl: HTMLElement, { addPanel }: PageFunctions): void;

--- a/_types/src/modules/features/SettingDialogue/PaneRemoteConfig.d.ts
+++ b/_types/src/modules/features/SettingDialogue/PaneRemoteConfig.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";
 import type { PageFunctions } from "./SettingPane.ts";
 export declare function paneRemoteConfig(this: ObsidianLiveSyncSettingTab, paneEl: HTMLElement, { addPanel, addPane }: PageFunctions): void;

--- a/_types/src/modules/features/SettingDialogue/PaneSelector.d.ts
+++ b/_types/src/modules/features/SettingDialogue/PaneSelector.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";
 import type { PageFunctions } from "./SettingPane.ts";
 export declare function paneSelector(this: ObsidianLiveSyncSettingTab, paneEl: HTMLElement, { addPanel }: PageFunctions): void;

--- a/_types/src/modules/features/SettingDialogue/PaneSetup.d.ts
+++ b/_types/src/modules/features/SettingDialogue/PaneSetup.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";
 import type { PageFunctions } from "./SettingPane.ts";
 export declare function paneSetup(this: ObsidianLiveSyncSettingTab, paneEl: HTMLElement, { addPanel, addPane }: PageFunctions): void;

--- a/_types/src/modules/features/SettingDialogue/PaneSyncSettings.d.ts
+++ b/_types/src/modules/features/SettingDialogue/PaneSyncSettings.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";
 import type { PageFunctions } from "./SettingPane.ts";
 export declare function paneSyncSettings(this: ObsidianLiveSyncSettingTab, paneEl: HTMLElement, { addPanel, addPane }: PageFunctions): void;

--- a/_types/src/modules/features/SettingDialogue/SettingPane.d.ts
+++ b/_types/src/modules/features/SettingDialogue/SettingPane.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type ConfigLevel } from "@lib/common/types";
 import type { AllSettingItemKey, AllSettings } from "./settingConstants";
 export declare const combineOnUpdate: (func1: OnUpdateFunc, func2: OnUpdateFunc) => OnUpdateFunc;

--- a/_types/src/modules/features/SettingDialogue/SveltePanel.d.ts
+++ b/_types/src/modules/features/SettingDialogue/SveltePanel.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type Component } from "svelte";
 import { type Writable } from "svelte/store";
 /**

--- a/_types/src/modules/features/SettingDialogue/remoteConfigBuffer.d.ts
+++ b/_types/src/modules/features/SettingDialogue/remoteConfigBuffer.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ObsidianLiveSyncSettings } from "@lib/common/types.ts";
 export declare function syncActivatedRemoteSettings(target: Partial<ObsidianLiveSyncSettings>, source: ObsidianLiveSyncSettings): void;

--- a/_types/src/modules/features/SettingDialogue/settingConstants.d.ts
+++ b/_types/src/modules/features/SettingDialogue/settingConstants.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export * from "@lib/common/settingConstants.ts";

--- a/_types/src/modules/features/SettingDialogue/settingUtils.d.ts
+++ b/_types/src/modules/features/SettingDialogue/settingUtils.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type ObsidianLiveSyncSettings } from "@lib/common/types";
 /**
  * Generates a summary of P2P configuration settings

--- a/_types/src/modules/features/SetupManager.d.ts
+++ b/_types/src/modules/features/SetupManager.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type ObsidianLiveSyncSettings } from "@lib/common/types.ts";
 import { AbstractModule } from "@/modules/AbstractModule.ts";
 /**

--- a/_types/src/modules/features/SetupWizard/dialogs/setupDialogTypes.d.ts
+++ b/_types/src/modules/features/SetupWizard/dialogs/setupDialogTypes.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { BucketSyncSetting, CouchDBConnection, EncryptionSettings, ObsidianLiveSyncSettings, P2PConnectionInfo } from "@lib/common/models/setting.type";
 export declare const TYPE_IDENTICAL = "identical";
 export declare const TYPE_INDEPENDENT = "independent";

--- a/_types/src/modules/main/ModuleLiveSyncMain.d.ts
+++ b/_types/src/modules/main/ModuleLiveSyncMain.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { AbstractModule } from "@/modules/AbstractModule.ts";
 import type { InjectableServiceHub } from "@lib/services/implements/injectable/InjectableServiceHub.ts";
 import type { LiveSyncCore } from "@/main.ts";

--- a/_types/src/modules/services/ObsidianAPIService.d.ts
+++ b/_types/src/modules/services/ObsidianAPIService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { InjectableAPIService } from "@lib/services/implements/injectable/InjectableAPIService";
 import type { ObsidianServiceContext } from "@lib/services/implements/obsidian/ObsidianServiceContext";
 import { type Command } from "@/deps.ts";

--- a/_types/src/modules/services/ObsidianAppLifecycleService.d.ts
+++ b/_types/src/modules/services/ObsidianAppLifecycleService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { AppLifecycleServiceBase } from "@lib/services/implements/injectable/InjectableAppLifecycleService";
 import type { ObsidianServiceContext } from "@lib/services/implements/obsidian/ObsidianServiceContext";
 declare module "obsidian" {

--- a/_types/src/modules/services/ObsidianConfirm.d.ts
+++ b/_types/src/modules/services/ObsidianConfirm.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type App, type Plugin } from "@/deps";
 import type { Confirm } from "@lib/interfaces/Confirm";
 import type { ObsidianServiceContext } from "@lib/services/implements/obsidian/ObsidianServiceContext";

--- a/_types/src/modules/services/ObsidianDatabaseService.d.ts
+++ b/_types/src/modules/services/ObsidianDatabaseService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ObsidianServiceContext } from "@lib/services/implements/obsidian/ObsidianServiceContext";
 import { DatabaseService, type DatabaseServiceDependencies } from "@lib/services/base/DatabaseService.ts";
 export declare class ObsidianDatabaseService<T extends ObsidianServiceContext> extends DatabaseService<T> {

--- a/_types/src/modules/services/ObsidianPathService.d.ts
+++ b/_types/src/modules/services/ObsidianPathService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ObsidianServiceContext } from "@lib/services/implements/obsidian/ObsidianServiceContext";
 import { PathService } from "@lib/services/base/PathService";
 import { type BASE_IS_NEW, type TARGET_IS_NEW, type EVEN } from "@/common/utils";

--- a/_types/src/modules/services/ObsidianServiceHub.d.ts
+++ b/_types/src/modules/services/ObsidianServiceHub.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { InjectableServiceHub } from "@lib/services/implements/injectable/InjectableServiceHub";
 import { ObsidianServiceContext } from "@lib/services/implements/obsidian/ObsidianServiceContext";
 import type ObsidianLiveSyncPlugin from "@/main";

--- a/_types/src/modules/services/ObsidianServices.d.ts
+++ b/_types/src/modules/services/ObsidianServices.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { InjectableConflictService } from "@lib/services/implements/injectable/InjectableConflictService";
 import { InjectableDatabaseEventService } from "@lib/services/implements/injectable/InjectableDatabaseEventService";
 import { InjectableFileProcessingService } from "@lib/services/implements/injectable/InjectableFileProcessingService";

--- a/_types/src/modules/services/ObsidianSettingService.d.ts
+++ b/_types/src/modules/services/ObsidianSettingService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type ObsidianLiveSyncSettings } from "@lib/common/types";
 import { SettingService, type SettingServiceDependencies } from "@lib/services/base/SettingService";
 import type { ObsidianServiceContext } from "@lib/services/implements/obsidian/ObsidianServiceContext";

--- a/_types/src/modules/services/ObsidianUIService.d.ts
+++ b/_types/src/modules/services/ObsidianUIService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ConfigService } from "@lib/services/base/ConfigService";
 import type { AppLifecycleService } from "@lib/services/base/AppLifecycleService";
 import type { ReplicatorService } from "@lib/services/base/ReplicatorService";

--- a/_types/src/modules/services/ObsidianVaultService.d.ts
+++ b/_types/src/modules/services/ObsidianVaultService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { InjectableVaultService } from "@lib/services/implements/injectable/InjectableVaultService";
 import type { ObsidianServiceContext } from "@lib/services/implements/obsidian/ObsidianServiceContext";
 import type { FilePath } from "@lib/common/types";

--- a/_types/src/serviceFeatures/onLayoutReady/enablei18n.d.ts
+++ b/_types/src/serviceFeatures/onLayoutReady/enablei18n.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 export declare const enableI18nFeature: import("@lib/interfaces/ServiceModule").ServiceFeatureFunction<keyof import("../../lib/src/services/ServiceHub").ServiceHub<import("../../lib/src/services/base/ServiceBase").ServiceContext>, keyof import("@lib/interfaces/ServiceModule").ServiceModules, Promise<boolean>>;

--- a/_types/src/serviceFeatures/redFlag.d.ts
+++ b/_types/src/serviceFeatures/redFlag.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";
 import { type LogFunction } from "@lib/services/lib/logUtils";
 import type { ObsidianLiveSyncSettings } from "@lib/common/models/setting.type";

--- a/_types/src/serviceFeatures/redFlag.simpleFetch.d.ts
+++ b/_types/src/serviceFeatures/redFlag.simpleFetch.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";
 import { type LogFunction } from "@lib/services/lib/logUtils";
 import { type FullScanOptions } from "@lib/serviceFeatures/offlineScanner";

--- a/_types/src/serviceFeatures/setupObsidian/setupManagerHandlers.d.ts
+++ b/_types/src/serviceFeatures/setupObsidian/setupManagerHandlers.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type SetupManager } from "@/modules/features/SetupManager";
 import type { SetupFeatureHost } from "@lib/serviceFeatures/setupObsidian/types";
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";

--- a/_types/src/serviceFeatures/setupObsidian/setupProtocol.d.ts
+++ b/_types/src/serviceFeatures/setupObsidian/setupProtocol.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { LogFunction } from "@lib/services/lib/logUtils";
 import type { SetupFeatureHost } from "@lib/serviceFeatures/setupObsidian/types";
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";

--- a/_types/src/serviceFeatures/useP2PReplicatorUI.d.ts
+++ b/_types/src/serviceFeatures/useP2PReplicatorUI.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";
 import { type UseP2PReplicatorResult } from "@lib/replication/trystero/UseP2PReplicatorResult";
 import { P2PLogCollector } from "@lib/replication/trystero/P2PLogCollector";

--- a/_types/src/serviceModules/DatabaseFileAccess.d.ts
+++ b/_types/src/serviceModules/DatabaseFileAccess.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { DatabaseFileAccess } from "@lib/interfaces/DatabaseFileAccess.ts";
 import { ServiceDatabaseFileAccessBase } from "@lib/serviceModules/ServiceDatabaseFileAccessBase";
 export declare class ServiceDatabaseFileAccess extends ServiceDatabaseFileAccessBase implements DatabaseFileAccess {

--- a/_types/src/serviceModules/FileAccessObsidian.d.ts
+++ b/_types/src/serviceModules/FileAccessObsidian.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type App } from "@/deps";
 import { FileAccessBase, type FileAccessBaseDependencies } from "@lib/serviceModules/FileAccessBase.ts";
 import { ObsidianFileSystemAdapter } from "./FileSystemAdapters/ObsidianFileSystemAdapter";

--- a/_types/src/serviceModules/FileHandler.d.ts
+++ b/_types/src/serviceModules/FileHandler.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { ServiceFileHandlerBase } from "@lib/serviceModules/ServiceFileHandlerBase";
 export declare class ServiceFileHandler extends ServiceFileHandlerBase {
 }

--- a/_types/src/serviceModules/FileSystemAdapters/ObsidianConversionAdapter.d.ts
+++ b/_types/src/serviceModules/FileSystemAdapters/ObsidianConversionAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { UXFileInfoStub, UXFolderInfo } from "@lib/common/types";
 import type { IConversionAdapter } from "@lib/serviceModules/adapters";
 import type { TFile, TFolder } from "obsidian";

--- a/_types/src/serviceModules/FileSystemAdapters/ObsidianFileSystemAdapter.d.ts
+++ b/_types/src/serviceModules/FileSystemAdapters/ObsidianFileSystemAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { FilePath, UXStat } from "@lib/common/types";
 import type { IFileSystemAdapter, IPathAdapter, ITypeGuardAdapter, IConversionAdapter, IStorageAdapter, IVaultAdapter } from "@lib/serviceModules/adapters";
 import type { TAbstractFile, TFile, TFolder, Stat, App } from "obsidian";

--- a/_types/src/serviceModules/FileSystemAdapters/ObsidianPathAdapter.d.ts
+++ b/_types/src/serviceModules/FileSystemAdapters/ObsidianPathAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { type TAbstractFile } from "@/deps";
 import type { FilePath } from "@lib/common/types";
 import type { IPathAdapter } from "@lib/serviceModules/adapters";

--- a/_types/src/serviceModules/FileSystemAdapters/ObsidianStorageAdapter.d.ts
+++ b/_types/src/serviceModules/FileSystemAdapters/ObsidianStorageAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { UXDataWriteOptions } from "@lib/common/types";
 import type { IStorageAdapter } from "@lib/serviceModules/adapters";
 import type { Stat, App } from "obsidian";

--- a/_types/src/serviceModules/FileSystemAdapters/ObsidianTypeGuardAdapter.d.ts
+++ b/_types/src/serviceModules/FileSystemAdapters/ObsidianTypeGuardAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { ITypeGuardAdapter } from "@lib/serviceModules/adapters";
 import { TFile, TFolder } from "obsidian";
 /**

--- a/_types/src/serviceModules/FileSystemAdapters/ObsidianVaultAdapter.d.ts
+++ b/_types/src/serviceModules/FileSystemAdapters/ObsidianVaultAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { UXDataWriteOptions } from "@lib/common/types";
 import type { IVaultAdapter } from "@lib/serviceModules/adapters";
 import type { TFile, App, TFolder } from "obsidian";

--- a/_types/src/serviceModules/ServiceFileAccessImpl.d.ts
+++ b/_types/src/serviceModules/ServiceFileAccessImpl.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import { ServiceFileAccessBase } from "@lib/serviceModules/ServiceFileAccessBase";
 import type { ObsidianFileSystemAdapter } from "./FileSystemAdapters/ObsidianFileSystemAdapter";
 export declare class ServiceFileAccessObsidian extends ServiceFileAccessBase<ObsidianFileSystemAdapter> {

--- a/_types/src/types.d.ts
+++ b/_types/src/types.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: f20eb19
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: 0563f26
 import type { DatabaseFileAccess } from "@lib/interfaces/DatabaseFileAccess";
 import type { Rebuilder } from "@lib/interfaces/DatabaseRebuilder";
 import type { IFileHandler } from "@lib/interfaces/FileHandler";

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "obsidian-livesync",
     "name": "Self-hosted LiveSync",
-    "version": "0.25.77",
+    "version": "0.25.78",
     "minAppVersion": "1.7.2",
     "description": "Community implementation of self-hosted livesync. Reflect your vault changes to some other devices immediately. Please make sure to disable other synchronize solutions to avoid content corruption or duplication.",
     "author": "vorotamoroz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "obsidian-livesync",
-    "version": "0.25.77",
+    "version": "0.25.78",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "obsidian-livesync",
-            "version": "0.25.77",
+            "version": "0.25.78",
             "license": "MIT",
             "workspaces": [
                 "src/apps/cli",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "obsidian-livesync",
-    "version": "0.25.77",
+    "version": "0.25.78",
     "description": "Reflect your vault changes to some other devices immediately. Please make sure to disable other synchronize solutions to avoid content corruption or duplication.",
     "main": "main.js",
     "type": "module",

--- a/src/apps/cli/package.json
+++ b/src/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "self-hosted-livesync-cli",
     "private": true,
-    "version": "0.25.77-cli",
+    "version": "0.25.78-cli",
     "main": "dist/index.cjs",
     "type": "module",
     "scripts": {

--- a/src/apps/webapp/package.json
+++ b/src/apps/webapp/package.json
@@ -1,7 +1,7 @@
 {
     "name": "livesync-webapp",
     "private": true,
-    "version": "0.25.77-webapp",
+    "version": "0.25.78-webapp",
     "type": "module",
     "description": "Browser-based Self-hosted LiveSync using FileSystem API",
     "scripts": {

--- a/src/apps/webpeer/package.json
+++ b/src/apps/webpeer/package.json
@@ -1,7 +1,7 @@
 {
     "name": "webpeer",
     "private": true,
-    "version": "0.25.77-webpeer",
+    "version": "0.25.78-webpeer",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/updates.md
+++ b/updates.md
@@ -4,16 +4,23 @@ Since 19th July, 2025 (beta1 in 0.25.0-beta1, 13th July, 2025)
 The head note of 0.25 is now in [updates_old.md](https://github.com/vrtmrz/obsidian-livesync/blob/main/updates_old.md). Because 0.25 got a lot of updates, thankfully, compatibility is kept and we do not need breaking changes! In other words, when get enough stabled. The next version will be v1.0.0. Even though it my hope.
 
 
-## Unreleased
+## 0.25.78
+
+23rd June, 2026
+
+### Fixed
+- No longer fast synchronisation (a.k.a. Fast Fetch) causes a rewind and re-fetch of the entire database when some errors occur during the process (#972, PR #973). Thank you so much for @apple-ouyang for the fix!
 
 ### Improved
 
-- Overhauled the Object Storage (e.g., MinIO and S3) replication engine ('Journal Replicator 2nd Edition'). It now leverages the standard Web Streams API for a resilient, backpressure-aware architecture, reducing memory footprints on large vaults.
-- Decoupled the physical storage logic to make it easier to add new storage backends in the future.
-- Stricter compliance with CouchDB's replication protocol (proper `_revisions` transfers with `new_edits: false`) when using Object Storage.
-- Introduced Connection String support for setup configuration.
-- Added comprehensive unit tests for the new `JournalSyncCore` engine, covering streams, backpressure, and `new_edits: false` validation.
-- Improved integration test workflows in the CI pipeline to run MinIO tests automatically using standard environment variables.
+- Overhauled the Object Storage (e.g., MinIO and S3) replication engine ('Journal Replicator 2nd Edition').
+  - It now leverages the standard Web Streams API for a resilient, backpressure-aware architecture, reducing memory footprints/temporary storage usage on large vaults.
+  - Decoupled the physical storage logic to make it easier to add new storage backends in the future.
+  - Stricter compliance with CouchDB's replication protocol (proper `_revisions` transfers with `new_edits: false`) when using Object Storage.
+
+### Testing
+  - Added comprehensive unit tests for the new `JournalSyncCore` engine, covering streams, backpressure, and `new_edits: false` validation.
+  - Improved integration test workflows in the CI pipeline to run MinIO tests automatically using standard environment variables.
 
 ## 0.25.77
 
@@ -101,59 +108,6 @@ I should also consider the version numbering for the CLI...
 
 - Adjust CouchDB's database name checking to its specification (#926).
 - `Reset Syncronisation on This Device` for minio and P2P is now working properly. 
-
-## ~~0.25.71~~ 0.25.72
-
-0.25.71 was cancelled due to the fixes needed (Object Storage related)
-
-3rd June, 2026
-
-### Improved
-
-- Database fetching (a.k.a. Reset Synchronisation on This Device) on the initialisation now supports streaming and is faster (CouchDB only)
-- The database fetching process has been streamlined, and database operations are now suspended until it has been completed
-- The initial synchronisation process has been simplified, making it easier to synchronise files with the remote server
-- We can select the remote database to fetch from during the initialisation, when there are multiple remote databases configured (e.g. multiple CouchDBs or S3 remotes)
-- Hebrew (he) Translation has been added (Thank you so much, @MusiCode1)!
-- Translation loading time has been reduced (Thank you so much, @bmcyver)!
-  
-### Fixed
-
-- No longer does the status element break other plugins' interaction (#930).
-- No longer does file events occured during initial database fetching using Object Storage. 
-
-### Refactored
-
-To support the new Community automated tests, we fixed numerous lint warnings. This may have also resolved potential issues.
-
-## 0.25.70
-
-25th May, 2026
-
-### New features
-- Diff dialogue now has great tools to navigate and understand the differences, including:
-  - A checkbox to toggle the visibility of collapsed identical sections, making it easier to focus on the actual differences (PR #889).
-  - A search feature to find specific text in past revisions, and navigate revisions with search results highlighted in the dialogue (PR #890).
-
-- Conflict resolution dialogue now has a navigation feature to jump between conflicts (PR #891).
-
-Thank you so much to @SeleiXi for implementing these features!
-
-### Improved
-
-- More diagnostic information for P2P connections is now shown, including why a connection failure occurred and the current connection status.
-
-## 0.25.69
-
-22nd May, 2026
-
-### Fixed
-- No longer does the P2P passphrase mismatch cause a server shutdown.
-- Settings related to P2P synchronisation are now correctly applied on start-up and no longer reverted.
-
-### New features
-- Diagnostic P2P connection stats are now available.
-  - These stats indicate the number of connection trials, successes, and failures.
 
 Full notes are in
 [updates_old.md](https://github.com/vrtmrz/obsidian-livesync/blob/main/updates_old.md).


### PR DESCRIPTION

### Fixed
- No longer fast synchronisation (a.k.a. Fast Fetch) causes a rewind and re-fetch of the entire database when some errors occur during the process (#972, PR #973). 
### Improved

- Overhauled the Object Storage (e.g., MinIO and S3) replication engine ('Journal Replicator 2nd Edition').
  - It now leverages the standard Web Streams API for a resilient, backpressure-aware architecture, reducing memory footprints/temporary storage usage on large vaults.
  - Decoupled the physical storage logic to make it easier to add new storage backends in the future.
  - Stricter compliance with CouchDB's replication protocol (proper `_revisions` transfers with `new_edits: false`) when using Object Storage.

### Testing
  - Added comprehensive unit tests for the new `JournalSyncCore` engine, covering streams, backpressure, and `new_edits: false` validation.
  - Improved integration test workflows in the CI pipeline to run MinIO tests automatically using standard environment variables.
