### PR TITLE
Compile CLI ignore patterns once

### DIFF
--- a/src/apps/cli/serviceModules/IgnoreRules.ts
+++ b/src/apps/cli/serviceModules/IgnoreRules.ts
@@ -1,4 +1,4 @@
-import { minimatch } from "minimatch";
+import { Minimatch } from "minimatch";
 import { fsPromises as fs, path } from "@/apps/cli/node-compat";
 
 /**
@@ -17,7 +17,7 @@ import { fsPromises as fs, path } from "@/apps/cli/node-compat";
  * Missing files (`.livesync/ignore` or `.gitignore`) are silently skipped.
  */
 export class IgnoreRules {
-    private patterns: string[] = [];
+    private patterns: Minimatch[] = [];
 
     constructor(private vaultPath: string) {}
 
@@ -108,7 +108,7 @@ export class IgnoreRules {
                     `Remove it from .livesync/ignore or use a separate include/exclude file.`
             );
         }
-        this.patterns.push(this._normalisePattern(raw));
+        this.patterns.push(new Minimatch(this._normalisePattern(raw), { dot: true }));
     }
 
     /**
@@ -124,6 +124,6 @@ export class IgnoreRules {
         }
         // Normalise to forward slashes for minimatch.
         const normalised = relativePath.replace(/\\/g, "/");
-        return this.patterns.some((p) => minimatch(normalised, p, { dot: true }));
+        return this.patterns.some((pattern) => pattern.match(normalised));
     }
 }

--- a/src/apps/cli/serviceModules/IgnoreRules.unit.spec.ts
+++ b/src/apps/cli/serviceModules/IgnoreRules.unit.spec.ts
@@ -1,7 +1,28 @@
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const minimatchStats = vi.hoisted(() => ({ constructions: 0 }));
+
+vi.mock("minimatch", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("minimatch")>();
+
+    class CountingMinimatch extends actual.Minimatch {
+        constructor(pattern: string, options?: import("minimatch").MinimatchOptions) {
+            super(pattern, options);
+            minimatchStats.constructions++;
+        }
+    }
+
+    return {
+        ...actual,
+        Minimatch: CountingMinimatch,
+        minimatch: (path: string, pattern: string, options?: import("minimatch").MinimatchOptions) =>
+            new CountingMinimatch(pattern, options).match(path),
+    };
+});
+
 import { IgnoreRules } from "./IgnoreRules";
 
 describe("IgnoreRules", () => {
@@ -18,6 +39,10 @@ describe("IgnoreRules", () => {
         await fs.mkdir(ignoreDir, { recursive: true });
         await fs.writeFile(path.join(ignoreDir, "ignore"), content, "utf-8");
     }
+
+    beforeEach(() => {
+        minimatchStats.constructions = 0;
+    });
 
     afterEach(async () => {
         await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
@@ -55,6 +80,20 @@ describe("IgnoreRules", () => {
     });
 
     describe("shouldIgnore", () => {
+        it("compiles loaded patterns once", async () => {
+            const vaultPath = await createVault();
+            await writeIgnoreFile(vaultPath, "*.tmp\nbuild/\n");
+            const rules = new IgnoreRules(vaultPath);
+            await rules.load();
+
+            expect(rules.shouldIgnore("notes/readme.md")).toBe(false);
+            expect(rules.shouldIgnore("notes/scratch.tmp")).toBe(true);
+            expect(rules.shouldIgnore("build/output.js")).toBe(true);
+            expect(rules.shouldIgnore("other.md")).toBe(false);
+
+            expect(minimatchStats.constructions).toBe(2);
+        });
+
         it("matches **/*.tmp against notes/scratch.tmp", async () => {
             const vaultPath = await createVault();
             await writeIgnoreFile(vaultPath, "*.tmp\n");


### PR DESCRIPTION
## Summary

- compile CLI ignore patterns when rules are loaded
- reuse `Minimatch` instances for every subsequent path check
- add a regression test that counts matcher construction

## Why

The long-running CLI daemon used the top-level `minimatch()` function in `shouldIgnore()`. Like the Obsidian-side path filter reported in #1006, this reparsed stable glob patterns for every checked path and could produce the same minimatch AST churn.

This change stores compiled matchers directly in `IgnoreRules.patterns`. Calling `load()` still replaces the full ruleset, so old matchers are released without adding another cache.

Refs #1006

## Verification

- `vitest run --config vitest.config.unit.ts`: 411 suites, 1369 tests passed
- `npm run tsc-check`
- `npm run lint` (one unrelated existing warning)
- `npm run build` (existing Svelte warnings only)
