### PR TITLE
Make the strfry test database writable

### DIFF
--- a/test/bench-network/compose.yml
+++ b/test/bench-network/compose.yml
@@ -44,7 +44,7 @@ services:
         EOF
         exec /app/strfry --config /tmp/strfry.conf relay
     tmpfs:
-      - /app/strfry-db:rw,size=256m
+      - /app/strfry-db:rw,size=256m,mode=1777
     healthcheck:
       test: ["CMD-SHELL", "nc -z 127.0.0.1 7777"]
       interval: 2s


### PR DESCRIPTION
## Summary

- Allow the relay process to write to its existing 256 MiB tmpfs database directory.
- Avoid hard-coding the user ID used by the mutable strfry image.

## Cause

The compose P2P E2E job stopped before running its tests because strfry could not open its LMDB database and reported 'mdb_env_open: Permission denied'. The tmpfs mount used the default root-only mode, while the current image runs the relay as a different user.

## Verification

- [x] docker compose -f test/bench-network/compose.yml config --quiet
- [ ] Compose P2P E2E passes in GitHub Actions

A local container run was not available because the local Docker daemon was not running.