### PR TITLE
fix: suppress bulk conflict resolution notice spam

### DIFF
--- a/src/modules/coreFeatures/ModuleConflictResolver.ts
+++ b/src/modules/coreFeatures/ModuleConflictResolver.ts
@@ -30,7 +30,8 @@ export class ModuleConflictResolver extends AbstractModule {
     private async _resolveConflictByDeletingRev(
         path: FilePathWithPrefix,
         deleteRevision: string,
-        subTitle = ""
+        subTitle = "",
+        showNotice = true
     ): Promise<typeof MISSING_OR_ERROR | typeof AUTO_MERGED> {
         const title = `Resolving ${subTitle ? `[${subTitle}]` : ""}:`;
         if (!(await this.core.fileHandler.deleteRevisionFromDB(path, deleteRevision))) {
@@ -58,7 +59,7 @@ export class ModuleConflictResolver extends AbstractModule {
             this._log(`Could not write the resolved content to the storage: ${path}`, LOG_LEVEL_NOTICE);
             return MISSING_OR_ERROR;
         }
-        const level = subTitle.indexOf("same") !== -1 || subTitle === "NEWEST" ? LOG_LEVEL_INFO : LOG_LEVEL_NOTICE;
+        const level = subTitle.indexOf("same") !== -1 || !showNotice ? LOG_LEVEL_INFO : LOG_LEVEL_NOTICE;
         this._log(`${path} has been merged automatically`, level);
         return AUTO_MERGED;
     }
@@ -165,7 +166,7 @@ export class ModuleConflictResolver extends AbstractModule {
         });
     }
 
-    private async _anyResolveConflictByNewest(filename: FilePathWithPrefix): Promise<boolean> {
+    private async _anyResolveConflictByNewest(filename: FilePathWithPrefix, showNotice = true): Promise<boolean> {
         const currentRev = await this.core.databaseFileAccess.fetchEntryMeta(filename, undefined, true);
         if (currentRev == false) {
             this._log(`Could not get current revision of ${filename}`);
@@ -203,7 +204,7 @@ export class ModuleConflictResolver extends AbstractModule {
             this._log(
                 `conflict: Deleting the older revision ${mTimeAndRev[i][1]} (${new Date(mTimeAndRev[i][0]).toLocaleString()}) of ${filename}`
             );
-            await this.services.conflict.resolveByDeletingRevision(filename, mTimeAndRev[i][1], "NEWEST");
+            await this._resolveConflictByDeletingRev(filename, mTimeAndRev[i][1], "NEWEST", showNotice);
         }
         return true;
     }
@@ -221,7 +222,7 @@ export class ModuleConflictResolver extends AbstractModule {
                     LOG_LEVEL_NOTICE,
                     "resolveAllConflictedFilesByNewerOnes"
                 );
-            await this.services.conflict.resolveByNewest(file);
+            await this._anyResolveConflictByNewest(file, false);
         }
         this._log(`Done!`, LOG_LEVEL_NOTICE, "resolveAllConflictedFilesByNewerOnes");
     }

--- a/src/modules/coreFeatures/ModuleConflictResolver.ts
+++ b/src/modules/coreFeatures/ModuleConflictResolver.ts
@@ -58,7 +58,7 @@ export class ModuleConflictResolver extends AbstractModule {
             this._log(`Could not write the resolved content to the storage: ${path}`, LOG_LEVEL_NOTICE);
             return MISSING_OR_ERROR;
         }
-        const level = subTitle.indexOf("same") !== -1 ? LOG_LEVEL_INFO : LOG_LEVEL_NOTICE;
+        const level = subTitle.indexOf("same") !== -1 || subTitle === "NEWEST" ? LOG_LEVEL_INFO : LOG_LEVEL_NOTICE;
         this._log(`${path} has been merged automatically`, level);
         return AUTO_MERGED;
     }
@@ -214,7 +214,8 @@ export class ModuleConflictResolver extends AbstractModule {
 
         let i = 0;
         for (const file of files) {
-            if (i++ % 10)
+            i++;
+            if (i % 10 === 0)
                 this._log(
                     `Check and Processing ${i} / ${files.length}`,
                     LOG_LEVEL_NOTICE,

--- a/src/modules/coreFeatures/ModuleConflictResolver.unit.spec.ts
+++ b/src/modules/coreFeatures/ModuleConflictResolver.unit.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_SETTINGS, LOG_LEVEL_INFO, LOG_LEVEL_NOTICE, type FilePathWithPrefix } from "@lib/common/types";
+import { ModuleConflictResolver } from "./ModuleConflictResolver";
+
+function createModule(files: FilePathWithPrefix[] = []) {
+    const resolveByNewest = vi.fn(async () => true);
+    const core = {
+        _services: {
+            API: {
+                addLog: vi.fn(),
+                addCommand: vi.fn(),
+                registerWindow: vi.fn(),
+                addRibbonIcon: vi.fn(),
+                registerProtocolHandler: vi.fn(),
+            },
+            setting: {
+                saveSettingData: vi.fn(async () => undefined),
+            },
+            conflict: {
+                resolveByNewest,
+            },
+        },
+        settings: DEFAULT_SETTINGS,
+        fileHandler: {
+            deleteRevisionFromDB: vi.fn(async () => true),
+            dbToStorage: vi.fn(async () => true),
+        },
+        databaseFileAccess: {
+            getConflictedRevs: vi.fn(async () => []),
+        },
+        storageAccess: {
+            getFileNames: vi.fn(async () => files),
+        },
+    } as any;
+    Object.defineProperty(core, "services", { get: () => core._services });
+
+    const module = new ModuleConflictResolver(core);
+    module._log = vi.fn();
+    return { module, resolveByNewest };
+}
+
+describe("ModuleConflictResolver bulk newest resolution", () => {
+    it("logs each successful newest resolution without displaying a notice", async () => {
+        const { module } = createModule();
+        const path = "example.md" as FilePathWithPrefix;
+
+        await (module as any)._resolveConflictByDeletingRev(path, "2-old", "NEWEST");
+
+        expect(module._log).toHaveBeenLastCalledWith(`${path} has been merged automatically`, LOG_LEVEL_INFO);
+    });
+
+    it("updates notice-level progress once every ten checked files", async () => {
+        const files = Array.from({ length: 11 }, (_, index) => `note-${index}.md` as FilePathWithPrefix);
+        const { module, resolveByNewest } = createModule(files);
+
+        await (module as any)._resolveAllConflictedFilesByNewerOnes();
+
+        expect(resolveByNewest).toHaveBeenCalledTimes(11);
+        expect(module._log).toHaveBeenCalledWith(
+            "Check and Processing 10 / 11",
+            LOG_LEVEL_NOTICE,
+            "resolveAllConflictedFilesByNewerOnes"
+        );
+        expect(module._log).toHaveBeenCalledTimes(3);
+    });
+});

--- a/src/modules/coreFeatures/ModuleConflictResolver.unit.spec.ts
+++ b/src/modules/coreFeatures/ModuleConflictResolver.unit.spec.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
-import { DEFAULT_SETTINGS, LOG_LEVEL_INFO, LOG_LEVEL_NOTICE, type FilePathWithPrefix } from "@lib/common/types";
+import {
+    DEFAULT_SETTINGS,
+    LOG_LEVEL_INFO,
+    LOG_LEVEL_NOTICE,
+    type FilePathWithPrefix,
+    type MetaEntry,
+} from "@lib/common/types";
 import { ModuleConflictResolver } from "./ModuleConflictResolver";
 
 function createModule(files: FilePathWithPrefix[] = []) {
-    const resolveByNewest = vi.fn(async () => true);
     const core = {
         _services: {
             API: {
@@ -17,7 +22,7 @@ function createModule(files: FilePathWithPrefix[] = []) {
                 saveSettingData: vi.fn(async () => undefined),
             },
             conflict: {
-                resolveByNewest,
+                resolveByNewest: vi.fn(async () => true),
             },
         },
         settings: DEFAULT_SETTINGS,
@@ -36,26 +41,55 @@ function createModule(files: FilePathWithPrefix[] = []) {
 
     const module = new ModuleConflictResolver(core);
     module._log = vi.fn();
-    return { module, resolveByNewest };
+    return { module };
 }
 
 describe("ModuleConflictResolver bulk newest resolution", () => {
-    it("logs each successful newest resolution without displaying a notice", async () => {
+    it("retains the success notice for a non-bulk newest resolution", async () => {
         const { module } = createModule();
         const path = "example.md" as FilePathWithPrefix;
 
         await (module as any)._resolveConflictByDeletingRev(path, "2-old", "NEWEST");
+
+        expect(module._log).toHaveBeenLastCalledWith(`${path} has been merged automatically`, LOG_LEVEL_NOTICE);
+    });
+
+    it("logs a successful bulk newest resolution without displaying a notice", async () => {
+        const { module } = createModule();
+        const path = "example.md" as FilePathWithPrefix;
+        module.core.databaseFileAccess.fetchEntryMeta = vi.fn(
+            async (_path: unknown, rev?: string): Promise<MetaEntry> =>
+                ({
+                    _id: "doc-id",
+                    _rev: rev ?? "2-current",
+                    path,
+                    ctime: 1,
+                    mtime: rev ? 1 : 2,
+                    size: 0,
+                    children: [],
+                    type: "plain",
+                    eden: {},
+                }) as unknown as MetaEntry
+        );
+        module.core.databaseFileAccess.getConflictedRevs = vi
+            .fn()
+            .mockResolvedValueOnce(["1-old"])
+            .mockResolvedValue([]);
+
+        await (module as any)._anyResolveConflictByNewest(path, false);
 
         expect(module._log).toHaveBeenLastCalledWith(`${path} has been merged automatically`, LOG_LEVEL_INFO);
     });
 
     it("updates notice-level progress once every ten checked files", async () => {
         const files = Array.from({ length: 11 }, (_, index) => `note-${index}.md` as FilePathWithPrefix);
-        const { module, resolveByNewest } = createModule(files);
+        const { module } = createModule(files);
+        const resolveByNewest = vi.spyOn(module as any, "_anyResolveConflictByNewest").mockResolvedValue(true);
 
         await (module as any)._resolveAllConflictedFilesByNewerOnes();
 
         expect(resolveByNewest).toHaveBeenCalledTimes(11);
+        expect(resolveByNewest).toHaveBeenCalledWith(files[0], false);
         expect(module._log).toHaveBeenCalledWith(
             "Check and Processing 10 / 11",
             LOG_LEVEL_NOTICE,

--- a/src/modules/coreFeatures/ModuleConflictResolver.unit.spec.ts
+++ b/src/modules/coreFeatures/ModuleConflictResolver.unit.spec.ts
@@ -48,8 +48,26 @@ describe("ModuleConflictResolver bulk newest resolution", () => {
     it("retains the success notice for a non-bulk newest resolution", async () => {
         const { module } = createModule();
         const path = "example.md" as FilePathWithPrefix;
+        module.core.databaseFileAccess.fetchEntryMeta = vi.fn(
+            async (_path: unknown, rev?: string): Promise<MetaEntry> =>
+                ({
+                    _id: "doc-id",
+                    _rev: rev ?? "2-current",
+                    path,
+                    ctime: 1,
+                    mtime: rev ? 1 : 2,
+                    size: 0,
+                    children: [],
+                    type: "plain",
+                    eden: {},
+                }) as unknown as MetaEntry
+        );
+        module.core.databaseFileAccess.getConflictedRevs = vi
+            .fn()
+            .mockResolvedValueOnce(["1-old"])
+            .mockResolvedValue([]);
 
-        await (module as any)._resolveConflictByDeletingRev(path, "2-old", "NEWEST");
+        await (module as any)._anyResolveConflictByNewest(path);
 
         expect(module._log).toHaveBeenLastCalledWith(`${path} has been merged automatically`, LOG_LEVEL_NOTICE);
     });


### PR DESCRIPTION
## Summary

- suppress per-file success notices only during bulk newest-revision conflict resolution
- retain the existing success notice for non-bulk `resolveByNewest` calls
- update the keyed bulk progress notice once every ten checked files
- add focused unit coverage for bulk suppression, non-bulk notices, and progress updates

Closes #1016.

## Testing

- `npm run test:unit -- src/modules/coreFeatures/ModuleConflictResolver.unit.spec.ts` (3 passed)
- `npm run check` (passed; existing lint and Svelte warnings remain)
- `npm run build` (passed; existing Svelte warnings remain)
- GitHub Unit Tests, Integration Tests, and Snyk checks passed

The full local unit suite passed 1,382 of 1,383 tests. The unrelated `src/rabinKarpBom.unit.spec.ts` test failed consistently on this checkout; GitHub's full Unit Tests check passed.

The reproduction screenshot is intentionally not included because it contains private vault paths.