### PR TITLE
Use cached ignore matchers from commonlib

### DIFF
--- a/updates.md
+++ b/updates.md
@@ -5,6 +5,10 @@ The head note of 0.25 is now in [updates_old.md](https://github.com/vrtmrz/obsid
 
 ## Unreleased
 
+### Improved
+
+- Improved vault scanning and CLI file filtering by reusing compiled ignore patterns, reducing processing overhead for vaults with many files or ignore rules (#1006, #1007, and #1008).
+
 ### Improved (CLI and Webapp)
 
 - Rooted storage adapters now reject absolute, drive-qualified, backslash-separated, and traversal paths. They also prevent file writes, appends, and removal from targeting the configured root itself.


### PR DESCRIPTION
## Summary

- Update `src/lib` from `1cb156d` to `ef1bdf0`.
- Bring in [livesync-commonlib#67](https://github.com/vrtmrz/livesync-commonlib/pull/67), which reuses compiled ignore matchers across path checks.

## Why

`isAccepted()` is called repeatedly while scanning vault paths. It previously used the top-level `minimatch()` API for every path and pattern check, recompiling the same glob patterns and creating avoidable matcher and regular-expression allocations.

This is the common-library part of [#1006](https://github.com/vrtmrz/obsidian-livesync/issues/1006). The CLI-specific cache was merged separately in [#1007](https://github.com/vrtmrz/obsidian-livesync/pull/1007).

## Behaviour and impact

Ignore results are unchanged. Compiled matchers are cached by ignore-array identity in a `WeakMap`, so replacing the ignore array creates a fresh cache, while obsolete arrays and their matchers remain eligible for collection.

For `F` paths and `P` active patterns, matcher compilation changes from up to approximately `2 × F × P` compilations to approximately `2 × P` per ignore-array instance. Matching itself is still performed for every required path and pattern.

## Microbenchmark

A local synthetic benchmark used the locked `minimatch` version with 5,000 paths, 20 non-matching patterns, five measured rounds, and explicit garbage collection between rounds:

- Previous approach: median 939 ms.
- Cached approach: median 69.4 ms.
- Hot-path speed-up: approximately 13.5 times.

This deliberately exercises a non-matching worst case. It measures the ignore-matching hot path, not overall Obsidian start-up or synchronisation time. The main benefit is lower compilation and allocation pressure; it should not be interpreted as proof of a retained-memory leak.

## Validation

- Commonlib matcher-cache and target-filter tests: 28 passed.
- Full obsidian-livesync unit suite during implementation: 1,314 tests passed.
- `npm run build`: passed.
- `npm run check`: passed.
- Real Obsidian smoke test: the built plug-in loaded with no renderer errors.
- Commonlib downstream `obsidian-livesync-unit-tests`: passed.
