### PR TITLE
docs: add managed CouchDB hosting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ Each workflow establishes ordinary note synchronisation on the first device, gen
 > CouchDB can also be run on a Raspberry Pi (please be mindful of your server's security).
 
 
+### Third-party managed CouchDB hosting
+
+> [!NOTE]
+> The following is a third-party hosting option proposed by Zenith Hosting. It is not an official Self-hosted LiveSync service, and it is neither endorsed nor recommended by this project.
+
+If you would rather not set up and maintain a server yourself, Zenith Hosting offers a managed CouchDB server which this plug-in can be configured to connect to: [Zenith Hosting](https://zenith.hosting/host/obsidian-livesync). As with any hosted service, your data will reside on a server operated by a third party, so please consider whether that is acceptable for your vault before using it.
+
 ## Information in the Status Bar
 
 Synchronisation status is shown in the status bar with the following icons.


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we host a managed CouchDB sync server that Self-hosted LiveSync can connect to, so this PR adds a short note about it under How to Use (https://zenith.hosting/host/obsidian-livesync).

updated per your review: the note is now explicitly framed as a third-party hosting option proposed by Zenith Hosting, and it states plainly that it is not an official Self-hosted LiveSync service and is neither endorsed nor recommended by the project. i also added a line telling readers their data will sit on a server run by a third party, since that seemed like the honest thing to put next to it.

understood on sponsorships, thanks for being upfront about it.
