### PR TITLE
Fix stale Security Seed after remote rebuild

### DIFF
--- a/src/modules/core/ModuleReplicator.ts
+++ b/src/modules/core/ModuleReplicator.ts
@@ -49,7 +49,8 @@ async function canReplicateWithPBKDF2(
     // Showing message is false: that because be shown here. (And it is a fatal error, no way to hide it).
     // tagged as network error at beginning for error filtering with NetworkWarningStyles
     const ensureMessage = `${MARK_LOG_NETWORK_ERROR}Failed to initialise the encryption key, preventing replication.`;
-    const ensureResult = await replicator.ensurePBKDF2Salt(currentSettings, showMessage, true);
+    // A remote database rebuild replaces the Security Seed while this process may still hold the previous one.
+    const ensureResult = await replicator.ensurePBKDF2Salt(currentSettings, showMessage, false);
     if (!ensureResult) {
         errorManager.showError(ensureMessage, showMessage ? LOG_LEVEL_NOTICE : LOG_LEVEL_INFO);
         return false;

--- a/src/modules/core/ModuleReplicator.unit.spec.ts
+++ b/src/modules/core/ModuleReplicator.unit.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { ModuleReplicator } from "./ModuleReplicator";
+
+describe("ModuleReplicator", () => {
+    it("refreshes the remote Security Seed before replication", async () => {
+        const ensurePBKDF2Salt = vi.fn(async () => true);
+        let beforeReplicate: ((showMessage: boolean) => Promise<boolean>) | undefined;
+        const addHandler = vi.fn((handler: (showMessage: boolean) => Promise<boolean>, priority?: number) => {
+            if (priority === 20) {
+                beforeReplicate = handler;
+            }
+        });
+        const services = {
+            API: { isOnline: true },
+            replicator: {
+                onReplicatorInitialised: { addHandler: vi.fn() },
+                getActiveReplicator: () => ({ ensurePBKDF2Salt }),
+            },
+            setting: { currentSettings: () => ({}) },
+            databaseEvents: { onDatabaseInitialised: { addHandler: vi.fn() } },
+            appLifecycle: { onSettingLoaded: { addHandler: vi.fn() } },
+            replication: {
+                parseSynchroniseResult: { addHandler: vi.fn() },
+                onBeforeReplicate: { addHandler },
+                onReplicationFailed: { addHandler: vi.fn() },
+            },
+        };
+        const module = {
+            _unresolvedErrorManager: {
+                showError: vi.fn(),
+                clearError: vi.fn(),
+            },
+            _onReplicatorInitialised: vi.fn(),
+            _everyOnDatabaseInitialized: vi.fn(),
+            _everyOnloadAfterLoadSettings: vi.fn(),
+            _parseReplicationResult: vi.fn(),
+            _everyBeforeReplicate: vi.fn(),
+            onReplicationFailed: vi.fn(),
+        };
+
+        ModuleReplicator.prototype.onBindFunction.call(module, {} as never, services as never);
+        expect(beforeReplicate).toBeDefined();
+
+        await beforeReplicate!(false);
+
+        expect(ensurePBKDF2Salt).toHaveBeenCalledWith({}, false, false);
+    });
+});

--- a/updates.md
+++ b/updates.md
@@ -5,6 +5,10 @@ The head note of 0.25 is now in [updates_old.md](https://github.com/vrtmrz/obsid
 
 ## Unreleased
 
+### Fixed
+
+- Refresh the remote Security Seed before each replication, preventing a client that remained open during a remote database rebuild from uploading data encrypted with the previous seed (#1018).
+
 ## 0.25.81
 
 14th July, 2026


### PR DESCRIPTION
## Summary

- refresh the remote Security Seed in the existing replication preflight instead of reusing the process cache
- add a focused regression test for the preflight cache policy
- document the fix under `Unreleased`

This prevents a long-running client from uploading documents encrypted with an obsolete seed after another device recreates the remote database.

Fixes #1018

## Verification

- `npm exec --yes --package=deno -- npm run check` (passes; one existing `no-explicit-any` warning)
- `npx vitest run --config vitest.config.unit.ts src/modules/core/ModuleReplicator.unit.spec.ts` (passes)
- `npm run build` (passes with existing Svelte warnings)
- `npm run test:unit` (1,380 tests pass, including the new regression test; the existing `src/rabinKarpBom.unit.spec.ts` U+FEFF boundary test fails on current `main`-equivalent code and is unrelated to this change)

Please run CI tests.