### PR TITLE
(refactor): genReplication to use StreamInbox and improve event handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
                 "markdown-it": "^14.2.0",
                 "minimatch": "^10.2.5",
                 "obsidian": "^1.13.1",
-                "octagonal-wheels": "^0.1.46",
+                "octagonal-wheels": "^0.1.47",
                 "qrcode-generator": "^1.4.4",
                 "xxhash-wasm-102": "npm:xxhash-wasm@^1.0.2"
             },
@@ -11684,9 +11684,9 @@
             "license": "MIT"
         },
         "node_modules/octagonal-wheels": {
-            "version": "0.1.46",
-            "resolved": "https://registry.npmjs.org/octagonal-wheels/-/octagonal-wheels-0.1.46.tgz",
-            "integrity": "sha512-19eB7b/WNNrZ4Xghu93f+NVJsbRiaZaIIzU1rn5shxb6SzwVBoOVkNPJdCAsONl6C1MwjaGDrPUS8CBXvPHjPg==",
+            "version": "0.1.47",
+            "resolved": "https://registry.npmjs.org/octagonal-wheels/-/octagonal-wheels-0.1.47.tgz",
+            "integrity": "sha512-pv+AoplTzDmcrYpxun/N7sab7KAVoPvUhwvnrXwrVihjj8sQ89HmovndpMvGJxdpp4+uOOY4SiO0DVWTp+YCkQ==",
             "license": "MIT",
             "dependencies": {
                 "idb": "^8.0.3"
@@ -16210,11 +16210,11 @@
         },
         "src/apps/cli": {
             "name": "self-hosted-livesync-cli",
-            "version": "0.25.77-cli",
+            "version": "0.25.78-cli",
             "dependencies": {
                 "chokidar": "^4.0.0",
                 "minimatch": "^10.2.5",
-                "octagonal-wheels": "^0.1.46",
+                "octagonal-wheels": "^0.1.47",
                 "pouchdb-adapter-http": "^9.0.0",
                 "pouchdb-adapter-leveldb": "^9.0.0",
                 "pouchdb-core": "^9.0.0",
@@ -16236,9 +16236,9 @@
         },
         "src/apps/webapp": {
             "name": "livesync-webapp",
-            "version": "0.25.77-webapp",
+            "version": "0.25.78-webapp",
             "dependencies": {
-                "octagonal-wheels": "^0.1.46"
+                "octagonal-wheels": "^0.1.47"
             },
             "devDependencies": {
                 "@playwright/test": "^1.58.2",
@@ -16251,9 +16251,9 @@
             }
         },
         "src/apps/webpeer": {
-            "version": "0.25.77-webpeer",
+            "version": "0.25.78-webpeer",
             "dependencies": {
-                "octagonal-wheels": "^0.1.46"
+                "octagonal-wheels": "^0.1.47"
             },
             "devDependencies": {
                 "@sveltejs/vite-plugin-svelte": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
         "markdown-it": "^14.2.0",
         "minimatch": "^10.2.5",
         "obsidian": "^1.13.1",
-        "octagonal-wheels": "^0.1.46",
+        "octagonal-wheels": "^0.1.47",
         "qrcode-generator": "^1.4.4",
         "xxhash-wasm-102": "npm:xxhash-wasm@^1.0.2"
     },

--- a/src/apps/cli/package.json
+++ b/src/apps/cli/package.json
@@ -41,7 +41,7 @@
     "dependencies": {
         "chokidar": "^4.0.0",
         "minimatch": "^10.2.5",
-        "octagonal-wheels": "^0.1.46",
+        "octagonal-wheels": "^0.1.47",
         "pouchdb-adapter-http": "^9.0.0",
         "pouchdb-adapter-leveldb": "^9.0.0",
         "pouchdb-core": "^9.0.0",

--- a/src/apps/webapp/package.json
+++ b/src/apps/webapp/package.json
@@ -12,7 +12,7 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "octagonal-wheels": "^0.1.46"
+        "octagonal-wheels": "^0.1.47"
     },
     "devDependencies": {
         "@playwright/test": "^1.58.2",

--- a/src/apps/webpeer/package.json
+++ b/src/apps/webpeer/package.json
@@ -12,7 +12,7 @@
         "check": "svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json"
     },
     "dependencies": {
-        "octagonal-wheels": "^0.1.46"
+        "octagonal-wheels": "^0.1.47"
     },
     "devDependencies": {
         "eslint-plugin-svelte": "^3.19.0",

--- a/updates.md
+++ b/updates.md
@@ -3,6 +3,13 @@ Since 19th July, 2025 (beta1 in 0.25.0-beta1, 13th July, 2025)
 
 The head note of 0.25 is now in [updates_old.md](https://github.com/vrtmrz/obsidian-livesync/blob/main/updates_old.md). Because 0.25 got a lot of updates, thankfully, compatibility is kept and we do not need breaking changes! In other words, when get enough stabled. The next version will be v1.0.0. Even though it my hope.
 
+## Unreleased
+
+29th June, 2026
+
+### Miscellaneous
+
+- Updated `octagonal-wheels` to `0.1.47` across the plug-in and workspace packages to improve smoothness.
 
 ## 0.25.78
 


### PR DESCRIPTION
Updated `octagonal-wheels` to `0.1.47` across the plug-in and workspace packages to improve smoothness.
Update subrepository pointer 