### PR TITLE
releasing 0.25.80

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "obsidian-livesync",
     "name": "Self-hosted LiveSync",
-    "version": "0.25.79",
+    "version": "0.25.80",
     "minAppVersion": "1.7.2",
     "description": "Community implementation of self-hosted livesync. Reflect your vault changes to some other devices immediately. Please make sure to disable other synchronize solutions to avoid content corruption or duplication.",
     "author": "vorotamoroz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "obsidian-livesync",
-    "version": "0.25.79",
+    "version": "0.25.80",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "obsidian-livesync",
-            "version": "0.25.79",
+            "version": "0.25.80",
             "license": "MIT",
             "workspaces": [
                 "src/apps/cli",
@@ -16210,7 +16210,7 @@
         },
         "src/apps/cli": {
             "name": "self-hosted-livesync-cli",
-            "version": "0.25.79-cli",
+            "version": "0.25.80-cli",
             "dependencies": {
                 "chokidar": "^4.0.0",
                 "minimatch": "^10.2.5",
@@ -16236,7 +16236,7 @@
         },
         "src/apps/webapp": {
             "name": "livesync-webapp",
-            "version": "0.25.79-webapp",
+            "version": "0.25.80-webapp",
             "dependencies": {
                 "octagonal-wheels": "^0.1.47"
             },
@@ -16251,7 +16251,7 @@
             }
         },
         "src/apps/webpeer": {
-            "version": "0.25.79-webpeer",
+            "version": "0.25.80-webpeer",
             "dependencies": {
                 "octagonal-wheels": "^0.1.47"
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "obsidian-livesync",
-    "version": "0.25.79",
+    "version": "0.25.80",
     "description": "Reflect your vault changes to some other devices immediately. Please make sure to disable other synchronize solutions to avoid content corruption or duplication.",
     "main": "main.js",
     "type": "module",

--- a/src/apps/cli/package.json
+++ b/src/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "self-hosted-livesync-cli",
     "private": true,
-    "version": "0.25.79-cli",
+    "version": "0.25.80-cli",
     "main": "dist/index.cjs",
     "type": "module",
     "scripts": {

--- a/src/apps/webapp/package.json
+++ b/src/apps/webapp/package.json
@@ -1,7 +1,7 @@
 {
     "name": "livesync-webapp",
     "private": true,
-    "version": "0.25.79-webapp",
+    "version": "0.25.80-webapp",
     "type": "module",
     "description": "Browser-based Self-hosted LiveSync using FileSystem API",
     "scripts": {

--- a/src/apps/webpeer/package.json
+++ b/src/apps/webpeer/package.json
@@ -1,7 +1,7 @@
 {
     "name": "webpeer",
     "private": true,
-    "version": "0.25.79-webpeer",
+    "version": "0.25.80-webpeer",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/updates.md
+++ b/updates.md
@@ -3,7 +3,9 @@ Since 19th July, 2025 (beta1 in 0.25.0-beta1, 13th July, 2025)
 
 The head note of 0.25 is now in [updates_old.md](https://github.com/vrtmrz/obsidian-livesync/blob/main/updates_old.md). Because 0.25 got a lot of updates, thankfully, compatibility is kept and we do not need breaking changes! In other words, when get enough stabled. The next version will be v1.0.0. Even though it my hope.
 
-## Unreleased
+## 0.25.80
+
+7th July, 2026
 
 ### Fixed
 
@@ -109,42 +111,6 @@ Also, this update is a very large one, even if we had a lot of time, and we had 
 ### Miscellaneous
 - Some dependencies have been updated.
 - Now we check the compatibility with iOS 15 in the CI tests to ensure the plugin continues to work on older iOS versions even after we upgrade some dependencies.
-
-## 0.25.74
-
-8th June, 2026
-
-### Fixed
-
-- Fixed an issue where disabling hidden file synchronisation did not take effect, allowing non-target hidden files to continue to be processed and synchronised by replication or boot-sequence scan (#941).
-- Prevented the automatic merging of conflicted revisions when one of the revisions has been deleted, which was causing deleted files to reappear (#911).
-- The startup sequence now saves the state more effectively (Thank you so much for @bmcyver)!
-
-## Only CLI
-
-8th June, 2026
-
-I should also consider the version numbering for the CLI...
-
-### Improved
-
-- Added new remote database management commands: `remote-status`, `unlock-remote`, `lock-remote`, and `mark-resolved`.
-- --vault option is now available for daemon and mirror commands! (Thank you so much for @starskyzheng)!
-- Decoupled the database directory path from the actual vault directory path using the `--vault` (or `-V`) option.
-
-### Fixed (preventive)
-
-- Validated that the specified vault path exists and is indeed a directory before starting the CLI.
-- Integrated path resolution and validations for one-off commands (such as `'push'`, `'pull'`, `'cat'`, `'rm'`, `'info'`, and `'resolve'`) against the decoupled vault path instead of the database path.
-
-## 0.25.73
-
-4th June, 2026
-
-### Fixed
-
-- Adjust CouchDB's database name checking to its specification (#926).
-- `Reset Syncronisation on This Device` for minio and P2P is now working properly. 
 
 Full notes are in
 [updates_old.md](https://github.com/vrtmrz/obsidian-livesync/blob/main/updates_old.md).

--- a/updates_old.md
+++ b/updates_old.md
@@ -4,6 +4,64 @@ Since 19th July, 2025 (beta1 in 0.25.0-beta1, 13th July, 2025)
 The head note of 0.25 is now in [updates_old.md](https://github.com/vrtmrz/obsidian-livesync/blob/main/updates_old.md). Because 0.25 got a lot of updates, thankfully, compatibility is kept and we do not need breaking changes! In other words, when get enough stabled. The next version will be v1.0.0. Even though it my hope.
 
 
+## 0.25.80
+
+7th July, 2026
+
+### Fixed
+
+- Improved Markdown conflict auto-merge so that non-overlapping edits are merged while overlapping delete-and-edit cases remain visible for manual resolution (#993).
+  - Behaviour change:
+    - When one side deletes an unchanged line and the other side edits a different region, the deleted line is no longer reintroduced into the merged result.
+    - When one side deletes a line and the other side modifies that same line, the conflict is preserved instead of silently choosing one side.
+- Fixed an issue where applying a newer database entry to storage could incorrectly preserve an older local file as a conflict (#994).
+  - Behaviour change:
+    - Local storage is preserved as a conflict when it may contain unsynchronised changes that are not represented in the revision history. A newer incoming text entry is applied without creating a conflict only when it clearly extends the existing local text.
+- Fixed an issue where choosing Disable and then Overwrite in Hidden File Sync could silently skip hidden files, because the overwrite setup ran while hidden file synchronisation was still disabled (#989, PR #992).
+  - Hidden File Sync is now re-enabled before the Fetch, Overwrite, or Merge initialisation runs, instead of after it completes. If that initialisation fails, the setting may remain enabled.
+
+## 0.25.79
+
+29th June, 2026
+
+### Fixed
+
+- Fast Fetch now retries transient stream interruptions and resumes from the latest persisted checkpoint, instead of starting over after ordinary network or platform interruptions (#977, PR #978; commonlib PR #59). Thank you so much for @apple-ouyang for the fix!
+- Simple Fetch now remembers the selected setup choices while an interrupted Fetch All operation is still pending, so users are not asked the same questions again on retry (#977, PR #978). Thank you so much for @apple-ouyang for the fix!
+- No longer hidden storage events, such as `.git` paths, reach the normal target-file filter when internal file synchronisation is disabled. This avoids noisy non-target logs before those files are skipped (commonlib PR #60). Thank you so much for @apple-ouyang for the fix!
+- Fixed an issue where a file deleted from storage could be resurrected by the offline scanner because the database tombstone was not written when the storage file was already gone (commonlib PR #56). Thank you so much for @cosmic-fire-eng for the fix!
+
+### Improved
+
+- Local database maintenance commands now ask before applying the required chunk settings, and can apply those prerequisites before continuing (#980, PR #981). Thank you so much for @apple-ouyang for the improvement!
+- Improved CouchDB replication event handling by using the new `StreamInbox` helper from `octagonal-wheels` (commonlib PR #62).
+
+### Documentation
+
+- Added `nginx` to the setup documentation table of contents (PR #976). Thank you so much for @kiraventom for the improvement!
+
+### Miscellaneous
+
+- Updated `octagonal-wheels` to `0.1.47` across the plug-in and workspace packages to use the newly published helper modules.
+
+## 0.25.78
+
+23rd June, 2026
+
+### Fixed
+- No longer fast synchronisation (a.k.a. Fast Fetch) causes a rewind and re-fetch of the entire database when some errors occur during the process (#972, PR #973). Thank you so much for @apple-ouyang for the fix!
+
+### Improved
+
+- Overhauled the Object Storage (e.g., MinIO and S3) replication engine ('Journal Replicator 2nd Edition').
+  - It now leverages the standard Web Streams API for a resilient, backpressure-aware architecture, reducing memory footprints/temporary storage usage on large vaults.
+  - Decoupled the physical storage logic to make it easier to add new storage backends in the future.
+  - Stricter compliance with CouchDB's replication protocol (proper `_revisions` transfers with `new_edits: false`) when using Object Storage.
+
+### Testing
+  - Added comprehensive unit tests for the new `JournalSyncCore` engine, covering streams, backpressure, and `new_edits: false` validation.
+  - Improved integration test workflows in the CI pipeline to run MinIO tests automatically using standard environment variables.
+
 ## 0.25.77
 
 19th June, 2026


### PR DESCRIPTION

### Fixed

- Improved Markdown conflict auto-merge so that non-overlapping edits are merged while overlapping delete-and-edit cases remain visible for manual resolution (#993).
  - Behaviour change:
    - When one side deletes an unchanged line and the other side edits a different region, the deleted line is no longer reintroduced into the merged result.
    - When one side deletes a line and the other side modifies that same line, the conflict is preserved instead of silently choosing one side.
- Fixed an issue where applying a newer database entry to storage could incorrectly preserve an older local file as a conflict (#994).
  - Behaviour change:
    - Local storage is preserved as a conflict when it may contain unsynchronised changes that are not represented in the revision history. A newer incoming text entry is applied without creating a conflict only when it clearly extends the existing local text.
- Fixed an issue where choosing Disable and then Overwrite in Hidden File Sync could silently skip hidden files, because the overwrite setup ran while hidden file synchronisation was still disabled (#989, PR #992).
  - Hidden File Sync is now re-enabled before the Fetch, Overwrite, or Merge initialisation runs, instead of after it completes. If that initialisation fails, the setting may remain enabled.
