### PR TITLE
fix: enable hidden file sync before overwrite setup

### DIFF
--- a/src/features/HiddenFileSync/CmdHiddenFileSync.ts
+++ b/src/features/HiddenFileSync/CmdHiddenFileSync.ts
@@ -51,6 +51,7 @@ import { EVENT_SETTING_SAVED, eventHub } from "@/common/events.ts";
 import { Semaphore } from "octagonal-wheels/concurrency/semaphore";
 import type { LiveSyncCore } from "@/main.ts";
 import { tryGetFilePath } from "@lib/common/utils.doc.ts";
+import { configureHiddenFileSyncMode } from "./configureHiddenFileSyncMode.ts";
 type SyncDirection = "push" | "pull" | "safe" | "pullForce" | "pushForce";
 
 declare global {
@@ -1832,43 +1833,35 @@ ${messageFetch}${messageOverwrite}${messageMerge}
     }
 
     async configureHiddenFileSync(mode: keyof OPTIONAL_SYNC_FEATURES) {
-        if (
-            mode != "FETCH" &&
-            mode != "OVERWRITE" &&
-            mode != "MERGE" &&
-            mode != "DISABLE" &&
-            mode != "DISABLE_HIDDEN"
-        ) {
-            return;
-        }
-
-        if (mode == "DISABLE" || mode == "DISABLE_HIDDEN") {
-            // await this.core.$allSuspendExtraSync();
-            await this.core.services.setting.applyPartial(
-                {
-                    syncInternalFiles: false,
-                },
-                true
-            );
-            // this.core.settings.syncInternalFiles = false;
-            // await this.core.saveSettings();
-            return;
-        }
-        this._log("Gathering files for enabling Hidden File Sync", LOG_LEVEL_NOTICE);
-        if (mode == "FETCH") {
-            await this.initialiseInternalFileSync("pullForce", true);
-        } else if (mode == "OVERWRITE") {
-            await this.initialiseInternalFileSync("pushForce", true);
-        } else if (mode == "MERGE") {
-            await this.initialiseInternalFileSync("safe", true);
-        }
-        await this.core.services.setting.applyPartial(
-            {
-                useAdvancedMode: true,
-                syncInternalFiles: true,
+        const result = await configureHiddenFileSyncMode(mode, {
+            disable: async () => {
+                // await this.core.$allSuspendExtraSync();
+                await this.core.services.setting.applyPartial(
+                    {
+                        syncInternalFiles: false,
+                    },
+                    true
+                );
+                // this.core.settings.syncInternalFiles = false;
+                // await this.core.saveSettings();
             },
-            true
-        );
+            enable: async () => {
+                this._log("Gathering files for enabling Hidden File Sync", LOG_LEVEL_NOTICE);
+                await this.core.services.setting.applyPartial(
+                    {
+                        useAdvancedMode: true,
+                        syncInternalFiles: true,
+                    },
+                    true
+                );
+            },
+            initialise: async (direction) => {
+                await this.initialiseInternalFileSync(direction, true);
+            },
+        });
+        if (result == "ignored" || result == "disabled") {
+            return;
+        }
         // this.plugin.settings.useAdvancedMode = true;
         // this.plugin.settings.syncInternalFiles = true;
 

--- a/src/features/HiddenFileSync/configureHiddenFileSyncMode.ts
+++ b/src/features/HiddenFileSync/configureHiddenFileSyncMode.ts
@@ -1,0 +1,45 @@
+type HiddenFileSyncMode = "FETCH" | "OVERWRITE" | "MERGE" | "DISABLE" | "DISABLE_HIDDEN";
+type HiddenFileSyncDirection = "pullForce" | "pushForce" | "safe";
+
+type ConfigureHiddenFileSyncHandlers = {
+    disable: () => Promise<void>;
+    enable: () => Promise<void>;
+    initialise: (direction: HiddenFileSyncDirection) => Promise<void>;
+};
+
+export type ConfigureHiddenFileSyncResult = "ignored" | "disabled" | "enabled";
+
+function getInitialiseDirection(mode: keyof OPTIONAL_SYNC_FEATURES): HiddenFileSyncDirection | false {
+    if (mode == "FETCH") return "pullForce";
+    if (mode == "OVERWRITE") return "pushForce";
+    if (mode == "MERGE") return "safe";
+    return false;
+}
+
+function isDisableMode(mode: keyof OPTIONAL_SYNC_FEATURES): boolean {
+    return mode == "DISABLE" || mode == "DISABLE_HIDDEN";
+}
+
+function isHiddenFileSyncMode(mode: keyof OPTIONAL_SYNC_FEATURES): mode is HiddenFileSyncMode {
+    return mode == "FETCH" || mode == "OVERWRITE" || mode == "MERGE" || isDisableMode(mode);
+}
+
+export async function configureHiddenFileSyncMode(
+    mode: keyof OPTIONAL_SYNC_FEATURES,
+    handlers: ConfigureHiddenFileSyncHandlers
+): Promise<ConfigureHiddenFileSyncResult> {
+    if (!isHiddenFileSyncMode(mode)) {
+        return "ignored";
+    }
+    if (isDisableMode(mode)) {
+        await handlers.disable();
+        return "disabled";
+    }
+    const direction = getInitialiseDirection(mode);
+    if (direction === false) {
+        return "ignored";
+    }
+    await handlers.enable();
+    await handlers.initialise(direction);
+    return "enabled";
+}

--- a/src/features/HiddenFileSync/configureHiddenFileSyncMode.unit.spec.ts
+++ b/src/features/HiddenFileSync/configureHiddenFileSyncMode.unit.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { configureHiddenFileSyncMode } from "./configureHiddenFileSyncMode.ts";
+
+describe("configureHiddenFileSyncMode", () => {
+    it.each([
+        ["FETCH", "pullForce"],
+        ["OVERWRITE", "pushForce"],
+        ["MERGE", "safe"],
+    ] as const)("enables hidden file sync before initialising %s", async (mode, direction) => {
+        const calls: string[] = [];
+
+        const result = await configureHiddenFileSyncMode(mode, {
+            disable: vi.fn(async () => {
+                calls.push("disable");
+            }),
+            enable: vi.fn(async () => {
+                calls.push("enable");
+            }),
+            initialise: vi.fn(async (actualDirection) => {
+                calls.push(`init:${actualDirection}`);
+            }),
+        });
+
+        expect(result).toBe("enabled");
+        expect(calls).toEqual(["enable", `init:${direction}`]);
+    });
+
+    it.each(["DISABLE", "DISABLE_HIDDEN"] as const)("disables hidden file sync immediately for %s", async (mode) => {
+        const calls: string[] = [];
+
+        const result = await configureHiddenFileSyncMode(mode, {
+            disable: vi.fn(async () => {
+                calls.push("disable");
+            }),
+            enable: vi.fn(async () => {
+                calls.push("enable");
+            }),
+            initialise: vi.fn(async (direction) => {
+                calls.push(`init:${direction}`);
+            }),
+        });
+
+        expect(result).toBe("disabled");
+        expect(calls).toEqual(["disable"]);
+    });
+});

--- a/updates.md
+++ b/updates.md
@@ -3,6 +3,13 @@ Since 19th July, 2025 (beta1 in 0.25.0-beta1, 13th July, 2025)
 
 The head note of 0.25 is now in [updates_old.md](https://github.com/vrtmrz/obsidian-livesync/blob/main/updates_old.md). Because 0.25 got a lot of updates, thankfully, compatibility is kept and we do not need breaking changes! In other words, when get enough stabled. The next version will be v1.0.0. Even though it my hope.
 
+## Unreleased
+
+### Fixed
+
+- Fixed an issue where choosing Disable and then Overwrite in Hidden File Sync could silently skip hidden files, because the overwrite setup ran while hidden file synchronisation was still disabled (#989, PR #992).
+  - Hidden File Sync is now re-enabled before the Fetch, Overwrite, or Merge initialisation runs, instead of after it completes. If that initialisation fails, the setting may remain enabled.
+
 ## 0.25.79
 
 29th June, 2026


### PR DESCRIPTION

### Fixed

- Fixed an issue where choosing Disable and then Overwrite in Hidden File Sync could silently skip hidden files, because the overwrite setup ran while hidden file synchronisation was still disabled (#989, PR #992).
  - Hidden File Sync is now re-enabled before the Fetch, Overwrite, or Merge initialisation runs, instead of after it completes. If that initialisation fails, the setting may remain enabled.
