### PR TITLE
Preserve U+FEFF at Rabin–Karp chunk boundaries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
                 "markdown-it": "^14.2.0",
                 "minimatch": "^10.2.5",
                 "obsidian": "^1.13.1",
-                "octagonal-wheels": "^0.1.47",
+                "octagonal-wheels": "^0.1.50",
                 "qrcode-generator": "^1.4.4",
                 "xxhash-wasm-102": "npm:xxhash-wasm@^1.0.2"
             },
@@ -11700,9 +11700,9 @@
             "license": "MIT"
         },
         "node_modules/octagonal-wheels": {
-            "version": "0.1.47",
-            "resolved": "https://registry.npmjs.org/octagonal-wheels/-/octagonal-wheels-0.1.47.tgz",
-            "integrity": "sha512-pv+AoplTzDmcrYpxun/N7sab7KAVoPvUhwvnrXwrVihjj8sQ89HmovndpMvGJxdpp4+uOOY4SiO0DVWTp+YCkQ==",
+            "version": "0.1.50",
+            "resolved": "https://registry.npmjs.org/octagonal-wheels/-/octagonal-wheels-0.1.50.tgz",
+            "integrity": "sha512-1JUU1+hFJKaF4aUchXYfFB9fCHagoYcYiYwSq0B64qwrmh+CGmMb6lSambHM21wBpyoKkO7FO3z7N+Xs5YXPug==",
             "license": "MIT",
             "dependencies": {
                 "idb": "^8.0.3"
@@ -16230,7 +16230,7 @@
             "dependencies": {
                 "chokidar": "^4.0.0",
                 "minimatch": "^10.2.5",
-                "octagonal-wheels": "^0.1.47",
+                "octagonal-wheels": "^0.1.50",
                 "pouchdb-adapter-http": "^9.0.0",
                 "pouchdb-adapter-leveldb": "^9.0.0",
                 "pouchdb-core": "^9.0.0",
@@ -16254,7 +16254,7 @@
             "name": "livesync-webapp",
             "version": "0.25.80-webapp",
             "dependencies": {
-                "octagonal-wheels": "^0.1.47"
+                "octagonal-wheels": "^0.1.50"
             },
             "devDependencies": {
                 "@playwright/test": "^1.58.2",
@@ -16269,7 +16269,7 @@
         "src/apps/webpeer": {
             "version": "0.25.80-webpeer",
             "dependencies": {
-                "octagonal-wheels": "^0.1.47"
+                "octagonal-wheels": "^0.1.50"
             },
             "devDependencies": {
                 "@sveltejs/vite-plugin-svelte": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
         "markdown-it": "^14.2.0",
         "minimatch": "^10.2.5",
         "obsidian": "^1.13.1",
-        "octagonal-wheels": "^0.1.47",
+        "octagonal-wheels": "^0.1.50",
         "qrcode-generator": "^1.4.4",
         "xxhash-wasm-102": "npm:xxhash-wasm@^1.0.2"
     },

--- a/src/apps/cli/package.json
+++ b/src/apps/cli/package.json
@@ -41,7 +41,7 @@
     "dependencies": {
         "chokidar": "^4.0.0",
         "minimatch": "^10.2.5",
-        "octagonal-wheels": "^0.1.47",
+        "octagonal-wheels": "^0.1.50",
         "pouchdb-adapter-http": "^9.0.0",
         "pouchdb-adapter-leveldb": "^9.0.0",
         "pouchdb-core": "^9.0.0",

--- a/src/apps/webapp/package.json
+++ b/src/apps/webapp/package.json
@@ -12,7 +12,7 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "octagonal-wheels": "^0.1.47"
+        "octagonal-wheels": "^0.1.50"
     },
     "devDependencies": {
         "@playwright/test": "^1.58.2",

--- a/src/apps/webpeer/package.json
+++ b/src/apps/webpeer/package.json
@@ -12,7 +12,7 @@
         "check": "svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json"
     },
     "dependencies": {
-        "octagonal-wheels": "^0.1.47"
+        "octagonal-wheels": "^0.1.50"
     },
     "devDependencies": {
         "eslint-plugin-svelte": "^3.19.0",

--- a/src/rabinKarpBom.unit.spec.ts
+++ b/src/rabinKarpBom.unit.spec.ts
@@ -1,0 +1,18 @@
+import { splitPiecesRabinKarp } from "@lib/string_and_binary/chunks.ts";
+import { describe, expect, it } from "vitest";
+
+describe("Rabin-Karp text splitting", () => {
+    it("preserves U+FEFF at the beginning of an internal chunk", async () => {
+        const content = `${"a".repeat(1024)}\uFEFF${"b".repeat(1024)}`;
+        const createChunks = await splitPiecesRabinKarp(new Blob([content], { type: "text/plain" }), 1024, true, 1024);
+        const chunks: string[] = [];
+
+        for await (const chunk of createChunks()) {
+            chunks.push(chunk);
+        }
+
+        expect(chunks).toHaveLength(3);
+        expect(chunks[1].startsWith("\uFEFF")).toBe(true);
+        expect(chunks.join("")).toBe(content);
+    });
+});

--- a/updates.md
+++ b/updates.md
@@ -5,6 +5,10 @@ The head note of 0.25 is now in [updates_old.md](https://github.com/vrtmrz/obsid
 
 ## Unreleased
 
+### Fixed
+
+- Fixed an issue where a U+FEFF character at a Rabin–Karp chunk boundary could be lost, changing the reconstructed file and causing repeated size-mismatch conflicts (#1000).
+
 ### Improved
 
 - Improved vault scanning and CLI file filtering by reusing compiled ignore patterns, reducing processing overhead for vaults with many files or ignore rules (#1006, #1007, and #1008).


### PR DESCRIPTION
## Summary

- Update `octagonal-wheels` from `0.1.47` to `0.1.50` across the plug-in, CLI, webapp, and webpeer workspaces.
- Add a regression test covering U+FEFF at the beginning of an internal Rabin–Karp text chunk.
- Record the fix in the unreleased notes.

When a Rabin–Karp boundary fell immediately before U+FEFF, the decoder in older `octagonal-wheels` versions treated that character as a byte-order signature and removed it. Rejoining the chunks then changed the file content and size, which could cause repeated conflicts. Version `0.1.50` preserves the character during decoding.

## Verification

- Confirmed the new unit test fails with `octagonal-wheels@0.1.47`.
- Confirmed the same test passes with `octagonal-wheels@0.1.50`.
- `npm run test:unit` — 69 files and 1,372 tests passed.
- `npm run build`
- `npm run check` — including the iOS 15 compatibility check.

This change is expected to address the reported behaviour in #1000.
