### PR TITLE
Fix conflict issues

### DIFF
--- a/devs.md
+++ b/devs.md
@@ -148,6 +148,20 @@ Hence, the new feature should be implemented as follows:
 - **Service Hub** (`src/modules/services/`): Central service registry using dependency injection
 - **Common Library** (`src/lib/`): Platform-independent sync logic, shared with other tools
 
+### Conflict Merge Policy
+
+Markdown conflict auto-merge should behave like a conservative three-way merge. The guiding rule is to merge changes when they touch non-overlapping regions, and to keep a manual conflict when the edits overlap semantically.
+
+When in doubt, prefer the safer outcome: preserve data, keep the conflict visible, and ask the user rather than silently discarding content or choosing one side.
+
+- If one side deletes a line and the other side leaves that same line unchanged, treat it as a safe deletion. The deleted line must not be reintroduced into the merged result.
+- If one side inserts new content in a different region while the other side deletes an unchanged old region, preserve the insertion and the deletion.
+- If one side deletes a line and the other side modifies that same line, keep the conflict for user resolution.
+- If both sides insert different content at the same position, keep both insertions in a deterministic order unless the surrounding deletion context indicates that they are competing replacements.
+- Avoid resolving conflicts by simply choosing the newest revision unless the user has explicitly selected that behaviour.
+
+This policy is intentionally aligned with the conflict checkboxes and compatibility settings: automatic merge should remove avoidable prompts, but it must not silently choose between overlapping user intentions.
+
 ### File Structure Conventions
 
 - **Platform-specific code**: Use `.platform.ts` suffix (replaced with `.obsidian.ts` in production builds via esbuild)

--- a/updates.md
+++ b/updates.md
@@ -3,6 +3,18 @@ Since 19th July, 2025 (beta1 in 0.25.0-beta1, 13th July, 2025)
 
 The head note of 0.25 is now in [updates_old.md](https://github.com/vrtmrz/obsidian-livesync/blob/main/updates_old.md). Because 0.25 got a lot of updates, thankfully, compatibility is kept and we do not need breaking changes! In other words, when get enough stabled. The next version will be v1.0.0. Even though it my hope.
 
+## Unreleased
+
+### Fixed
+
+- Improved Markdown conflict auto-merge so that non-overlapping edits are merged while overlapping delete-and-edit cases remain visible for manual resolution (#993).
+  - Behaviour change:
+    - When one side deletes an unchanged line and the other side edits a different region, the deleted line is no longer reintroduced into the merged result.
+    - When one side deletes a line and the other side modifies that same line, the conflict is preserved instead of silently choosing one side.
+- Fixed an issue where applying a newer database entry to storage could incorrectly preserve an older local file as a conflict (#994).
+  - Behaviour change:
+    - Local storage is preserved as a conflict only when it is actually newer than the incoming database entry and is not already represented in the revision history.
+
 ## 0.25.79
 
 29th June, 2026

--- a/updates.md
+++ b/updates.md
@@ -13,7 +13,7 @@ The head note of 0.25 is now in [updates_old.md](https://github.com/vrtmrz/obsid
     - When one side deletes a line and the other side modifies that same line, the conflict is preserved instead of silently choosing one side.
 - Fixed an issue where applying a newer database entry to storage could incorrectly preserve an older local file as a conflict (#994).
   - Behaviour change:
-    - Local storage is preserved as a conflict only when it is actually newer than the incoming database entry and is not already represented in the revision history.
+    - Local storage is preserved as a conflict when it may contain unsynchronised changes that are not represented in the revision history. If the incoming database entry is clearly newer, it is applied to storage instead.
 
 ## 0.25.79
 

--- a/updates.md
+++ b/updates.md
@@ -13,7 +13,7 @@ The head note of 0.25 is now in [updates_old.md](https://github.com/vrtmrz/obsid
     - When one side deletes a line and the other side modifies that same line, the conflict is preserved instead of silently choosing one side.
 - Fixed an issue where applying a newer database entry to storage could incorrectly preserve an older local file as a conflict (#994).
   - Behaviour change:
-    - Local storage is preserved as a conflict when it may contain unsynchronised changes that are not represented in the revision history. If the incoming database entry is clearly newer, it is applied to storage instead.
+    - Local storage is preserved as a conflict when it may contain unsynchronised changes that are not represented in the revision history. A newer incoming text entry is applied without creating a conflict only when it clearly extends the existing local text.
 
 ## 0.25.79
 


### PR DESCRIPTION
Fixes:
- Improved Markdown conflict auto-merge so that non-overlapping edits are merged while overlapping delete-and-edit cases remain visible for manual resolution (#993).
  - Behaviour change:
    - When one side deletes an unchanged line and the other side edits a different region, the deleted line is no longer reintroduced into the merged result.
    - When one side deletes a line and the other side modifies that same line, the conflict is preserved instead of silently choosing one side.
- Fixed an issue where applying a newer database entry to storage could incorrectly preserve an older local file as a conflict (#994).
  - Behaviour change:
    - Local storage is preserved as a conflict when it may contain unsynchronised changes that are not represented in the revision history. A newer incoming text entry is applied without creating a conflict only when it clearly extends the existing local text.
