### PR TITLE
Protect finite remote activity across app lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This plug-in may be particularly useful for researchers, engineers, and develope
 Synchronisation status is shown in the status bar with the following icons.
 
 -   Activity Indicator
-    -   📲 Network request
+    -   📲 Remote activity
 -   Status
     -   ⏹️ Stopped
     -   💤 LiveSync enabled. Waiting for changes

--- a/_types/src/LiveSyncBaseCore.d.ts
+++ b/_types/src/LiveSyncBaseCore.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { SimpleStore } from "octagonal-wheels/databases/SimpleStoreBase";
 import type { HasSettings, ObsidianLiveSyncSettings, EntryDoc } from "@lib/common/types";
 import type { Confirm } from "@lib/interfaces/Confirm";

--- a/_types/src/common/KeyValueDB.d.ts
+++ b/_types/src/common/KeyValueDB.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { KeyValueDatabase } from "@lib/interfaces/KeyValueDatabase.ts";
 export { OpenKeyValueDatabase } from "./KeyValueDBv2.ts";
 export declare const _OpenKeyValueDatabase: (dbKey: string) => Promise<KeyValueDatabase>;

--- a/_types/src/common/KeyValueDBv2.d.ts
+++ b/_types/src/common/KeyValueDBv2.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { KeyValueDatabase } from "@lib/interfaces/KeyValueDatabase";
 import { type IDBPDatabase } from "idb";
 export declare function OpenKeyValueDatabase(dbKey: string): Promise<KeyValueDatabase>;

--- a/_types/src/common/PeriodicProcessor.d.ts
+++ b/_types/src/common/PeriodicProcessor.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";
 type PeriodicProcessorHost = NecessaryServices<"API" | "control", never>;
 export declare class PeriodicProcessor {

--- a/_types/src/common/SvelteItemView.d.ts
+++ b/_types/src/common/SvelteItemView.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { ItemView } from "@/deps.ts";
 import { type mount } from "svelte";
 export declare abstract class SvelteItemView extends ItemView {

--- a/_types/src/common/events.d.ts
+++ b/_types/src/common/events.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { eventHub } from "@lib/hub/hub";
 export declare const EVENT_PLUGIN_LOADED = "plugin-loaded";
 export declare const EVENT_PLUGIN_UNLOADED = "plugin-unloaded";

--- a/_types/src/common/obsidianEvents.d.ts
+++ b/_types/src/common/obsidianEvents.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { TFile } from "@/deps";
 import type { FilePathWithPrefix, LoadedEntry } from "@lib/common/types";
 export declare const EVENT_REQUEST_SHOW_HISTORY = "show-history";

--- a/_types/src/common/reportTool.d.ts
+++ b/_types/src/common/reportTool.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ObsidianLiveSyncSettings } from "@lib/common/models/setting.type";
 import type { LiveSyncBaseCore } from "@/LiveSyncBaseCore";
 export declare function generateReport(settings: ObsidianLiveSyncSettings, core: LiveSyncBaseCore): Promise<{

--- a/_types/src/common/stores.d.ts
+++ b/_types/src/common/stores.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { PersistentMap } from "octagonal-wheels/dataobject/PersistentMap";
 export declare let sameChangePairs: PersistentMap<number[]>;
 export declare function initializeStores(vaultName: string): void;

--- a/_types/src/common/types.d.ts
+++ b/_types/src/common/types.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type PluginManifest, TFile } from "@/deps.ts";
 import { type DatabaseEntry, type EntryBody, type FilePath } from "@lib/common/types.ts";
 export type { CacheData, FileEventItem } from "@lib/common/types.ts";

--- a/_types/src/common/utils.d.ts
+++ b/_types/src/common/utils.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { TAbstractFile } from "@/deps.ts";
 import { type AnyEntry, type CouchDBCredentials, type DocumentID, type EntryHasPath, type FilePath, type FilePathWithPrefix, type UXFileInfo, type UXFileInfoStub } from "@lib/common/types.ts";
 export { ICHeader, ICXHeader } from "./types.ts";

--- a/_types/src/deps.d.ts
+++ b/_types/src/deps.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type FilePath } from "@lib/common/types.ts";
 export { addIcon, App, debounce, Editor, FuzzySuggestModal, MarkdownRenderer, MarkdownView, Modal, Notice, Platform, Plugin, PluginSettingTab, requestUrl, sanitizeHTMLToDom, Setting, stringifyYaml, TAbstractFile, TextAreaComponent, TFile, TFolder, parseYaml, ItemView, WorkspaceLeaf, Menu, request, getLanguage, ButtonComponent, TextComponent, ToggleComponent, DropdownComponent, Component, } from "obsidian";
 export type { DataWriteOptions, PluginManifest, RequestUrlParam, RequestUrlResponse, MarkdownFileInfo, ListedFiles, ValueComponent, Stat, Command, ViewCreator, } from "obsidian";

--- a/_types/src/features/ConfigSync/CmdConfigSync.d.ts
+++ b/_types/src/features/ConfigSync/CmdConfigSync.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type PluginManifest } from "@/deps.ts";
 import type { EntryDoc, LoadedEntry, FilePathWithPrefix, FilePath, AnyEntry } from "@lib/common/types.ts";
 import { LiveSyncCommands } from "@/features/LiveSyncCommands.ts";

--- a/_types/src/features/ConfigSync/PluginDialogModal.d.ts
+++ b/_types/src/features/ConfigSync/PluginDialogModal.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { mount } from "svelte";
 import { App, Modal } from "@/deps.ts";
 import ObsidianLiveSyncPlugin from "@/main.ts";

--- a/_types/src/features/HiddenFileCommon/JsonResolveModal.d.ts
+++ b/_types/src/features/HiddenFileCommon/JsonResolveModal.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { App, Modal } from "@/deps.ts";
 import { type FilePath, type LoadedEntry } from "@lib/common/types.ts";
 import { mount } from "svelte";

--- a/_types/src/features/HiddenFileSync/CmdHiddenFileSync.d.ts
+++ b/_types/src/features/HiddenFileSync/CmdHiddenFileSync.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type LoadedEntry, type FilePathWithPrefix, type FilePath, type DocumentID, type UXFileInfo, type UXStat, type MetaEntry, type UXDataWriteOptions } from "@lib/common/types.ts";
 import { type InternalFileInfo } from "@/common/types.ts";
 import { type CustomRegExp } from "@lib/common/utils.ts";

--- a/_types/src/features/HiddenFileSync/configureHiddenFileSyncMode.d.ts
+++ b/_types/src/features/HiddenFileSync/configureHiddenFileSyncMode.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 type HiddenFileSyncDirection = "pullForce" | "pushForce" | "safe";
 type ConfigureHiddenFileSyncHandlers = {
     disable: () => Promise<void>;

--- a/_types/src/features/LiveSyncCommands.d.ts
+++ b/_types/src/features/LiveSyncCommands.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type AnyEntry, type DocumentID, type FilePath, type FilePathWithPrefix, type LOG_LEVEL } from "@lib/common/types.ts";
 import type ObsidianLiveSyncPlugin from "@/main.ts";
 import type { LiveSyncCore } from "@/main.ts";

--- a/_types/src/features/LocalDatabaseMainte/CmdLocalDatabaseMainte.d.ts
+++ b/_types/src/features/LocalDatabaseMainte/CmdLocalDatabaseMainte.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type DocumentID, type EntryDoc, type EntryLeaf } from "@lib/common/types";
 import { LiveSyncCommands } from "@/features/LiveSyncCommands";
 type ChunkID = DocumentID;

--- a/_types/src/features/LocalDatabaseMainte/maintenancePrerequisites.d.ts
+++ b/_types/src/features/LocalDatabaseMainte/maintenancePrerequisites.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ObsidianLiveSyncSettings } from "@lib/common/types";
 type MaintenancePrerequisiteSettings = Pick<ObsidianLiveSyncSettings, "doNotUseFixedRevisionForChunks" | "readChunksOnline">;
 type MaintenancePrerequisiteOptions = {

--- a/_types/src/features/P2PSync/P2PReplicator/P2POpenReplicationModal.d.ts
+++ b/_types/src/features/P2PSync/P2PReplicator/P2POpenReplicationModal.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { App, Modal } from "@/deps.ts";
 import { mount } from "svelte";
 import type { LiveSyncTrysteroReplicator } from "@lib/replication/trystero/LiveSyncTrysteroReplicator";

--- a/_types/src/features/P2PSync/P2PReplicator/P2PReplicationUI.d.ts
+++ b/_types/src/features/P2PSync/P2PReplicator/P2PReplicationUI.d.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
-import { App } from "@/deps.ts";
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
+import type { App } from "@/deps.ts";
 import type { LiveSyncTrysteroReplicator } from "@lib/replication/trystero/LiveSyncTrysteroReplicator";
 /**
  * Creates an openReplicationUI factory for Obsidian environments.

--- a/_types/src/features/P2PSync/P2PReplicator/P2PReplicatorPaneView.d.ts
+++ b/_types/src/features/P2PSync/P2PReplicator/P2PReplicatorPaneView.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { Menu, WorkspaceLeaf } from "@/deps.ts";
 import { SvelteItemView } from "@/common/SvelteItemView.ts";
 import { type PeerStatus } from "@lib/replication/trystero/P2PReplicatorPaneCommon.ts";

--- a/_types/src/features/P2PSync/P2PReplicator/P2PServerStatusPaneView.d.ts
+++ b/_types/src/features/P2PSync/P2PReplicator/P2PServerStatusPaneView.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { WorkspaceLeaf } from "@/deps.ts";
 import { SvelteItemView } from "@/common/SvelteItemView.ts";
 import type { LiveSyncBaseCore } from "@/LiveSyncBaseCore.ts";

--- a/_types/src/lib/src/API/DirectFileManipulator.d.ts
+++ b/_types/src/lib/src/API/DirectFileManipulator.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export { DirectFileManipulator } from "./DirectFileManipulatorV2.ts";
 export type { DirectFileManipulatorOptions } from "./DirectFileManipulatorV2.ts";

--- a/_types/src/lib/src/API/processSetting.d.ts
+++ b/_types/src/lib/src/API/processSetting.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type ObsidianLiveSyncSettings } from "@lib/common/types";
 /**
  * Encode settings to a tiny array to encode in QRCode,

--- a/_types/src/lib/src/ContentSplitter/ContentSplitter.d.ts
+++ b/_types/src/lib/src/ContentSplitter/ContentSplitter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 /**
  * Content-Splitter for Self-hosted LiveSync.
  * Splits content into manageable chunks for efficient storage and synchronisation.

--- a/_types/src/lib/src/ContentSplitter/ContentSplitterBase.d.ts
+++ b/_types/src/lib/src/ContentSplitter/ContentSplitterBase.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type SavingEntry } from "@lib/common/types.ts";
 import { type ContentSplitterOptions, type SplitOptions } from "./ContentSplitter.ts";
 export declare abstract class ContentSplitterCore {

--- a/_types/src/lib/src/ContentSplitter/ContentSplitterRabinKarp.d.ts
+++ b/_types/src/lib/src/ContentSplitter/ContentSplitterRabinKarp.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ContentSplitterOptions, SplitOptions } from "./ContentSplitter.ts";
 import { ContentSplitterBase } from "./ContentSplitterBase.ts";
 /**

--- a/_types/src/lib/src/ContentSplitter/ContentSplitterV1.d.ts
+++ b/_types/src/lib/src/ContentSplitter/ContentSplitterV1.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ContentSplitterOptions, SplitOptions } from "./ContentSplitter";
 import { ContentSplitterBase } from "./ContentSplitterBase";
 /**

--- a/_types/src/lib/src/ContentSplitter/ContentSplitterV2.d.ts
+++ b/_types/src/lib/src/ContentSplitter/ContentSplitterV2.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ContentSplitterOptions, SplitOptions } from "./ContentSplitter.ts";
 import { ContentSplitterBase } from "./ContentSplitterBase.ts";
 /**

--- a/_types/src/lib/src/ContentSplitter/ContentSplitters.d.ts
+++ b/_types/src/lib/src/ContentSplitter/ContentSplitters.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { SavingEntry } from "@lib/common/types";
 import type { ContentSplitterOptions } from "./ContentSplitter";
 import { ContentSplitterCore, type ContentSplitterBase } from "./ContentSplitterBase";

--- a/_types/src/lib/src/UI/svelteDialog.d.ts
+++ b/_types/src/lib/src/UI/svelteDialog.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export type { HasSetResult, HasGetInitialData, ComponentHasResult, GuestDialogProps, DialogSvelteComponentBaseProps, DialogControlBase, } from "@lib/services/implements/base/SvelteDialog.ts";
 export { CONTEXT_DIALOG_CONTROLS, setupDialogContext, getDialogContext, SvelteDialogManagerBase, } from "@lib/services/implements/base/SvelteDialog.ts";

--- a/_types/src/lib/src/bureau/bureau.d.ts
+++ b/_types/src/lib/src/bureau/bureau.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type SlipBoard } from "octagonal-wheels/bureau/SlipBoard";
 declare global {
     interface Slips extends LSSlips {

--- a/_types/src/lib/src/common/ConnectionString.d.ts
+++ b/_types/src/lib/src/common/ConnectionString.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { CouchDBConnection, BucketSyncSetting, P2PConnectionInfo } from "./models/setting.type";
 export type RemoteConfigurationResult = {
     type: "couchdb";

--- a/_types/src/lib/src/common/LSError.d.ts
+++ b/_types/src/lib/src/common/LSError.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { Constructor } from "@lib/common/utils.type";
 interface ErrorWithCause extends Error {
     cause?: unknown;

--- a/_types/src/lib/src/common/configForDoc.d.ts
+++ b/_types/src/lib/src/common/configForDoc.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { Confirm } from "@lib/interfaces/Confirm";
 import { type ObsidianLiveSyncSettings } from "./types";
 declare enum ConditionType {

--- a/_types/src/lib/src/common/coreEnvFunctions.d.ts
+++ b/_types/src/lib/src/common/coreEnvFunctions.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { getLanguage as ObsidianGetLanguage } from "obsidian";
 export declare function setGetLanguage(func: typeof ObsidianGetLanguage): void;
 export declare function getLanguage(): string;

--- a/_types/src/lib/src/common/coreEnvVars.d.ts
+++ b/_types/src/lib/src/common/coreEnvVars.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 declare const manifestVersion: string;
 declare const packageVersion: string;
 export { manifestVersion, packageVersion };

--- a/_types/src/lib/src/common/i18n.d.ts
+++ b/_types/src/lib/src/common/i18n.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { AllMessageKeys, I18N_LANGS } from "./rosetta";
 import type { TaggedType } from "./types";
 export declare let currentLang: I18N_LANGS;

--- a/_types/src/lib/src/common/logger.d.ts
+++ b/_types/src/lib/src/common/logger.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export * from "octagonal-wheels/common/logger";
 export type * from "octagonal-wheels/common/logger";

--- a/_types/src/lib/src/common/messages/combinedMessages.dev.d.ts
+++ b/_types/src/lib/src/common/messages/combinedMessages.dev.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { PartialMessages as def } from "./def.ts";
 import { type MESSAGE } from "@lib/common/rosetta.ts";
 type MessageKeys = keyof typeof def.def;

--- a/_types/src/lib/src/common/messages/combinedMessages.prod.d.ts
+++ b/_types/src/lib/src/common/messages/combinedMessages.prod.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare const allMessages: {
     readonly "(Active)": {
         readonly def: "(Active)";

--- a/_types/src/lib/src/common/messages/de.d.ts
+++ b/_types/src/lib/src/common/messages/de.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare const PartialMessages: {
     readonly de: {
         "(Active)": string;

--- a/_types/src/lib/src/common/messages/def.d.ts
+++ b/_types/src/lib/src/common/messages/def.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare const PartialMessages: {
     readonly def: {
         "(Active)": string;

--- a/_types/src/lib/src/common/messages/es.d.ts
+++ b/_types/src/lib/src/common/messages/es.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare const PartialMessages: {
     readonly es: {
         "(Active)": string;

--- a/_types/src/lib/src/common/messages/fr.d.ts
+++ b/_types/src/lib/src/common/messages/fr.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare const PartialMessages: {
     readonly fr: {
         "(BETA) Always overwrite with a newer file": string;

--- a/_types/src/lib/src/common/messages/he.d.ts
+++ b/_types/src/lib/src/common/messages/he.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare const PartialMessages: {
     readonly he: {
         "(BETA) Always overwrite with a newer file": string;

--- a/_types/src/lib/src/common/messages/ja.d.ts
+++ b/_types/src/lib/src/common/messages/ja.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare const PartialMessages: {
     readonly ja: {
         "(Active)": string;

--- a/_types/src/lib/src/common/messages/ko.d.ts
+++ b/_types/src/lib/src/common/messages/ko.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare const PartialMessages: {
     readonly ko: {
         "(Active)": string;

--- a/_types/src/lib/src/common/messages/ru.d.ts
+++ b/_types/src/lib/src/common/messages/ru.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare const PartialMessages: {
     readonly ru: {
         "(Active)": string;

--- a/_types/src/lib/src/common/messages/zh-tw.d.ts
+++ b/_types/src/lib/src/common/messages/zh-tw.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare const PartialMessages: {
     readonly "zh-tw": {
         "(Active)": string;

--- a/_types/src/lib/src/common/messages/zh.d.ts
+++ b/_types/src/lib/src/common/messages/zh.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare const PartialMessages: {
     readonly zh: {
         "(Active)": string;

--- a/_types/src/lib/src/common/models/auth.type.d.ts
+++ b/_types/src/lib/src/common/models/auth.type.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export type CouchDBCredentials = BasicCredentials | JWTCredentials;
 export type JWTAlgorithm = "HS256" | "HS512" | "ES256" | "ES512" | "";
 export type Credential = {

--- a/_types/src/lib/src/common/models/db.const.d.ts
+++ b/_types/src/lib/src/common/models/db.const.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { DocumentID } from "./db.type";
 export declare const VERSIONING_DOCID: DocumentID;
 export declare const MILESTONE_DOCID: DocumentID;

--- a/_types/src/lib/src/common/models/db.definition.d.ts
+++ b/_types/src/lib/src/common/models/db.definition.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { MILESTONE_DOCID, NODEINFO_DOCID } from "./db.const";
 import type { AnyEntry, ChunkVersionRange, DatabaseEntry, EntryChunkPack, EntryLeaf, EntryTypes, EntryVersionInfo, InternalFileEntry, LoadedEntry, MetaEntry, NewEntry, NoteEntry, PlainEntry } from "./db.type";
 import type { TweakValues } from "./tweak.definition";

--- a/_types/src/lib/src/common/models/db.type.d.ts
+++ b/_types/src/lib/src/common/models/db.type.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { TaggedType } from "octagonal-wheels/common/types";
 import type { EntryTypes, SYNCINFO_ID } from "./db.const";
 export type FilePath = TaggedType<string, "FilePath">;

--- a/_types/src/lib/src/common/models/diff.definition.d.ts
+++ b/_types/src/lib/src/common/models/diff.definition.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { AUTO_MERGED, CANCELLED, MISSING_OR_ERROR, NOT_CONFLICTED } from "./shared.const.symbols";
 export type diff_result_leaf = {
     rev: string;

--- a/_types/src/lib/src/common/models/fileaccess.const.d.ts
+++ b/_types/src/lib/src/common/models/fileaccess.const.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare const CHeader = "h:";
 export declare const PSCHeader = "ps:";
 export declare const PSCHeaderEnd = "ps;";

--- a/_types/src/lib/src/common/models/fileaccess.type.d.ts
+++ b/_types/src/lib/src/common/models/fileaccess.type.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { FilePath, FilePathWithPrefix } from "./db.type";
 export type UXStat = {
     size: number;

--- a/_types/src/lib/src/common/models/redflag.const.d.ts
+++ b/_types/src/lib/src/common/models/redflag.const.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { FilePath } from "./db.type";
 export declare const PREFIXMD_LOGFILE = "livesync_log_";
 export declare const PREFIXMD_LOGFILE_UC = "LIVESYNC_LOG_";

--- a/_types/src/lib/src/common/models/setting.const.d.ts
+++ b/_types/src/lib/src/common/models/setting.const.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare const SETTING_VERSION_INITIAL = 0;
 export declare const SETTING_VERSION_SUPPORT_CASE_INSENSITIVE = 10;
 export declare const CURRENT_SETTING_VERSION = 10;

--- a/_types/src/lib/src/common/models/setting.const.defaults.d.ts
+++ b/_types/src/lib/src/common/models/setting.const.defaults.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type ObsidianLiveSyncSettings, type P2PSyncSetting } from "./setting.type";
 export declare const P2P_DEFAULT_SETTINGS: P2PSyncSetting;
 export declare const DEFAULT_SETTINGS: ObsidianLiveSyncSettings;

--- a/_types/src/lib/src/common/models/setting.const.preferred.d.ts
+++ b/_types/src/lib/src/common/models/setting.const.preferred.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ObsidianLiveSyncSettings } from "./setting.type";
 export declare const PREFERRED_BASE: Partial<ObsidianLiveSyncSettings>;
 export declare const PREFERRED_SETTING_CLOUDANT: Partial<ObsidianLiveSyncSettings>;

--- a/_types/src/lib/src/common/models/setting.const.qr.d.ts
+++ b/_types/src/lib/src/common/models/setting.const.qr.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ObsidianLiveSyncSettings } from "./setting.type";
 export declare const KeyIndexOfSettings: Record<keyof ObsidianLiveSyncSettings, number>;

--- a/_types/src/lib/src/common/models/setting.type.d.ts
+++ b/_types/src/lib/src/common/models/setting.type.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ChunkAlgorithms, E2EEAlgorithms, HashAlgorithms, MODE_AUTOMATIC, MODE_PAUSED, MODE_SELECTIVE, MODE_SHINY, RemoteTypes } from "./setting.const";
 import type { I18N_LANGS } from "@lib/common/rosetta";
 import type { CustomRegExpSourceList } from "./shared.type.util";

--- a/_types/src/lib/src/common/models/shared.const.behabiour.d.ts
+++ b/_types/src/lib/src/common/models/shared.const.behabiour.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare const MAX_DOC_SIZE = 1000;
 export declare const MAX_DOC_SIZE_BIN = 102400;
 export declare const VER = 12;

--- a/_types/src/lib/src/common/models/shared.const.d.ts
+++ b/_types/src/lib/src/common/models/shared.const.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare const SETTING_KEY_P2P_DEVICE_NAME = "p2p_device_name";
 export declare const configURIBase = "obsidian://setuplivesync?settings=";
 export declare const configURIBaseQR = "obsidian://setuplivesync?settingsQR=";

--- a/_types/src/lib/src/common/models/shared.const.symbols.d.ts
+++ b/_types/src/lib/src/common/models/shared.const.symbols.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare const CANCELLED: unique symbol;
 export declare const AUTO_MERGED: unique symbol;
 export declare const NOT_CONFLICTED: unique symbol;

--- a/_types/src/lib/src/common/models/shared.definition.configNames.d.ts
+++ b/_types/src/lib/src/common/models/shared.definition.configNames.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ObsidianLiveSyncSettings } from "./setting.type";
 export declare const LEVEL_ADVANCED = "ADVANCED";
 export declare const LEVEL_POWER_USER = "POWER_USER";

--- a/_types/src/lib/src/common/models/shared.definition.d.ts
+++ b/_types/src/lib/src/common/models/shared.definition.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare const DatabaseConnectingStatuses: {
     readonly STARTED: "STARTED";
     readonly NOT_CONNECTED: "NOT_CONNECTED";

--- a/_types/src/lib/src/common/models/shared.type.util.d.ts
+++ b/_types/src/lib/src/common/models/shared.type.util.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { TaggedType } from "octagonal-wheels/common/types";
 export type { TaggedType };
 export type CustomRegExpSource = TaggedType<string, "CustomRegExp">;

--- a/_types/src/lib/src/common/models/sync.definition.d.ts
+++ b/_types/src/lib/src/common/models/sync.definition.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { EntryTypes } from "./db.const";
 import type { DatabaseEntry, DocumentID } from "./db.type";
 export declare const ProtocolVersions: {

--- a/_types/src/lib/src/common/models/tweak.definition.d.ts
+++ b/_types/src/lib/src/common/models/tweak.definition.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ObsidianLiveSyncSettings } from "./setting.type";
 export declare const TweakValuesShouldMatchedTemplate: Partial<ObsidianLiveSyncSettings>;
 type TweakKeys = keyof TweakValues;

--- a/_types/src/lib/src/common/rosetta.d.ts
+++ b/_types/src/lib/src/common/rosetta.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 /**
 # Rosetta stone
 - To localise messages to your language, please write a translation to this file and submit a PR.

--- a/_types/src/lib/src/common/settingConstants.d.ts
+++ b/_types/src/lib/src/common/settingConstants.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type ConfigurationItem, type ObsidianLiveSyncSettings } from "./types.ts";
 type ExtractPropertiesByType<T, U> = {
     [K in keyof T as T[K] extends U ? K : never]: T[K] extends U ? K : never;

--- a/_types/src/lib/src/common/typeUtils.d.ts
+++ b/_types/src/lib/src/common/typeUtils.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { DocumentID, FilePath, FilePathWithPrefix } from "./models/db.type";
 import type { UXFileInfoStub } from "./types";
 /**

--- a/_types/src/lib/src/common/types.d.ts
+++ b/_types/src/lib/src/common/types.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export type { TaggedType } from "./models/shared.type.util.ts";
 export { LOG_LEVEL_DEBUG, LOG_LEVEL_INFO, LOG_LEVEL_NOTICE, LOG_LEVEL_URGENT, LOG_LEVEL_VERBOSE, } from "octagonal-wheels/common/logger";
 export type { LOG_LEVEL } from "octagonal-wheels/common/logger";

--- a/_types/src/lib/src/common/utils.d.ts
+++ b/_types/src/lib/src/common/utils.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type AnyEntry, type DatabaseEntry, type EntryLeaf, type SyncInfo, type LoadedEntry, type SavingEntry, type NewEntry, type PlainEntry, type CustomRegExpSource, type ParsedCustomRegExp, type CustomRegExpSourceList, type ObsidianLiveSyncSettings, type RemoteDBSettings, type P2PConnectionInfo, type BucketSyncSetting, type CouchDBConnection, type EncryptionSettings } from "./types.ts";
 import { replaceAll, replaceAllPairs } from "octagonal-wheels/string";
 export { replaceAll, replaceAllPairs };

--- a/_types/src/lib/src/common/utils.doc.d.ts
+++ b/_types/src/lib/src/common/utils.doc.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare function isErrorOf(ex: unknown, statusCode: number): boolean;
 /**
  * Checks if the error is effectively a 404 error from CouchDB or PouchDB.

--- a/_types/src/lib/src/common/utils.object.d.ts
+++ b/_types/src/lib/src/common/utils.object.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare function asCopy<T>(obj: T): T;
 export declare function ensureError(error: unknown): Error;

--- a/_types/src/lib/src/common/utils.patch.d.ts
+++ b/_types/src/lib/src/common/utils.patch.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare function generatePatchObj(from: Record<string | number | symbol, unknown>, to: Record<string | number | symbol, unknown>): Record<string | number | symbol, unknown>;
 export declare function applyPatch(from: Record<string | number | symbol, unknown>, patch: Record<string | number | symbol, unknown>): Record<string | number | symbol, unknown>;
 export declare function mergeObject(objA: Record<string | number | symbol, unknown> | [unknown], objB: Record<string | number | symbol, unknown> | [unknown]): unknown[] | {

--- a/_types/src/lib/src/common/utils.type.d.ts
+++ b/_types/src/lib/src/common/utils.type.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export type Constructor<T> = new (...args: any[]) => T; // eslint-disable-line @typescript-eslint/no-explicit-any -- Only type declaration

--- a/_types/src/lib/src/dataobject/StoredMap.d.ts
+++ b/_types/src/lib/src/dataobject/StoredMap.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { SimpleStore } from "octagonal-wheels/databases/SimpleStoreBase";
 export declare class StoredMapLike<U> {
     _store: SimpleStore<U>;

--- a/_types/src/lib/src/dev/checks.d.ts
+++ b/_types/src/lib/src/dev/checks.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 interface InstanceHaveOnBindFunction<T> {
     onBindFunction: (...params: T[]) => void;
 }

--- a/_types/src/lib/src/encryption/encryptHKDF.d.ts
+++ b/_types/src/lib/src/encryption/encryptHKDF.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { encryptHKDFWorker, decryptHKDFWorker } from "@lib/worker/bgWorker.ts";
 export declare const encryptHKDF: typeof encryptHKDFWorker;
 export declare const decryptHKDF: typeof decryptHKDFWorker;

--- a/_types/src/lib/src/encryption/stringEncryption.d.ts
+++ b/_types/src/lib/src/encryption/stringEncryption.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 /**
  * Encrypts a string using a passphrase, unless the string is already encrypted.
  *

--- a/_types/src/lib/src/events/coreEvents.d.ts
+++ b/_types/src/lib/src/events/coreEvents.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { FilePathWithPrefix, ObsidianLiveSyncSettings } from "@lib/common/types";
 export declare const EVENT_LAYOUT_READY = "layout-ready";
 export declare const EVENT_PLUGIN_LOADED = "plugin-loaded";

--- a/_types/src/lib/src/hub/hub.d.ts
+++ b/_types/src/lib/src/hub/hub.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { EventHub } from "octagonal-wheels/events";
 declare global {
     interface LSEvents {

--- a/_types/src/lib/src/index.d.ts
+++ b/_types/src/lib/src/index.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export { DirectFileManipulator, type DirectFileManipulatorOptions } from "./API/DirectFileManipulator.ts";

--- a/_types/src/lib/src/interfaces/AsyncActivityRunner.d.ts
+++ b/_types/src/lib/src/interfaces/AsyncActivityRunner.d.ts
@@ -1,0 +1,20 @@
+// @ts-nocheck
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
+/** Options attached to one bounded asynchronous activity. */
+export interface AsyncActivityOptions {
+    /** An optional diagnostic label supplied to the activity owner. */
+    label?: string;
+}
+/**
+ * Runs bounded asynchronous work inside a consumer-owned activity scope.
+ *
+ * The common library deliberately does not prescribe what the scope does. A
+ * browser host may keep the screen awake, while a headless host may omit the
+ * runner and execute the task directly.
+ */
+export interface AsyncActivityRunner {
+    /** Runs the task and returns its result without changing its error semantics. */
+    run<T>(task: () => T | PromiseLike<T>, options?: AsyncActivityOptions): Promise<T>;
+}
+/** Runs a task through the injected activity owner, or directly when none is supplied. */
+export declare function runWithOptionalActivity<T>(runner: AsyncActivityRunner | undefined, task: () => T | PromiseLike<T>, options?: AsyncActivityOptions): Promise<T>;

--- a/_types/src/lib/src/interfaces/Confirm.d.ts
+++ b/_types/src/lib/src/interfaces/Confirm.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export interface Confirm {
     askYesNo(message: string): Promise<"yes" | "no">;
     askString(title: string, key: string, placeholder: string, isPassword?: boolean): Promise<string | false>;

--- a/_types/src/lib/src/interfaces/DatabaseFileAccess.d.ts
+++ b/_types/src/lib/src/interfaces/DatabaseFileAccess.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { FilePathWithPrefix, LoadedEntry, MetaEntry, UXFileInfo, UXFileInfoStub } from "@lib/common/types";
 export interface DatabaseFileAccess {
     delete: (file: UXFileInfoStub | FilePathWithPrefix, rev?: string) => Promise<boolean>;

--- a/_types/src/lib/src/interfaces/DatabaseRebuilder.d.ts
+++ b/_types/src/lib/src/interfaces/DatabaseRebuilder.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export interface Rebuilder {
     $performRebuildDB(method: "localOnly" | "remoteOnly" | "rebuildBothByThisDevice" | "localOnlyWithChunks"): Promise<void>;
     $rebuildRemote(): Promise<void>;

--- a/_types/src/lib/src/interfaces/FileHandler.d.ts
+++ b/_types/src/lib/src/interfaces/FileHandler.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { FilePath, FilePathWithPrefix, MetaEntry } from "@lib/common/models/db.type";
 import type { UXFileInfo, UXFileInfoStub, UXInternalFileInfoStub } from "@lib/common/models/fileaccess.type";
 export interface IFileHandler {

--- a/_types/src/lib/src/interfaces/KeyValueDatabase.d.ts
+++ b/_types/src/lib/src/interfaces/KeyValueDatabase.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export interface KeyValueDatabase {
     get<T>(key: IDBValidKey): Promise<T>;
     set<T>(key: IDBValidKey, value: T): Promise<IDBValidKey>;

--- a/_types/src/lib/src/interfaces/ServiceModule.d.ts
+++ b/_types/src/lib/src/interfaces/ServiceModule.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { DatabaseFileAccess } from "@lib/interfaces/DatabaseFileAccess";
 import type { Rebuilder } from "@lib/interfaces/DatabaseRebuilder";
 import type { IFileHandler } from "@lib/interfaces/FileHandler";

--- a/_types/src/lib/src/interfaces/StorageAccess.d.ts
+++ b/_types/src/lib/src/interfaces/StorageAccess.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { FilePath, FilePathWithPrefix, UXDataWriteOptions, UXFileInfo, UXFileInfoStub, UXFolderInfo, UXStat } from "@lib/common/types";
 import type { CustomRegExp } from "@lib/common/utils";
 import type { FileWithFileStat, FileWithStatAsProp } from "@lib/common/models/fileaccess.type";

--- a/_types/src/lib/src/interfaces/StorageEventManager.d.ts
+++ b/_types/src/lib/src/interfaces/StorageEventManager.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { FileEventType, FilePath, UXFileInfoStub, UXInternalFileInfoStub } from "@lib/common/types";
 export type FileEvent = {
     type: FileEventType;

--- a/_types/src/lib/src/managers/ChangeManager.d.ts
+++ b/_types/src/lib/src/managers/ChangeManager.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { FallbackWeakRef } from "octagonal-wheels/common/polyfill";
 /**
  * Options for configuring the ChangeManager.

--- a/_types/src/lib/src/managers/ChunkFetcher.d.ts
+++ b/_types/src/lib/src/managers/ChunkFetcher.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type DocumentID } from "@lib/common/types.ts";
 import { type ChunkManager } from "./ChunkManager.ts";
 import type { IReplicatorService, ISettingService } from "@lib/services/base/IService.ts";

--- a/_types/src/lib/src/managers/ChunkManager.d.ts
+++ b/_types/src/lib/src/managers/ChunkManager.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { LayeredChunkManager } from "./LayeredChunkManager";
 export { LayeredChunkManager as ChunkManager };

--- a/_types/src/lib/src/managers/ConflictManager.d.ts
+++ b/_types/src/lib/src/managers/ConflictManager.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type Diff } from "diff-match-patch";
 import { type EntryDoc, type FilePathWithPrefix, type diff_result_leaf, type LoadedEntry, type DIFF_CHECK_RESULT_AUTO } from "@lib/common/types.ts";
 import type { EntryManager } from "@lib/managers/EntryManager/EntryManager.ts";

--- a/_types/src/lib/src/managers/EntryManager/EntryManager.d.ts
+++ b/_types/src/lib/src/managers/EntryManager/EntryManager.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type FilePathWithPrefix, type FilePath, type LoadedEntry, type EntryDoc, type SavingEntry, type MetaEntry } from "@lib/common/types";
 import type { ChunkManager } from "@lib/managers/ChunkManager";
 import type { ContentSplitter } from "@lib/ContentSplitter/ContentSplitters";

--- a/_types/src/lib/src/managers/EntryManager/EntryManagerImpls.d.ts
+++ b/_types/src/lib/src/managers/EntryManager/EntryManagerImpls.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type SavingEntry, type DocumentID, type EntryDoc, type EntryBase, type FilePath, type FilePathWithPrefix, type LoadedEntry, type ObsidianLiveSyncSettings, type MetaEntry } from "@lib/common/types";
 import type { ContentSplitter } from "@lib/ContentSplitter/ContentSplitters";
 import type { HashManager } from "@lib/managers/HashManager/HashManager";

--- a/_types/src/lib/src/managers/HashManager/HashManager.d.ts
+++ b/_types/src/lib/src/managers/HashManager/HashManager.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { HashAlgorithm } from "@lib/common/models/setting.type.ts";
 import { HashManagerCore, type HashManagerCoreOptions } from "./HashManagerCore.ts";
 /**

--- a/_types/src/lib/src/managers/HashManager/HashManagerCore.d.ts
+++ b/_types/src/lib/src/managers/HashManager/HashManagerCore.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ISettingService } from "@lib/services/base/IService.ts";
 import type { HashAlgorithm } from "@lib/common/models/setting.type.ts";
 /**

--- a/_types/src/lib/src/managers/HashManager/PureJSHashManager.d.ts
+++ b/_types/src/lib/src/managers/HashManager/PureJSHashManager.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { HashManagerCore } from "./HashManagerCore.ts";
 import type { HashAlgorithm } from "@lib/common/models/setting.type.ts";
 /**

--- a/_types/src/lib/src/managers/HashManager/XXHashHashManager.d.ts
+++ b/_types/src/lib/src/managers/HashManager/XXHashHashManager.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { HashManagerCore, type HashManagerCoreOptions } from "./HashManagerCore.ts";
 import type { XXHashAPI } from "xxhash-wasm-102";
 import type { HashAlgorithm } from "@lib/common/models/setting.type.ts";

--- a/_types/src/lib/src/managers/LayeredChunkManager.d.ts
+++ b/_types/src/lib/src/managers/LayeredChunkManager.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { DocumentID, EntryDoc, EntryLeaf } from "@lib/common/types.ts";
 import type { ChangeManager } from "@lib/managers/ChangeManager.ts";
 import type { ChunkManagerEventMap, ChunkManagerOptions, ChunkReadOptions, ChunkWriteOptions, WriteResult } from "./LayeredChunkManager/types.ts";

--- a/_types/src/lib/src/managers/LayeredChunkManager/ArrivalWaitLayer.d.ts
+++ b/_types/src/lib/src/managers/LayeredChunkManager/ArrivalWaitLayer.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { DocumentID, EntryLeaf } from "@lib/common/types";
 import type { IReadLayer } from "./ChunkLayerInterfaces";
 import type { ChunkReadOptions } from "./types.ts";

--- a/_types/src/lib/src/managers/LayeredChunkManager/CacheLayer.d.ts
+++ b/_types/src/lib/src/managers/LayeredChunkManager/CacheLayer.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { DocumentID, EntryLeaf } from "@lib/common/types";
 import type { IReadLayer, IWriteLayer } from "./ChunkLayerInterfaces";
 import type { ChunkReadOptions, ChunkWriteOptions, WriteResult } from "./types.ts";

--- a/_types/src/lib/src/managers/LayeredChunkManager/ChunkLayerInterfaces.d.ts
+++ b/_types/src/lib/src/managers/LayeredChunkManager/ChunkLayerInterfaces.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { DocumentID, EntryLeaf } from "@lib/common/types.ts";
 import type { ChunkReadOptions, ChunkWriteOptions, WriteResult } from "./types.ts";
 /**

--- a/_types/src/lib/src/managers/LayeredChunkManager/DatabaseReadLayer.d.ts
+++ b/_types/src/lib/src/managers/LayeredChunkManager/DatabaseReadLayer.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { EntryLeaf, DocumentID, EntryDoc } from "@lib/common/types";
 import type { IReadLayer } from "./ChunkLayerInterfaces";
 import type { ChunkReadOptions } from "./types.ts";

--- a/_types/src/lib/src/managers/LayeredChunkManager/DatabaseWriteLayer.d.ts
+++ b/_types/src/lib/src/managers/LayeredChunkManager/DatabaseWriteLayer.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { EntryLeaf, DocumentID, EntryDoc } from "@lib/common/types";
 import type { IWriteLayer } from "./ChunkLayerInterfaces";
 import type { ChunkWriteOptions, WriteResult } from "./types.ts";

--- a/_types/src/lib/src/managers/LayeredChunkManager/HotPackLayer.d.ts
+++ b/_types/src/lib/src/managers/LayeredChunkManager/HotPackLayer.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { EntryLeaf, DocumentID } from "@lib/common/types";
 import type { IWriteLayer } from "./ChunkLayerInterfaces";
 import type { ChunkWriteOptions, WriteResult } from "./types.ts";

--- a/_types/src/lib/src/managers/LayeredChunkManager/types.d.ts
+++ b/_types/src/lib/src/managers/LayeredChunkManager/types.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { EntryDoc } from "@lib/common/models/db.definition";
 import type { DocumentID, EntryLeaf } from "@lib/common/models/db.type";
 import type { ISettingService } from "@lib/services/base/IService";

--- a/_types/src/lib/src/managers/LiveSyncManagers.d.ts
+++ b/_types/src/lib/src/managers/LiveSyncManagers.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type EntryDoc } from "@lib/common/types";
 import { ContentSplitter } from "@lib/ContentSplitter/ContentSplitters.ts";
 import { ChangeManager } from "@lib/managers/ChangeManager.ts";

--- a/_types/src/lib/src/managers/StorageEventManager.d.ts
+++ b/_types/src/lib/src/managers/StorageEventManager.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type FileEventType, type FilePath, type UXFileInfoStub, type UXFolderInfo, type UXInternalFileInfoStub } from "@lib/common/types.ts";
 import { type FileEventItem } from "@lib/common/types.ts";
 import type { IStorageAccessManager } from "@lib/interfaces/StorageAccess.ts";

--- a/_types/src/lib/src/managers/StorageProcessingManager.d.ts
+++ b/_types/src/lib/src/managers/StorageProcessingManager.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { FilePathWithPrefix } from "@lib/common/models/db.type";
 import type { UXFileInfoStub } from "@lib/common/models/fileaccess.type";
 import type { IStorageAccessManager } from "@lib/interfaces/StorageAccess";

--- a/_types/src/lib/src/managers/adapters/IStorageEventConverterAdapter.d.ts
+++ b/_types/src/lib/src/managers/adapters/IStorageEventConverterAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { FilePath, UXFileInfoStub, UXInternalFileInfoStub } from "@lib/common/types";
 /**
  * Adapter interface for converting platform-specific file types to UX types

--- a/_types/src/lib/src/managers/adapters/IStorageEventManagerAdapter.d.ts
+++ b/_types/src/lib/src/managers/adapters/IStorageEventManagerAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { IStorageEventTypeGuardAdapter } from "./IStorageEventTypeGuardAdapter";
 import type { IStorageEventPersistenceAdapter } from "./IStorageEventPersistenceAdapter";
 import type { IStorageEventWatchAdapter } from "./IStorageEventWatchAdapter";

--- a/_types/src/lib/src/managers/adapters/IStorageEventPersistenceAdapter.d.ts
+++ b/_types/src/lib/src/managers/adapters/IStorageEventPersistenceAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { FileEventItem } from "@lib/common/types";
 import type { FileEventItemSentinel } from "@lib/managers/StorageEventManager";
 /**

--- a/_types/src/lib/src/managers/adapters/IStorageEventStatusAdapter.d.ts
+++ b/_types/src/lib/src/managers/adapters/IStorageEventStatusAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 /**
  * Adapter interface for status update operations
  */

--- a/_types/src/lib/src/managers/adapters/IStorageEventTypeGuardAdapter.d.ts
+++ b/_types/src/lib/src/managers/adapters/IStorageEventTypeGuardAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 /**
  * Adapter interface for type guard operations in StorageEventManager
  *

--- a/_types/src/lib/src/managers/adapters/IStorageEventWatchAdapter.d.ts
+++ b/_types/src/lib/src/managers/adapters/IStorageEventWatchAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { FilePath } from "@lib/common/types";
 /**
  * Event handlers for storage events

--- a/_types/src/lib/src/managers/adapters/index.d.ts
+++ b/_types/src/lib/src/managers/adapters/index.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export type { IStorageEventTypeGuardAdapter } from "./IStorageEventTypeGuardAdapter";
 export type { IStorageEventPersistenceAdapter } from "./IStorageEventPersistenceAdapter";
 export type { IStorageEventWatchAdapter, IStorageEventWatchHandlers } from "./IStorageEventWatchAdapter";

--- a/_types/src/lib/src/mock_and_interop/stores.d.ts
+++ b/_types/src/lib/src/mock_and_interop/stores.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { LOG_LEVEL } from "@lib/common/types.ts";
 export type LockStats = {
     pending: string[];

--- a/_types/src/lib/src/mock_and_interop/wrapper.d.ts
+++ b/_types/src/lib/src/mock_and_interop/wrapper.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare class WrappedNotice {
     constructor(message: string | DocumentFragment, timeout?: number);
     setMessage(message: string | DocumentFragment): this;

--- a/_types/src/lib/src/mods.d.ts
+++ b/_types/src/lib/src/mods.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare function getWebCrypto(): Promise<Crypto>;

--- a/_types/src/lib/src/pouchdb/LiveSyncDBFunctions.d.ts
+++ b/_types/src/lib/src/pouchdb/LiveSyncDBFunctions.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type EntryDoc, type EntryMilestoneInfo, type RemoteDBSettings, type ChunkVersionRange, type TweakValues, type DeviceInfo } from "@lib/common/types.ts";
 export type ENSURE_DB_RESULT = "OK" | "INCOMPATIBLE" | "LOCKED" | "NODE_LOCKED" | "NODE_CLEANED" | ["MISMATCHED", TweakValues];
 /**

--- a/_types/src/lib/src/pouchdb/LiveSyncLocalDB.d.ts
+++ b/_types/src/lib/src/pouchdb/LiveSyncLocalDB.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type EntryDoc, type EntryLeaf, type Credential, type RemoteDBSettings, type DocumentID, type FilePathWithPrefix, type FilePath, type DatabaseEntry, type LoadedEntry, type MetaEntry, type SavingEntry, type diff_result_leaf } from "@lib/common/types.ts";
 import { eventHub } from "@lib/hub/hub.ts";
 import { LiveSyncManagers } from "@lib/managers/LiveSyncManagers.ts";

--- a/_types/src/lib/src/pouchdb/ReplicatorShim.d.ts
+++ b/_types/src/lib/src/pouchdb/ReplicatorShim.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export type SomeDocument<T extends object> = PouchDB.Core.ExistingDocument<T> & PouchDB.Core.ChangesMeta;
 /**
  * Minimal subset of the PouchDB public API required by {@link replicateShim}.

--- a/_types/src/lib/src/pouchdb/StreamingFetch.d.ts
+++ b/_types/src/lib/src/pouchdb/StreamingFetch.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { EntryDoc } from "@lib/common/models/db.definition";
 import type { AnyEntry, EntryLeaf } from "@lib/common/models/db.type";
 type DBSequence = number | string;

--- a/_types/src/lib/src/pouchdb/StreamingFetch.integration.spec.d.ts
+++ b/_types/src/lib/src/pouchdb/StreamingFetch.integration.spec.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export {};

--- a/_types/src/lib/src/pouchdb/chunks.d.ts
+++ b/_types/src/lib/src/pouchdb/chunks.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { CouchDBConnection } from "@lib/common/types";
 export declare function purgeUnreferencedChunks(db: PouchDB.Database, dryRun: boolean, connSetting?: CouchDBConnection, performCompact?: boolean): Promise<number>;
 export declare function transferChunks(key: string, label: string, dbFrom: PouchDB.Database, dbTo: PouchDB.Database, items: {

--- a/_types/src/lib/src/pouchdb/compress.d.ts
+++ b/_types/src/lib/src/pouchdb/compress.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import * as fflate from "fflate";
 import type { EntryDoc } from "@lib/common/types";
 export declare function _compressText(text: string): Promise<string>;

--- a/_types/src/lib/src/pouchdb/encryption.d.ts
+++ b/_types/src/lib/src/pouchdb/encryption.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type EntryDoc, type AnyEntry, type EntryLeaf, type DocumentID, type E2EEAlgorithm } from "@lib/common/types";
 import { encryptWorker, decryptWorker, encryptHKDFWorker, decryptHKDFWorker } from "@lib/worker/bgWorker.ts";
 export declare const encrypt: typeof encryptWorker;

--- a/_types/src/lib/src/pouchdb/negotiation.d.ts
+++ b/_types/src/lib/src/pouchdb/negotiation.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare const checkRemoteVersion: (db: PouchDB.Database, migrate: (from: number, to: number) => Promise<boolean>, barrier?: number) => Promise<boolean>;
 export declare const bumpRemoteVersion: (db: PouchDB.Database, barrier?: number) => Promise<boolean>;
 export declare const checkSyncInfo: (db: PouchDB.Database) => Promise<boolean>;

--- a/_types/src/lib/src/pouchdb/pouchdb-browser.d.ts
+++ b/_types/src/lib/src/pouchdb/pouchdb-browser.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import PouchDB from "pouchdb-core";
 export { PouchDB };

--- a/_types/src/lib/src/pouchdb/pouchdb-http.d.ts
+++ b/_types/src/lib/src/pouchdb/pouchdb-http.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import PouchDB from "pouchdb-core";
 export { PouchDB };

--- a/_types/src/lib/src/pouchdb/pouchdb-test.d.ts
+++ b/_types/src/lib/src/pouchdb/pouchdb-test.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import PouchDB from "pouchdb-core";
 export { PouchDB };

--- a/_types/src/lib/src/pouchdb/utils_couchdb.d.ts
+++ b/_types/src/lib/src/pouchdb/utils_couchdb.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare const isValidRemoteCouchDBURI: (uri: string) => boolean;
 export declare function isCloudantURI(uri: string): boolean;
 export declare function isErrorOfMissingDoc(ex: unknown): boolean;

--- a/_types/src/lib/src/replication/LiveSyncAbstractReplicator.d.ts
+++ b/_types/src/lib/src/replication/LiveSyncAbstractReplicator.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type EntryDoc, type DatabaseConnectingStatus, type RemoteDBSettings, type EntryLeaf, type TweakValues, type NodeData } from "@lib/common/types.ts";
 import type { RequiredServices } from "@lib/interfaces/ServiceModule";
 export type ReplicationCallback = (e: PouchDB.Core.ExistingDocument<EntryDoc>[]) => Promise<boolean> | boolean;

--- a/_types/src/lib/src/replication/SyncParamsHandler.d.ts
+++ b/_types/src/lib/src/replication/SyncParamsHandler.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { SyncParameters } from "@lib/common/types.ts";
 import { LiveSyncError } from "@lib/common/LSError.ts";
 /**

--- a/_types/src/lib/src/replication/couchdb/LiveSyncReplicator.d.ts
+++ b/_types/src/lib/src/replication/couchdb/LiveSyncReplicator.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type EntryDoc, type RemoteDBSettings, type EntryLeaf, type TweakValues, type SyncParameters, type DatabaseEntry, type NodeData } from "@lib/common/types.ts";
 import { LiveSyncAbstractReplicator, type LiveSyncReplicatorEnv, type RemoteDBStatus } from "@lib/replication/LiveSyncAbstractReplicator.ts";
 import type { ServiceHub } from "@lib/services/ServiceHub.ts";

--- a/_types/src/lib/src/replication/httplib.d.ts
+++ b/_types/src/lib/src/replication/httplib.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { CouchDBCredentials, JWTCredentials, JWTHeader, JWTParams, JWTPayload, PreparedJWT, RemoteDBSettings } from "@lib/common/types";
 import { Computed } from "octagonal-wheels/dataobject/Computed";
 /**

--- a/_types/src/lib/src/replication/journal/JournalSyncCore.d.ts
+++ b/_types/src/lib/src/replication/journal/JournalSyncCore.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type EntryDoc, type SyncParameters, type BucketSyncSetting, type RemoteDBSettings } from "@lib/common/types.ts";
 import type { ReplicationCallback, ReplicationStat } from "@lib/replication/LiveSyncAbstractReplicator.ts";
 import { type SimpleStore } from "@lib/common/utils.ts";

--- a/_types/src/lib/src/replication/journal/JournalSyncTypes.d.ts
+++ b/_types/src/lib/src/replication/journal/JournalSyncTypes.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export type CheckPointInfo = {
     lastLocalSeq: number | string;
     journalEpoch: string;

--- a/_types/src/lib/src/replication/journal/LiveSyncJournalReplicator.d.ts
+++ b/_types/src/lib/src/replication/journal/LiveSyncJournalReplicator.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type RemoteDBSettings, type EntryLeaf, type ChunkVersionRange, type TweakValues, type NodeData } from "@lib/common/types.ts";
 import { JournalSyncCore } from "./JournalSyncCore.ts";
 import { LiveSyncAbstractReplicator, type RemoteDBStatus } from "@lib/replication/LiveSyncAbstractReplicator.ts";

--- a/_types/src/lib/src/replication/journal/LiveSyncJournalReplicatorEnv.d.ts
+++ b/_types/src/lib/src/replication/journal/LiveSyncJournalReplicatorEnv.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { LiveSyncReplicatorEnv } from "@lib/replication/LiveSyncAbstractReplicator";
 export interface LiveSyncJournalReplicatorEnv extends LiveSyncReplicatorEnv { // eslint-disable-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface -- Empty interface
 }

--- a/_types/src/lib/src/replication/journal/objectstore/JournalStorageAdapter.d.ts
+++ b/_types/src/lib/src/replication/journal/objectstore/JournalStorageAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { RemoteDBStatus } from "@lib/replication/LiveSyncAbstractReplicator.ts";
 import type { BucketSyncSetting } from "@lib/common/types.ts";
 export interface IJournalStorage {

--- a/_types/src/lib/src/replication/journal/objectstore/MinioStorageAdapter.d.ts
+++ b/_types/src/lib/src/replication/journal/objectstore/MinioStorageAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { S3 } from "@aws-sdk/client-s3";
 import { type BucketSyncSetting } from "@lib/common/types.ts";
 import type { RemoteDBStatus } from "@lib/replication/LiveSyncAbstractReplicator.ts";

--- a/_types/src/lib/src/replication/journal/objectstore/MinioStorageAdapter.integration.spec.d.ts
+++ b/_types/src/lib/src/replication/journal/objectstore/MinioStorageAdapter.integration.spec.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export {};

--- a/_types/src/lib/src/replication/trystero/LiveSyncTrysteroReplicator.d.ts
+++ b/_types/src/lib/src/replication/trystero/LiveSyncTrysteroReplicator.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type RemoteDBSettings, type EntryLeaf, type TweakValues, type LOG_LEVEL, type NodeData } from "@lib/common/types";
 import { LiveSyncAbstractReplicator, type LiveSyncReplicatorEnv, type RemoteDBStatus } from "@lib/replication/LiveSyncAbstractReplicator";
 import { TrysteroReplicator } from "./TrysteroReplicator";

--- a/_types/src/lib/src/replication/trystero/P2PLogCollector.d.ts
+++ b/_types/src/lib/src/replication/trystero/P2PLogCollector.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { P2PReplicationProgress } from "./TrysteroReplicator";
 export declare class P2PLogCollector {
     constructor();

--- a/_types/src/lib/src/replication/trystero/P2PReplicatorBase.d.ts
+++ b/_types/src/lib/src/replication/trystero/P2PReplicatorBase.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { LOG_LEVEL } from "octagonal-wheels/common/logger";
 import type { SimpleStore } from "octagonal-wheels/databases/SimpleStoreBase";
 import type { ReactiveSource } from "octagonal-wheels/dataobject/reactive_v2";

--- a/_types/src/lib/src/replication/trystero/P2PReplicatorCore.d.ts
+++ b/_types/src/lib/src/replication/trystero/P2PReplicatorCore.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";
 import type { P2PPaneParams } from "./UseP2PReplicatorResult";
 export type P2PViewFactory = (leaf: unknown) => unknown;

--- a/_types/src/lib/src/replication/trystero/P2PReplicatorPaneCommon.d.ts
+++ b/_types/src/lib/src/replication/trystero/P2PReplicatorPaneCommon.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { InjectableServiceHub } from "@lib/services/InjectableServices.ts";
 export declare const EVENT_P2P_PEER_SHOW_EXTRA_MENU = "p2p-peer-show-extra-menu";
 export declare enum AcceptedStatus {

--- a/_types/src/lib/src/replication/trystero/ProxiedDB.d.ts
+++ b/_types/src/lib/src/replication/trystero/ProxiedDB.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type ReplicatorHostEnv } from "./types";
 import type { EntryDoc } from "@lib/common/models/db.definition";
 export declare function createHostingDB(env: ReplicatorHostEnv): {

--- a/_types/src/lib/src/replication/trystero/TrysteroReplicator.d.ts
+++ b/_types/src/lib/src/replication/trystero/TrysteroReplicator.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type EntryDoc, type ObsidianLiveSyncSettings } from "@lib/common/types";
 import { type ProgressInfo } from "@lib/pouchdb/ReplicatorShim";
 import type { Confirm } from "@lib/interfaces/Confirm";
@@ -64,6 +64,7 @@ export declare class TrysteroReplicator {
     get deviceName(): string;
     get platform(): string;
     get confirm(): Confirm;
+    private runBoundedRemoteActivity;
     constructor(env: ReplicatorHostEnv, server?: P2PHost);
     close(): Promise<void>;
     open(): Promise<void>;

--- a/_types/src/lib/src/replication/trystero/TrysteroReplicatorP2PClient.d.ts
+++ b/_types/src/lib/src/replication/trystero/TrysteroReplicatorP2PClient.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { PouchDBShim, SomeDocument } from "@lib/pouchdb/ReplicatorShim";
 import type { TrysteroReplicatorP2PServer } from "./TrysteroReplicatorP2PServer";
 import { type BindableObject, type NonPrivateMethodKeys, type Response } from "./types";

--- a/_types/src/lib/src/replication/trystero/TrysteroReplicatorP2PConnection.d.ts
+++ b/_types/src/lib/src/replication/trystero/TrysteroReplicatorP2PConnection.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { TrysteroReplicatorP2PServer } from "./TrysteroReplicatorP2PServer";
 export { TrysteroReplicatorP2PServer as TrysteroConnection };

--- a/_types/src/lib/src/replication/trystero/TrysteroReplicatorP2PServer.d.ts
+++ b/_types/src/lib/src/replication/trystero/TrysteroReplicatorP2PServer.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type ActionSender, type Room } from "@trystero-p2p/nostr";
 import { type P2PSyncSetting } from "@lib/common/types";
 import { type ReplicatorHostEnv, type FullFilledDeviceInfo, type Request, type Response, type Payload, type Advertisement, type BindableObject, type BindableFunction } from "./types";

--- a/_types/src/lib/src/replication/trystero/UseP2PReplicatorResult.d.ts
+++ b/_types/src/lib/src/replication/trystero/UseP2PReplicatorResult.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ReactiveSource } from "octagonal-wheels/dataobject/reactive_v2";
 import type { LiveSyncTrysteroReplicator } from "./LiveSyncTrysteroReplicator";
 import type { P2PLogCollector } from "./P2PLogCollector";

--- a/_types/src/lib/src/replication/trystero/addP2PEventHandlers.d.ts
+++ b/_types/src/lib/src/replication/trystero/addP2PEventHandlers.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { LiveSyncTrysteroReplicator } from "./LiveSyncTrysteroReplicator";
 import type { Advertisement } from "./types";
 /**

--- a/_types/src/lib/src/replication/trystero/rpcCompat.d.ts
+++ b/_types/src/lib/src/replication/trystero/rpcCompat.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare function toRpcMethodName(method: string): string;

--- a/_types/src/lib/src/replication/trystero/types.d.ts
+++ b/_types/src/lib/src/replication/trystero/types.d.ts
@@ -1,9 +1,10 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { JsonLike } from "@lib/rpc";
 import type { P2PSyncSetting, EntryDoc } from "@lib/common/types";
 import type { SimpleStore } from "@lib/common/utils";
 import type { Confirm } from "@lib/interfaces/Confirm";
+import type { AsyncActivityRunner } from "@lib/interfaces/AsyncActivityRunner";
 export declare const DIRECTION_REQUEST = "request";
 export type DIRECTION_REQUEST = typeof DIRECTION_REQUEST;
 export declare const DIRECTION_RESPONSE = "response";
@@ -79,6 +80,7 @@ export interface ReplicatorHostEnv extends ReplicatorHost {
     settings: P2PSyncSetting;
     db: PouchDB.Database<EntryDoc>;
     simpleStore: SimpleStore<unknown>;
+    runBoundedRemoteActivity?: AsyncActivityRunner["run"];
     processReplicatedDocs(docs: Array<PouchDB.Core.ExistingDocument<EntryDoc>>): void | Promise<void>;
 }
 export type Advertisement = {

--- a/_types/src/lib/src/replication/trystero/useP2PReplicatorCommands.d.ts
+++ b/_types/src/lib/src/replication/trystero/useP2PReplicatorCommands.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";
 import type { UseP2PReplicatorResult } from "./UseP2PReplicatorResult";
 /**

--- a/_types/src/lib/src/replication/trystero/useP2PReplicatorFeature.d.ts
+++ b/_types/src/lib/src/replication/trystero/useP2PReplicatorFeature.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";
 import { LiveSyncTrysteroReplicator } from "./LiveSyncTrysteroReplicator";
 import { type UseP2PReplicatorResult } from "./UseP2PReplicatorResult";

--- a/_types/src/lib/src/rpc/RpcRoom.d.ts
+++ b/_types/src/lib/src/rpc/RpcRoom.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { RpcSession } from "./RpcSession";
 import { type JsonLike, type RpcMethodHandler, type RpcRegisterOptions, type RpcRoomOptions } from "./types";
 export declare class RpcRoom {

--- a/_types/src/lib/src/rpc/RpcSession.d.ts
+++ b/_types/src/lib/src/rpc/RpcSession.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { JsonLike } from "./types";
 import type { RpcRoom } from "./RpcRoom";
 export declare class RpcSession {

--- a/_types/src/lib/src/rpc/chunking.d.ts
+++ b/_types/src/lib/src/rpc/chunking.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare function estimateBytes(text: string): number;
 export declare function splitIntoChunks(payload: string, maxBytes: number): string[];
 export declare class IncomingChunkBuffer {

--- a/_types/src/lib/src/rpc/errors.d.ts
+++ b/_types/src/lib/src/rpc/errors.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { JsonLike, RpcErrorCode, RpcErrorShape } from "./types";
 export declare class RpcError extends Error {
     code: RpcErrorCode;

--- a/_types/src/lib/src/rpc/index.d.ts
+++ b/_types/src/lib/src/rpc/index.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export { RpcRoom } from "./RpcRoom";
 export { RpcSession } from "./RpcSession";
 export { RpcError } from "./errors";

--- a/_types/src/lib/src/rpc/pouchdb/RpcPouchDBProxy.d.ts
+++ b/_types/src/lib/src/rpc/pouchdb/RpcPouchDBProxy.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { RpcSession } from "@lib/rpc/RpcSession";
 /**
  * A PouchDB-compatible proxy that forwards all database operations to a remote

--- a/_types/src/lib/src/rpc/pouchdb/RpcPouchDBServer.d.ts
+++ b/_types/src/lib/src/rpc/pouchdb/RpcPouchDBServer.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { RpcRoom } from "@lib/rpc/RpcRoom";
 /**
  * Exposes a PouchDB database as a set of RPC methods registered on an

--- a/_types/src/lib/src/rpc/transports/DiagRTCPeerConnections.d.ts
+++ b/_types/src/lib/src/rpc/transports/DiagRTCPeerConnections.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { DiagRTCStats, DiagRTCFailureDiagnosis } from "./DiagRTCPeerConnections.types";
 /**
  * Subscribes to connection status updates. The callback will be called with the latest connection statistics whenever there is a change in the connection status of any RTCPeerConnection instance.

--- a/_types/src/lib/src/rpc/transports/DiagRTCPeerConnections.types.d.ts
+++ b/_types/src/lib/src/rpc/transports/DiagRTCPeerConnections.types.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export type DiagRTCConnectionStatus = {
     connectionState: RTCPeerConnection["connectionState"];
     iceConnectionState: RTCPeerConnection["iceConnectionState"];

--- a/_types/src/lib/src/rpc/transports/DiagRTCPeerConnections.utils.d.ts
+++ b/_types/src/lib/src/rpc/transports/DiagRTCPeerConnections.utils.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type DiagRTCPeerConnectionInternalStateHistory, type DiagRTCFailureDiagnosis, type DiagRTCPeerConnectionMetrics, type DiagRTCFailureStats } from "./DiagRTCPeerConnections.types";
 /**
  * Diagnoses the failure reason of a failed RTCPeerConnection based on its internal state history and selected candidate pair information.

--- a/_types/src/lib/src/rpc/transports/TrysteroTransport.d.ts
+++ b/_types/src/lib/src/rpc/transports/TrysteroTransport.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type Room } from "@trystero-p2p/nostr";
 import { RpcRoom } from "@lib/rpc/RpcRoom";
 import { RpcPouchDBProxy } from "@lib/rpc/pouchdb/RpcPouchDBProxy";

--- a/_types/src/lib/src/rpc/transports/trysteroUtils.d.ts
+++ b/_types/src/lib/src/rpc/transports/trysteroUtils.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { BaseRoomConfig } from "@trystero-p2p/nostr";
 import type { P2PConnectionInfo } from "@lib/common/models/setting.type";
 export declare function generateJoinRoomOptions(settings: P2PConnectionInfo): BaseRoomConfig;

--- a/_types/src/lib/src/rpc/types.d.ts
+++ b/_types/src/lib/src/rpc/types.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare const RPC_VERSION_MAJOR = 1;
 export declare const RPC_VERSION_MINOR = 0;
 export type JsonLike = null | boolean | number | string | JsonLike[] | {

--- a/_types/src/lib/src/serviceFeatures/checkRemoteSize.d.ts
+++ b/_types/src/lib/src/serviceFeatures/checkRemoteSize.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { createInstanceLogFunction, type LogFunction } from "@lib/services/lib/logUtils";
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";
 /**

--- a/_types/src/lib/src/serviceFeatures/offlineScanner.d.ts
+++ b/_types/src/lib/src/serviceFeatures/offlineScanner.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type FilePathWithPrefix, type FilePathWithPrefixLC, type MetaEntry, type UXFileInfoStub, type ObsidianLiveSyncSettings, type LOG_LEVEL } from "@lib/common/types";
 import { type LogFunction } from "@lib/services/lib/logUtils";
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";

--- a/_types/src/lib/src/serviceFeatures/prepareDatabaseForUse.d.ts
+++ b/_types/src/lib/src/serviceFeatures/prepareDatabaseForUse.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";
 import { UnresolvedErrorManager } from "@lib/services/base/UnresolvedErrorManager";
 import { type LogFunction } from "@lib/services/lib/logUtils";

--- a/_types/src/lib/src/serviceFeatures/remoteConfig.d.ts
+++ b/_types/src/lib/src/serviceFeatures/remoteConfig.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type LOG_LEVEL } from "@lib/common/logger";
 import type { ObsidianLiveSyncSettings } from "@lib/common/models/setting.type";
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";

--- a/_types/src/lib/src/serviceFeatures/setupObsidian/qrCode.d.ts
+++ b/_types/src/lib/src/serviceFeatures/setupObsidian/qrCode.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";
 import type { SetupFeatureHost } from "./types";
 export declare function encodeSetupSettingsAsQR(host: SetupFeatureHost): Promise<string>;

--- a/_types/src/lib/src/serviceFeatures/setupObsidian/setupUri.d.ts
+++ b/_types/src/lib/src/serviceFeatures/setupObsidian/setupUri.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { LogFunction } from "@lib/services/lib/logUtils";
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";
 import type { SetupFeatureHost } from "./types";

--- a/_types/src/lib/src/serviceFeatures/setupObsidian/types.d.ts
+++ b/_types/src/lib/src/serviceFeatures/setupObsidian/types.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";
 export type SetupFeatureHost = NecessaryServices<"API" | "UI" | "setting", never>;

--- a/_types/src/lib/src/serviceFeatures/targetFilter.d.ts
+++ b/_types/src/lib/src/serviceFeatures/targetFilter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type UXFileInfoStub } from "@lib/common/types";
 import { type LogFunction } from "@lib/services/lib/logUtils";
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";

--- a/_types/src/lib/src/serviceModules/FileAccessBase.d.ts
+++ b/_types/src/lib/src/serviceModules/FileAccessBase.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { FilePath, UXDataWriteOptions, UXFileInfoStub, UXFolderInfo } from "@lib/common/types.ts";
 import type { IStorageAccessManager } from "@lib/interfaces/StorageAccess.ts";
 import type { IAPIService, IPathService, ISettingService, IVaultService } from "@lib/services/base/IService.ts";

--- a/_types/src/lib/src/serviceModules/Rebuilder.d.ts
+++ b/_types/src/lib/src/serviceModules/Rebuilder.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { IFileHandler } from "@lib/interfaces/FileHandler";
 import type { APIService } from "@lib/services/base/APIService";
 import type { AppLifecycleService } from "@lib/services/base/AppLifecycleService";
@@ -52,8 +52,10 @@ export declare class ServiceRebuilder extends ServiceModuleBase<ServiceRebuilder
         enableOverwrite?: boolean;
     }): Promise<void>;
     rebuildRemote(): Promise<void>;
+    private performRemoteRebuild;
     $rebuildRemote(): Promise<void>;
     rebuildEverything(): Promise<void>;
+    private performRebuildEverything;
     $rebuildEverything(): Promise<void>;
     $fetchLocal(makeLocalChunkBeforeSync?: boolean, preventMakeLocalFilesBeforeSync?: boolean): Promise<void>;
     $fetchLocalDBFast(autoResume: boolean): Promise<void>;
@@ -65,7 +67,9 @@ export declare class ServiceRebuilder extends ServiceModuleBase<ServiceRebuilder
     suspendReflectingDatabase(ignoreMinIO?: boolean): Promise<void>;
     resumeReflectingDatabase(ignoreMinIO?: boolean): Promise<void>;
     fetchLocal(makeLocalChunkBeforeSync?: boolean, preventMakeLocalFilesBeforeSync?: boolean, autoResume?: boolean): Promise<void>;
+    private performFetchLocal;
     fetchLocalDBFast(autoResume: boolean): Promise<void>;
+    private performFetchLocalDBFast;
     /**
      * Finish rebuild process with resuming the reflection.
      *

--- a/_types/src/lib/src/serviceModules/ServiceDatabaseFileAccessBase.d.ts
+++ b/_types/src/lib/src/serviceModules/ServiceDatabaseFileAccessBase.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { UXFileInfoStub, FilePathWithPrefix, UXFileInfo, MetaEntry, LoadedEntry, FilePath } from "@lib/common/types";
 import type { DatabaseFileAccess } from "@lib/interfaces/DatabaseFileAccess";
 import type { StorageAccess } from "@lib/interfaces/StorageAccess";

--- a/_types/src/lib/src/serviceModules/ServiceFileAccessBase.d.ts
+++ b/_types/src/lib/src/serviceModules/ServiceFileAccessBase.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { FilePath, FilePathWithPrefix, UXDataWriteOptions, UXFileInfo, UXFileInfoStub, UXFolderInfo, UXStat } from "@lib/common/types";
 import { ServiceModuleBase } from "@lib/serviceModules/ServiceModuleBase";
 import type { APIService } from "@lib/services/base/APIService";

--- a/_types/src/lib/src/serviceModules/ServiceFileHandlerBase.d.ts
+++ b/_types/src/lib/src/serviceModules/ServiceFileHandlerBase.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { AnyEntry, FilePath, FilePathWithPrefix, MetaEntry, UXFileInfo, UXFileInfoStub, UXInternalFileInfoStub } from "@lib/common/types";
 import type { IFileHandler } from "@lib/interfaces/FileHandler.ts";
 import { ServiceModuleBase } from "@lib/serviceModules/ServiceModuleBase";

--- a/_types/src/lib/src/serviceModules/ServiceModuleBase.d.ts
+++ b/_types/src/lib/src/serviceModules/ServiceModuleBase.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { APIService } from "@lib/services/base/APIService";
 import { createInstanceLogFunction } from "@lib/services/lib/logUtils";
 export interface ServiceModuleBaseDependencies {

--- a/_types/src/lib/src/serviceModules/adapters/IConversionAdapter.d.ts
+++ b/_types/src/lib/src/serviceModules/adapters/IConversionAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { UXFileInfoStub, UXFolderInfo } from "@lib/common/types.ts";
 /**
  * Conversion adapter interface

--- a/_types/src/lib/src/serviceModules/adapters/IFileSystemAdapter.d.ts
+++ b/_types/src/lib/src/serviceModules/adapters/IFileSystemAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { FilePath, UXStat } from "@lib/common/types.ts";
 import type { IPathAdapter } from "./IPathAdapter.ts";
 import type { ITypeGuardAdapter } from "./ITypeGuardAdapter.ts";

--- a/_types/src/lib/src/serviceModules/adapters/IPathAdapter.d.ts
+++ b/_types/src/lib/src/serviceModules/adapters/IPathAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { FilePath } from "@lib/common/types.ts";
 /**
  * Path operations adapter interface

--- a/_types/src/lib/src/serviceModules/adapters/IStorageAdapter.d.ts
+++ b/_types/src/lib/src/serviceModules/adapters/IStorageAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 /**
  * Focused compatibility views of the existing storage adapter.
  *

--- a/_types/src/lib/src/serviceModules/adapters/ITypeGuardAdapter.d.ts
+++ b/_types/src/lib/src/serviceModules/adapters/ITypeGuardAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 /**
  * Type guard adapter interface
  * Provides runtime type checking for native file system objects

--- a/_types/src/lib/src/serviceModules/adapters/IVaultAdapter.d.ts
+++ b/_types/src/lib/src/serviceModules/adapters/IVaultAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { UXDataWriteOptions } from "@lib/common/types.ts";
 /**
  * Vault adapter interface

--- a/_types/src/lib/src/serviceModules/adapters/index.d.ts
+++ b/_types/src/lib/src/serviceModules/adapters/index.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export type { IPathAdapter } from "./IPathAdapter.ts";
 export type { ITypeGuardAdapter } from "./ITypeGuardAdapter.ts";
 export type { IConversionAdapter } from "./IConversionAdapter.ts";

--- a/_types/src/lib/src/services/BrowserServices.d.ts
+++ b/_types/src/lib/src/services/BrowserServices.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { InjectableVaultServiceCompat } from "@lib/services/implements/injectable/InjectableVaultService";
 import { ServiceContext } from "@lib/services/base/ServiceBase";
 import { InjectableServiceHub } from "@lib/services/implements/injectable/InjectableServiceHub";

--- a/_types/src/lib/src/services/HeadlessServices.d.ts
+++ b/_types/src/lib/src/services/HeadlessServices.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { ServiceContext } from "@lib/services/base/ServiceBase";
 import { InjectableServiceHub } from "@lib/services/implements/injectable/InjectableServiceHub";
 import type { DatabaseService } from "@lib/services/base/DatabaseService.ts";

--- a/_types/src/lib/src/services/InjectableServices.d.ts
+++ b/_types/src/lib/src/services/InjectableServices.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export { InjectableServiceHub } from "@lib/services/implements/injectable/InjectableServiceHub.ts";

--- a/_types/src/lib/src/services/ServiceHub.d.ts
+++ b/_types/src/lib/src/services/ServiceHub.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { UIService } from "./implements/base/UIService.ts";
 import type { ConfigService } from "@lib/services/base/ConfigService.ts";
 import type { TestService } from "@lib/services/base/TestService.ts";

--- a/_types/src/lib/src/services/base/APIService.d.ts
+++ b/_types/src/lib/src/services/base/APIService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { FetchHttpHandler } from "@smithy/fetch-http-handler";
 import type { LOG_LEVEL } from "@lib/common/logger";
 import type { IAPIService, ICommandCompat } from "./IService";

--- a/_types/src/lib/src/services/base/AppLifecycleService.d.ts
+++ b/_types/src/lib/src/services/base/AppLifecycleService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { IAppLifecycleService, ISettingService } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";
 export interface AppLifecycleServiceDependencies {

--- a/_types/src/lib/src/services/base/ConfigService.d.ts
+++ b/_types/src/lib/src/services/base/ConfigService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { IConfigService } from "@lib/services/base/IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";
 export declare abstract class ConfigService<T extends ServiceContext = ServiceContext> extends ServiceBase<T> implements IConfigService {

--- a/_types/src/lib/src/services/base/ConflictService.d.ts
+++ b/_types/src/lib/src/services/base/ConflictService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { FilePathWithPrefix, MISSING_OR_ERROR, AUTO_MERGED } from "@lib/common/types";
 import type { IConflictService } from "@lib/services/base/IService";
 import { ServiceBase } from "@lib/services/base/ServiceBase";

--- a/_types/src/lib/src/services/base/ControlService.d.ts
+++ b/_types/src/lib/src/services/base/ControlService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { createInstanceLogFunction } from "@lib/services/lib/logUtils";
 import type { APIService } from "./APIService";
 import type { DatabaseService } from "./DatabaseService";

--- a/_types/src/lib/src/services/base/DatabaseEventService.d.ts
+++ b/_types/src/lib/src/services/base/DatabaseEventService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { IDatabaseEventService } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";
 /**

--- a/_types/src/lib/src/services/base/DatabaseService.d.ts
+++ b/_types/src/lib/src/services/base/DatabaseService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { IDatabaseService, IPathService, IVaultService, openDatabaseParameters } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";
 import { LiveSyncLocalDB } from "@lib/pouchdb/LiveSyncLocalDB";

--- a/_types/src/lib/src/services/base/FileProcessingService.d.ts
+++ b/_types/src/lib/src/services/base/FileProcessingService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { IFileProcessingService } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";
 /**

--- a/_types/src/lib/src/services/base/IService.d.ts
+++ b/_types/src/lib/src/services/base/IService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { FetchHttpHandler } from "@smithy/fetch-http-handler";
 import { type LOG_LEVEL } from "octagonal-wheels/common/logger";
 import type { AnyEntry, AUTO_MERGED, CouchDBCredentials, diff_result, DocumentID, EntryDoc, EntryHasPath, FileEventItem, FilePath, FilePathWithPrefix, LoadedEntry, MetaEntry, MISSING_OR_ERROR, ObsidianLiveSyncSettings, RemoteDBSettings, TweakValues, UXFileInfo, UXFileInfoStub } from "@lib/common/types";
@@ -12,6 +12,7 @@ import type { ReplicationStatics } from "@lib/common/models/shared.definition";
 import type { ReplicatorService } from "./ReplicatorService";
 import type { DatabaseEventService } from "./DatabaseEventService";
 import type { BASE_IS_NEW, EVEN, TARGET_IS_NEW } from "@lib/common/models/shared.const.symbols";
+import type { AsyncActivityOptions } from "@lib/interfaces/AsyncActivityRunner.ts";
 declare global {
     interface OPTIONAL_SYNC_FEATURES {
         DISABLE: "DISABLE";
@@ -103,6 +104,10 @@ export interface IReplicatorService {
     getNewReplicator(settingOverride?: Partial<ObsidianLiveSyncSettings>): Promise<LiveSyncAbstractReplicator | undefined | false>;
     getActiveReplicator(): LiveSyncAbstractReplicator | undefined;
     replicationStatics: ReactiveSource<ReplicationStatics>;
+    /** Number of finite remote operations currently in progress. */
+    boundedRemoteActivityCount: ReactiveSource<number>;
+    /** Runs a finite remote operation within the host activity policy. */
+    runBoundedRemoteActivity<T>(task: () => T | PromiseLike<T>, options?: AsyncActivityOptions): Promise<T>;
 }
 export interface IReplicationService {
     processSynchroniseResult(doc: MetaEntry): Promise<boolean>;

--- a/_types/src/lib/src/services/base/KeyValueDBService.d.ts
+++ b/_types/src/lib/src/services/base/KeyValueDBService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { SimpleStore } from "@lib/common/utils";
 import type { IKeyValueDBService, IVaultService } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";

--- a/_types/src/lib/src/services/base/PathService.d.ts
+++ b/_types/src/lib/src/services/base/PathService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { DocumentID, EntryHasPath, FilePathWithPrefix, FilePath, AnyEntry, UXFileInfo, UXFileInfoStub } from "@lib/common/types";
 import type { IPathService, ISettingService } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";

--- a/_types/src/lib/src/services/base/RemoteService.d.ts
+++ b/_types/src/lib/src/services/base/RemoteService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { CouchDBCredentials, EntryDoc } from "@lib/common/types";
 import type { IRemoteService } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";

--- a/_types/src/lib/src/services/base/ReplicationService.d.ts
+++ b/_types/src/lib/src/services/base/ReplicationService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type LOG_LEVEL } from "@lib/common/types";
 import type { IAPIService, IDatabaseService, IFileProcessingService, IReplicationService, IReplicatorService, ISettingService } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";
@@ -60,9 +60,10 @@ export declare abstract class ReplicationService<T extends ServiceContext = Serv
      */
     isReplicationReady(showMessage?: boolean): Promise<boolean>;
     onReplicationFailed: import("@lib/services/lib/HandlerUtils").BooleanMultipleHandlerFunction<(showMessage?: boolean) => Promise<boolean>>;
+    private performReplicationRequest;
     /**
-     * perform replication. The actual replication logic should be implemented in the handler of this event.
-     * @param showMessage
+     * Perform replication and handle a failed result.
+     * @param showMessage Whether to show replication progress messages.
      */
     performReplication(showMessage?: boolean): Promise<boolean | void>;
     /**

--- a/_types/src/lib/src/services/base/ReplicatorService.d.ts
+++ b/_types/src/lib/src/services/base/ReplicatorService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { LiveSyncAbstractReplicator } from "@lib/replication/LiveSyncAbstractReplicator";
 import type { IReplicatorService } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";
@@ -7,16 +7,19 @@ import type { SettingService } from "./SettingService";
 import type { AppLifecycleService } from "./AppLifecycleService";
 import { UnresolvedErrorManager } from "./UnresolvedErrorManager";
 import type { DatabaseEventService } from "./DatabaseEventService";
+import { type AsyncActivityOptions, type AsyncActivityRunner } from "@lib/interfaces/AsyncActivityRunner.ts";
 export interface ReplicatorServiceDependencies {
     settingService: SettingService;
     appLifecycleService: AppLifecycleService;
     databaseEventService: DatabaseEventService;
+    activityRunner?: AsyncActivityRunner;
 }
 /**
  * The ReplicatorService provides methods for managing replication.
  */
 export declare abstract class ReplicatorService<T extends ServiceContext = ServiceContext> extends ServiceBase<T> implements IReplicatorService {
     protected dependencies: ReplicatorServiceDependencies;
+    readonly boundedRemoteActivityCount: import("octagonal-wheels/dataobject/reactive_v2").ReactiveSource<number>;
     _log: (msg: unknown, level?: import("octagonal-wheels/common/logger").LOG_LEVEL, key?: string) => void;
     private settingService;
     private databaseEventService;
@@ -25,6 +28,11 @@ export declare abstract class ReplicatorService<T extends ServiceContext = Servi
     private appLifecycleService;
     _unresolvedErrorManager: UnresolvedErrorManager;
     constructor(context: T, dependencies: ReplicatorServiceDependencies);
+    /**
+     * Runs one finite remote operation while exposing its lifetime to host policy and status UI.
+     * Continuous replication must not use this boundary.
+     */
+    runBoundedRemoteActivity<TValue>(task: () => TValue | PromiseLike<TValue>, options?: AsyncActivityOptions): Promise<TValue>;
     private suspendReplication;
     private reinitialiseReplicator;
     private disposeReplicator;

--- a/_types/src/lib/src/services/base/ServiceBase.d.ts
+++ b/_types/src/lib/src/services/base/ServiceBase.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare class ServiceContext {
 }
 export declare abstract class ServiceBase<T extends ServiceContext> {

--- a/_types/src/lib/src/services/base/SettingService.d.ts
+++ b/_types/src/lib/src/services/base/SettingService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type ObsidianLiveSyncSettings } from "@lib/common/types";
 import type { IAPIService, ISettingService } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";

--- a/_types/src/lib/src/services/base/TestService.d.ts
+++ b/_types/src/lib/src/services/base/TestService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ITestService } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";
 /**

--- a/_types/src/lib/src/services/base/TweakValueService.d.ts
+++ b/_types/src/lib/src/services/base/TweakValueService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { RemoteDBSettings, TweakValues } from "@lib/common/types";
 import type { ITweakValueService } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";

--- a/_types/src/lib/src/services/base/UnresolvedErrorManager.d.ts
+++ b/_types/src/lib/src/services/base/UnresolvedErrorManager.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type LOG_LEVEL } from "octagonal-wheels/common/logger";
 import type { AppLifecycleService } from "./AppLifecycleService";
 export declare class UnresolvedErrorManager {

--- a/_types/src/lib/src/services/base/VaultService.d.ts
+++ b/_types/src/lib/src/services/base/VaultService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { FilePath } from "@lib/common/types";
 import type { IAPIService, ISettingService, IVaultService } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";

--- a/_types/src/lib/src/services/implements/base/UIService.d.ts
+++ b/_types/src/lib/src/services/implements/base/UIService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { Confirm } from "@lib/interfaces/Confirm";
 import type { ComponentHasResult, SvelteDialogManagerBase } from "@lib/UI/svelteDialog";
 import type { IAPIService, IUIService } from "@lib/services/base/IService";

--- a/_types/src/lib/src/services/implements/browser/BrowserAPIService.d.ts
+++ b/_types/src/lib/src/services/implements/browser/BrowserAPIService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 import { InjectableAPIService } from "@lib/services/implements/injectable/InjectableAPIService";
 import type { FetchHttpHandler } from "@smithy/fetch-http-handler";

--- a/_types/src/lib/src/services/implements/browser/BrowserConfirm.d.ts
+++ b/_types/src/lib/src/services/implements/browser/BrowserConfirm.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { Confirm } from "@lib/interfaces/Confirm";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 export declare class BrowserConfirm<T extends ServiceContext> implements Confirm {

--- a/_types/src/lib/src/services/implements/browser/BrowserDatabaseService.d.ts
+++ b/_types/src/lib/src/services/implements/browser/BrowserDatabaseService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 import { KeyValueDBService } from "@lib/services/base/KeyValueDBService";
 import { DatabaseService } from "@lib/services/base/DatabaseService.ts";

--- a/_types/src/lib/src/services/implements/browser/BrowserUIService.d.ts
+++ b/_types/src/lib/src/services/implements/browser/BrowserUIService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { UIService } from "@lib/services/implements/base/UIService";
 import type { ConfigService } from "@lib/services/base/ConfigService";
 import type { AppLifecycleService } from "@lib/services/base/AppLifecycleService";

--- a/_types/src/lib/src/services/implements/browser/ConfigServiceBrowserCompat.d.ts
+++ b/_types/src/lib/src/services/implements/browser/ConfigServiceBrowserCompat.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { ConfigService } from "@lib/services/base/ConfigService";
 import type { IAPIService, ISettingService } from "@lib/services/base/IService";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";

--- a/_types/src/lib/src/services/implements/browser/Menu.d.ts
+++ b/_types/src/lib/src/services/implements/browser/Menu.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type PromiseWithResolvers } from "octagonal-wheels/promises";
 export declare class MenuItem {
     type: string;

--- a/_types/src/lib/src/services/implements/browser/ui/renderMessageMarkdown.d.ts
+++ b/_types/src/lib/src/services/implements/browser/ui/renderMessageMarkdown.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare function renderMessageMarkdown(message: string): string;

--- a/_types/src/lib/src/services/implements/headless/HeadlessAPIService.d.ts
+++ b/_types/src/lib/src/services/implements/headless/HeadlessAPIService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 import { InjectableAPIService } from "@lib/services/implements/injectable/InjectableAPIService";
 import type { FetchHttpHandler } from "@smithy/fetch-http-handler";

--- a/_types/src/lib/src/services/implements/headless/HeadlessDatabaseService.d.ts
+++ b/_types/src/lib/src/services/implements/headless/HeadlessDatabaseService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { KeyValueDBService } from "@lib/services/base/KeyValueDBService";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 import { DatabaseService } from "@lib/services/base/DatabaseService.ts";

--- a/_types/src/lib/src/services/implements/injectable/InjectableAPIService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableAPIService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { APIService } from "@lib/services/base/APIService";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 export declare abstract class InjectableAPIService<T extends ServiceContext> extends APIService<T> {

--- a/_types/src/lib/src/services/implements/injectable/InjectableAppLifecycleService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableAppLifecycleService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { AppLifecycleService } from "@lib/services/base/AppLifecycleService";
 import type { IAppLifecycleService } from "@lib/services/base/IService";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";

--- a/_types/src/lib/src/services/implements/injectable/InjectableConflictService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableConflictService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { ConflictService } from "@lib/services/base/ConflictService";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 export declare class InjectableConflictService<T extends ServiceContext> extends ConflictService<T> {

--- a/_types/src/lib/src/services/implements/injectable/InjectableDatabaseEventService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableDatabaseEventService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { DatabaseEventService } from "@lib/services/base/DatabaseEventService";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 export declare class InjectableDatabaseEventService<T extends ServiceContext> extends DatabaseEventService<T> {

--- a/_types/src/lib/src/services/implements/injectable/InjectableFileProcessingService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableFileProcessingService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { FileProcessingService } from "@lib/services/base/FileProcessingService";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 export declare class InjectableFileProcessingService<T extends ServiceContext> extends FileProcessingService<T> {

--- a/_types/src/lib/src/services/implements/injectable/InjectablePathService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectablePathService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { UXFileInfo, AnyEntry, UXFileInfoStub, FilePathWithPrefix } from "@lib/common/types";
 import { PathService } from "@lib/services/base/PathService";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";

--- a/_types/src/lib/src/services/implements/injectable/InjectableRemoteService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableRemoteService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { RemoteService } from "@lib/services/base/RemoteService";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 export declare class InjectableRemoteService<T extends ServiceContext> extends RemoteService<T> {

--- a/_types/src/lib/src/services/implements/injectable/InjectableReplicationService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableReplicationService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { ReplicationService } from "@lib/services/base/ReplicationService";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 export declare class InjectableReplicationService<T extends ServiceContext> extends ReplicationService<T> {

--- a/_types/src/lib/src/services/implements/injectable/InjectableReplicatorService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableReplicatorService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { ReplicatorService } from "@lib/services/base/ReplicatorService";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 export declare class InjectableReplicatorService<T extends ServiceContext> extends ReplicatorService<T> {

--- a/_types/src/lib/src/services/implements/injectable/InjectableServiceHub.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableServiceHub.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ConfigService } from "@lib/services/base/ConfigService";
 import { ControlService } from "@lib/services/base/ControlService";
 import type { KeyValueDBService } from "@lib/services/base/KeyValueDBService";

--- a/_types/src/lib/src/services/implements/injectable/InjectableServices.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableServices.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type ServiceInstances } from "@lib/services/ServiceHub.ts";
 import type { UIService } from "@lib/services/implements/base/UIService.ts";
 import type { ConfigService } from "@lib/services/base/ConfigService.ts";

--- a/_types/src/lib/src/services/implements/injectable/InjectableSettingService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableSettingService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 import { SettingService, type SettingServiceDependencies } from "@lib/services/base/SettingService";
 import type { ObsidianLiveSyncSettings } from "@lib/common/types";

--- a/_types/src/lib/src/services/implements/injectable/InjectableTestService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableTestService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 import { TestService } from "@lib/services/base/TestService";
 export declare class InjectableTestService<T extends ServiceContext> extends TestService<T> {

--- a/_types/src/lib/src/services/implements/injectable/InjectableTweakValueService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableTweakValueService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 import { TweakValueService } from "@lib/services/base/TweakValueService";
 export declare class InjectableTweakValueService<T extends ServiceContext> extends TweakValueService<T> {

--- a/_types/src/lib/src/services/implements/injectable/InjectableVaultService.d.ts
+++ b/_types/src/lib/src/services/implements/injectable/InjectableVaultService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ServiceContext } from "@lib/services/base/ServiceBase";
 import { VaultService } from "@lib/services/base/VaultService";
 export declare abstract class InjectableVaultService<T extends ServiceContext> extends VaultService<T> {

--- a/_types/src/lib/src/services/implements/obsidian/ObsidianServiceContext.d.ts
+++ b/_types/src/lib/src/services/implements/obsidian/ObsidianServiceContext.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { ServiceContext } from "@lib/services/base/ServiceBase";
 import type ObsidianLiveSyncPlugin from "@/main";
 import type { App, Plugin } from "@/deps";

--- a/_types/src/lib/src/services/lib/HandlerUtils.d.ts
+++ b/_types/src/lib/src/services/lib/HandlerUtils.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 /**
  * A function type that can be used as a handler.
  */

--- a/_types/src/lib/src/services/lib/logUtils.d.ts
+++ b/_types/src/lib/src/services/lib/logUtils.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type LOG_LEVEL } from "octagonal-wheels/common/logger";
 import type { IAPIService } from "@lib/services/base/IService";
 export declare const MARK_LOG_SEPARATOR = "\u200A";

--- a/_types/src/lib/src/string_and_binary/chunks.d.ts
+++ b/_types/src/lib/src/string_and_binary/chunks.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare function splitPiecesTextV2(dataSrc: string | string[], pieceSize: number, minimumChunkSize: number): () => Generator<string>;
 export declare function binaryTextSplit(data: string, pieceSize: number, minimumChunkSize: number): () => Generator<string>;
 export declare function splitPiecesText(dataSrc: string | string[], pieceSize: number, plainSplit: boolean, minimumChunkSize: number, useSegmenter: boolean): () => Generator<string>;

--- a/_types/src/lib/src/string_and_binary/convert.d.ts
+++ b/_types/src/lib/src/string_and_binary/convert.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { arrayBufferToBase64, base64ToArrayBuffer, base64ToArrayBufferInternalBrowser, readString, writeString, tryConvertBase64ToArrayBuffer } from "octagonal-wheels/binary";
 export { arrayBufferToBase64, base64ToArrayBuffer, base64ToArrayBufferInternalBrowser, readString, writeString, tryConvertBase64ToArrayBuffer, };
 export declare function arrayBufferToBase64Single(buffer: Uint8Array | ArrayBuffer): Promise<string>;

--- a/_types/src/lib/src/string_and_binary/hash.d.ts
+++ b/_types/src/lib/src/string_and_binary/hash.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export * from "octagonal-wheels/hash/xxhash.js";
 export type * from "octagonal-wheels/hash/xxhash.js";

--- a/_types/src/lib/src/string_and_binary/path.d.ts
+++ b/_types/src/lib/src/string_and_binary/path.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type AnyEntry, type DocumentID, type EntryHasPath, type FilePath, type FilePathWithPrefix } from "@lib/common/types.ts";
 export declare function isValidFilenameInWidows(filename: string): boolean;
 export declare function isValidFilenameInDarwin(filename: string): boolean;

--- a/_types/src/lib/src/system/wakelock.d.ts
+++ b/_types/src/lib/src/system/wakelock.d.ts
@@ -1,8 +1,0 @@
-// @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
-/**
- * Run callback with screen wake lock held.
- * @param callback Callback to run with wake lock held
- * @returns Result of callback
- */
-export declare function withWakeLock<T>(callback: () => Promise<T>): Promise<T>;

--- a/_types/src/lib/src/worker/bg.common.d.ts
+++ b/_types/src/lib/src/worker/bg.common.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { END_OF_DATA } from "./universalTypes.ts";
 export declare function postBack(key: number, seq: number, data: string | END_OF_DATA): void;

--- a/_types/src/lib/src/worker/bg.worker.d.ts
+++ b/_types/src/lib/src/worker/bg.worker.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export {};

--- a/_types/src/lib/src/worker/bg.worker.encryption.d.ts
+++ b/_types/src/lib/src/worker/bg.worker.encryption.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { EncryptHKDFArguments } from "./universalTypes.ts";
 import type { EncryptArguments } from "./universalTypes.ts";
 /**

--- a/_types/src/lib/src/worker/bg.worker.splitting.d.ts
+++ b/_types/src/lib/src/worker/bg.worker.splitting.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { SplitArguments } from "./universalTypes.ts";
 /**
  * Processes the splitting of data into chunks.

--- a/_types/src/lib/src/worker/bgWorker.d.ts
+++ b/_types/src/lib/src/worker/bgWorker.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { EncryptArguments, EncryptHKDFArguments, EncryptHKDFProcessItem, EncryptProcessItem, ProcessItem, SplitArguments, SplitProcessItem } from "./universalTypes.ts";
 export type WorkerInstance = {
     worker: Worker;

--- a/_types/src/lib/src/worker/bgWorker.encryption.d.ts
+++ b/_types/src/lib/src/worker/bgWorker.encryption.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type EncryptHKDFProcessItem, type ResultPayload } from "./universalTypes.ts";
 import { type EncryptProcessItem } from "./universalTypes.ts";
 import { type EncryptHKDFArguments } from "./universalTypes.ts";

--- a/_types/src/lib/src/worker/bgWorker.mock.d.ts
+++ b/_types/src/lib/src/worker/bgWorker.mock.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { EncryptHKDFProcessItem, EncryptProcessItem, SplitProcessItem, ProcessItem } from "./universalTypes.ts";
 export type SplitArguments = {
     key: number;

--- a/_types/src/lib/src/worker/bgWorker.splitting.d.ts
+++ b/_types/src/lib/src/worker/bgWorker.splitting.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type ResultPayloadWithSeq, type SplitProcessItem } from "./universalTypes";
 /**
  * Splits data into pieces using a worker.

--- a/_types/src/lib/src/worker/universalTypes.d.ts
+++ b/_types/src/lib/src/worker/universalTypes.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { PromiseWithResolvers } from "octagonal-wheels/promises";
 export type EncryptArguments = {
     key: number;

--- a/_types/src/main.d.ts
+++ b/_types/src/main.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { Plugin, type App, type PluginManifest } from "./deps";
 import { LiveSyncCommands } from "./features/LiveSyncCommands.ts";
 import type { ObsidianServiceContext } from "@lib/services/implements/obsidian/ObsidianServiceContext.ts";

--- a/_types/src/managers/ObsidianStorageEventManagerAdapter.d.ts
+++ b/_types/src/managers/ObsidianStorageEventManagerAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { TFile, TFolder } from "@/deps";
 import type { FilePath, UXFileInfoStub, UXInternalFileInfoStub } from "@lib/common/types";
 import type { FileEventItem } from "@lib/common/types";

--- a/_types/src/managers/StorageEventManagerObsidian.d.ts
+++ b/_types/src/managers/StorageEventManagerObsidian.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { FilePath } from "@lib/common/types";
 import type ObsidianLiveSyncPlugin from "@/main";
 import type { LiveSyncCore } from "@/main";

--- a/_types/src/modules/AbstractModule.d.ts
+++ b/_types/src/modules/AbstractModule.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { AnyEntry, FilePathWithPrefix } from "@lib/common/types";
 import type { IMinimumLiveSyncCommands, LiveSyncBaseCore } from "@/LiveSyncBaseCore";
 import type { ServiceContext } from "@lib/services/base/ServiceBase";

--- a/_types/src/modules/AbstractObsidianModule.d.ts
+++ b/_types/src/modules/AbstractObsidianModule.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { LiveSyncCore } from "@/main";
 import type ObsidianLiveSyncPlugin from "@/main";
 import { AbstractModule } from "./AbstractModule.ts";

--- a/_types/src/modules/core/ModulePeriodicProcess.d.ts
+++ b/_types/src/modules/core/ModulePeriodicProcess.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { PeriodicProcessor } from "@/common/PeriodicProcessor";
 import type { LiveSyncCore } from "@/main";
 import { AbstractModule } from "@/modules/AbstractModule";

--- a/_types/src/modules/core/ModuleReplicator.d.ts
+++ b/_types/src/modules/core/ModuleReplicator.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { AbstractModule } from "@/modules/AbstractModule";
 import { type EntryDoc, type RemoteType } from "@lib/common/types";
 import type { LiveSyncCore } from "@/main";

--- a/_types/src/modules/core/ModuleReplicatorCouchDB.d.ts
+++ b/_types/src/modules/core/ModuleReplicatorCouchDB.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type RemoteDBSettings } from "@lib/common/types";
 import type { LiveSyncAbstractReplicator } from "@lib/replication/LiveSyncAbstractReplicator";
 import { AbstractModule } from "@/modules/AbstractModule";

--- a/_types/src/modules/core/ModuleReplicatorMinIO.d.ts
+++ b/_types/src/modules/core/ModuleReplicatorMinIO.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type RemoteDBSettings } from "@lib/common/types";
 import type { LiveSyncAbstractReplicator } from "@lib/replication/LiveSyncAbstractReplicator";
 import type { LiveSyncCore } from "@/main";

--- a/_types/src/modules/core/ReplicateResultProcessor.d.ts
+++ b/_types/src/modules/core/ReplicateResultProcessor.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type AnyEntry, type EntryDoc, type LoadedEntry, type MetaEntry } from "@lib/common/types";
 import type { ModuleReplicator } from "./ModuleReplicator";
 import type { ReactiveSource } from "octagonal-wheels/dataobject/reactive_v2";

--- a/_types/src/modules/coreFeatures/ModuleConflictChecker.d.ts
+++ b/_types/src/modules/coreFeatures/ModuleConflictChecker.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { AbstractModule } from "@/modules/AbstractModule.ts";
 import { type FilePathWithPrefix } from "@lib/common/types";
 import { QueueProcessor } from "octagonal-wheels/concurrency/processor";

--- a/_types/src/modules/coreFeatures/ModuleConflictResolver.d.ts
+++ b/_types/src/modules/coreFeatures/ModuleConflictResolver.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { AbstractModule } from "@/modules/AbstractModule.ts";
 import { type diff_check_result, type FilePathWithPrefix } from "@lib/common/types";
 import type { InjectableServiceHub } from "@lib/services/InjectableServices.ts";

--- a/_types/src/modules/coreFeatures/ModuleResolveMismatchedTweaks.d.ts
+++ b/_types/src/modules/coreFeatures/ModuleResolveMismatchedTweaks.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type TweakValues, type ObsidianLiveSyncSettings, type RemoteDBSettings } from "@lib/common/types.ts";
 import { AbstractModule } from "@/modules/AbstractModule.ts";
 import type { InjectableServiceHub } from "@lib/services/InjectableServices.ts";

--- a/_types/src/modules/coreObsidian/UILib/dialogs.d.ts
+++ b/_types/src/modules/coreObsidian/UILib/dialogs.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { ButtonComponent } from "@/deps.ts";
 import { App, FuzzySuggestModal, Modal, Plugin, Component } from "@/deps.ts";
 import { type CompatIntervalHandle } from "@lib/common/coreEnvFunctions.ts";

--- a/_types/src/modules/coreObsidian/storageLib/utilObsidian.d.ts
+++ b/_types/src/modules/coreObsidian/storageLib/utilObsidian.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { TFile, type TAbstractFile, type TFolder } from "@/deps.ts";
 import type { FilePathWithPrefix, UXFileInfo, UXFileInfoStub, UXFolderInfo, UXInternalFileInfoStub } from "@lib/common/types.ts";
 import type { LiveSyncCore } from "@/main.ts";

--- a/_types/src/modules/essential/ModuleBasicMenu.d.ts
+++ b/_types/src/modules/essential/ModuleBasicMenu.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { LiveSyncCore } from "@/main";
 import { AbstractModule } from "@/modules/AbstractModule";
 export declare class ModuleBasicMenu extends AbstractModule {

--- a/_types/src/modules/essential/ModuleMigration.d.ts
+++ b/_types/src/modules/essential/ModuleMigration.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { AbstractModule } from "@/modules/AbstractModule.ts";
 import type { LiveSyncCore } from "@/main.ts";
 export declare class ModuleMigration extends AbstractModule {

--- a/_types/src/modules/essentialObsidian/APILib/ObsHttpHandler.d.ts
+++ b/_types/src/modules/essentialObsidian/APILib/ObsHttpHandler.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { FetchHttpHandler, type FetchHttpHandlerOptions } from "@smithy/fetch-http-handler";
 import { HttpRequest, HttpResponse, type HttpHandlerOptions } from "@smithy/protocol-http";
 /**

--- a/_types/src/modules/essentialObsidian/ModuleObsidianEvents.d.ts
+++ b/_types/src/modules/essentialObsidian/ModuleObsidianEvents.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { AbstractObsidianModule } from "@/modules/AbstractObsidianModule.ts";
 import type { TFile } from "@/deps.ts";
 import { type ReactiveSource } from "octagonal-wheels/dataobject/reactive";
@@ -12,6 +12,11 @@ export declare class ModuleObsidianEvents extends AbstractObsidianModule {
     registerWatchEvents(): void;
     hasFocus: boolean;
     isLastHidden: boolean;
+    private boundedRemoteActivityEndHandler?;
+    private deferredBoundedLifecycle?;
+    private keepReplicationActiveInBackground;
+    private applyDeferredBoundedActivityLifecycle;
+    private deferLifecycleUntilBoundedRemoteActivityEnds;
     setHasFocus(hasFocus: boolean): void;
     watchWindowVisibility(): void;
     watchOnline(): void;

--- a/_types/src/modules/essentialObsidian/ModuleObsidianMenu.d.ts
+++ b/_types/src/modules/essentialObsidian/ModuleObsidianMenu.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { LiveSyncCore } from "@/main.ts";
 import { AbstractModule } from "@/modules/AbstractModule.ts";
 export declare class ModuleObsidianMenu extends AbstractModule {

--- a/_types/src/modules/features/DocumentHistory/DocumentHistoryModal.d.ts
+++ b/_types/src/modules/features/DocumentHistory/DocumentHistoryModal.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { TFile, Modal, App } from "@/deps.ts";
 import ObsidianLiveSyncPlugin from "@/main.ts";
 import { type DocumentID, type FilePathWithPrefix, type LoadedEntry } from "@lib/common/types.ts";

--- a/_types/src/modules/features/GlobalHistory/GlobalHistoryView.d.ts
+++ b/_types/src/modules/features/GlobalHistory/GlobalHistoryView.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { WorkspaceLeaf } from "@/deps.ts";
 import type ObsidianLiveSyncPlugin from "@/main.ts";
 import { SvelteItemView } from "@/common/SvelteItemView.ts";

--- a/_types/src/modules/features/InteractiveConflictResolving/ConflictResolveModal.d.ts
+++ b/_types/src/modules/features/InteractiveConflictResolving/ConflictResolveModal.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { App, Modal } from "@/deps.ts";
 import { CANCELLED, LEAVE_TO_SUBSEQUENT, type diff_result } from "@lib/common/types.ts";
 import { eventHub } from "@/common/events.ts";

--- a/_types/src/modules/features/Log/LogPaneView.d.ts
+++ b/_types/src/modules/features/Log/LogPaneView.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { WorkspaceLeaf } from "@/deps.ts";
 import type ObsidianLiveSyncPlugin from "@/main.ts";
 import { SvelteItemView } from "@/common/SvelteItemView.ts";

--- a/_types/src/modules/features/ModuleGlobalHistory.d.ts
+++ b/_types/src/modules/features/ModuleGlobalHistory.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { AbstractObsidianModule } from "@/modules/AbstractObsidianModule.ts";
 export declare class ModuleObsidianGlobalHistory extends AbstractObsidianModule {
     _everyOnloadStart(): Promise<boolean>;

--- a/_types/src/modules/features/ModuleInteractiveConflictResolver.d.ts
+++ b/_types/src/modules/features/ModuleInteractiveConflictResolver.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type FilePathWithPrefix, type diff_result } from "@lib/common/types.ts";
 import { AbstractObsidianModule } from "@/modules/AbstractObsidianModule.ts";
 import type { LiveSyncCore } from "@/main.ts";

--- a/_types/src/modules/features/ModuleLog.d.ts
+++ b/_types/src/modules/features/ModuleLog.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type ReactiveValue } from "octagonal-wheels/dataobject/reactive";
 import { type LOG_LEVEL } from "@lib/common/types.ts";
 import { AbstractObsidianModule } from "@/modules/AbstractObsidianModule.ts";

--- a/_types/src/modules/features/ModuleObsidianDocumentHistory.d.ts
+++ b/_types/src/modules/features/ModuleObsidianDocumentHistory.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type TFile } from "@/deps.ts";
 import type { FilePathWithPrefix, DocumentID } from "@lib/common/types.ts";
 import { AbstractObsidianModule } from "@/modules/AbstractObsidianModule.ts";

--- a/_types/src/modules/features/ModuleObsidianSettingAsMarkdown.d.ts
+++ b/_types/src/modules/features/ModuleObsidianSettingAsMarkdown.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type ObsidianLiveSyncSettings } from "@lib/common/types";
 import { AbstractModule } from "@/modules/AbstractModule.ts";
 import type { ServiceContext } from "@lib/services/base/ServiceBase.ts";

--- a/_types/src/modules/features/ModuleObsidianSettingTab.d.ts
+++ b/_types/src/modules/features/ModuleObsidianSettingTab.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { ObsidianLiveSyncSettingTab } from "./SettingDialogue/ObsidianLiveSyncSettingTab.ts";
 import { AbstractObsidianModule } from "@/modules/AbstractObsidianModule.ts";
 import type { LiveSyncCore } from "@/main.ts";

--- a/_types/src/modules/features/RemoteActivityStatus.d.ts
+++ b/_types/src/modules/features/RemoteActivityStatus.d.ts
@@ -1,0 +1,4 @@
+// @ts-nocheck
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
+/** Returns whether the status UI should report HTTP traffic or a finite remote operation in progress. */
+export declare function hasRemoteActivity(requestCount: number, responseCount: number, boundedRemoteActivityCount: number): boolean;

--- a/_types/src/modules/features/SettingDialogue/LiveSyncSetting.d.ts
+++ b/_types/src/modules/features/SettingDialogue/LiveSyncSetting.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { Setting, TextComponent, type ToggleComponent, type DropdownComponent, ButtonComponent, type TextAreaComponent, type ValueComponent } from "@/deps.ts";
 import { type ConfigurationItem } from "@lib/common/types.ts";
 import { type ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";

--- a/_types/src/modules/features/SettingDialogue/ObsidianLiveSyncSettingTab.d.ts
+++ b/_types/src/modules/features/SettingDialogue/ObsidianLiveSyncSettingTab.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { App, Component, PluginSettingTab } from "@/deps.ts";
 import { type ObsidianLiveSyncSettings } from "@lib/common/types.ts";
 import ObsidianLiveSyncPlugin from "@/main.ts";

--- a/_types/src/modules/features/SettingDialogue/PaneAdvanced.d.ts
+++ b/_types/src/modules/features/SettingDialogue/PaneAdvanced.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";
 import type { PageFunctions } from "./SettingPane.ts";
 export declare function paneAdvanced(this: ObsidianLiveSyncSettingTab, paneEl: HTMLElement, { addPanel }: PageFunctions): void;

--- a/_types/src/modules/features/SettingDialogue/PaneChangeLog.d.ts
+++ b/_types/src/modules/features/SettingDialogue/PaneChangeLog.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";
 export declare function paneChangeLog(this: ObsidianLiveSyncSettingTab, paneEl: HTMLElement): void;

--- a/_types/src/modules/features/SettingDialogue/PaneCustomisationSync.d.ts
+++ b/_types/src/modules/features/SettingDialogue/PaneCustomisationSync.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";
 import type { PageFunctions } from "./SettingPane.ts";
 export declare function paneCustomisationSync(this: ObsidianLiveSyncSettingTab, paneEl: HTMLElement, { addPanel }: PageFunctions): void;

--- a/_types/src/modules/features/SettingDialogue/PaneGeneral.d.ts
+++ b/_types/src/modules/features/SettingDialogue/PaneGeneral.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";
 import type { PageFunctions } from "./SettingPane.ts";
 export declare function paneGeneral(this: ObsidianLiveSyncSettingTab, paneEl: HTMLElement, { addPanel, addPane }: PageFunctions): void;

--- a/_types/src/modules/features/SettingDialogue/PaneHatch.d.ts
+++ b/_types/src/modules/features/SettingDialogue/PaneHatch.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";
 import type { PageFunctions } from "./SettingPane.ts";
 export declare function paneHatch(this: ObsidianLiveSyncSettingTab, paneEl: HTMLElement, { addPanel }: PageFunctions): void;

--- a/_types/src/modules/features/SettingDialogue/PaneMaintenance.d.ts
+++ b/_types/src/modules/features/SettingDialogue/PaneMaintenance.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab";
 import { type PageFunctions } from "./SettingPane";
 export declare function paneMaintenance(this: ObsidianLiveSyncSettingTab, paneEl: HTMLElement, { addPanel }: PageFunctions): void;

--- a/_types/src/modules/features/SettingDialogue/PanePatches.d.ts
+++ b/_types/src/modules/features/SettingDialogue/PanePatches.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";
 import type { PageFunctions } from "./SettingPane.ts";
 export declare function panePatches(this: ObsidianLiveSyncSettingTab, paneEl: HTMLElement, { addPanel }: PageFunctions): void;

--- a/_types/src/modules/features/SettingDialogue/PanePowerUsers.d.ts
+++ b/_types/src/modules/features/SettingDialogue/PanePowerUsers.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";
 import type { PageFunctions } from "./SettingPane.ts";
 export declare function panePowerUsers(this: ObsidianLiveSyncSettingTab, paneEl: HTMLElement, { addPanel }: PageFunctions): void;

--- a/_types/src/modules/features/SettingDialogue/PaneRemoteConfig.d.ts
+++ b/_types/src/modules/features/SettingDialogue/PaneRemoteConfig.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";
 import type { PageFunctions } from "./SettingPane.ts";
 export declare function paneRemoteConfig(this: ObsidianLiveSyncSettingTab, paneEl: HTMLElement, { addPanel, addPane }: PageFunctions): void;

--- a/_types/src/modules/features/SettingDialogue/PaneSelector.d.ts
+++ b/_types/src/modules/features/SettingDialogue/PaneSelector.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";
 import type { PageFunctions } from "./SettingPane.ts";
 export declare function paneSelector(this: ObsidianLiveSyncSettingTab, paneEl: HTMLElement, { addPanel }: PageFunctions): void;

--- a/_types/src/modules/features/SettingDialogue/PaneSetup.d.ts
+++ b/_types/src/modules/features/SettingDialogue/PaneSetup.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";
 import type { PageFunctions } from "./SettingPane.ts";
 export declare function paneSetup(this: ObsidianLiveSyncSettingTab, paneEl: HTMLElement, { addPanel, addPane }: PageFunctions): void;

--- a/_types/src/modules/features/SettingDialogue/PaneSyncSettings.d.ts
+++ b/_types/src/modules/features/SettingDialogue/PaneSyncSettings.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab.ts";
 import type { PageFunctions } from "./SettingPane.ts";
 export declare function paneSyncSettings(this: ObsidianLiveSyncSettingTab, paneEl: HTMLElement, { addPanel, addPane }: PageFunctions): void;

--- a/_types/src/modules/features/SettingDialogue/SettingPane.d.ts
+++ b/_types/src/modules/features/SettingDialogue/SettingPane.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type ConfigLevel } from "@lib/common/types";
 import type { AllSettingItemKey, AllSettings } from "./settingConstants";
 export declare const combineOnUpdate: (func1: OnUpdateFunc, func2: OnUpdateFunc) => OnUpdateFunc;

--- a/_types/src/modules/features/SettingDialogue/SveltePanel.d.ts
+++ b/_types/src/modules/features/SettingDialogue/SveltePanel.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type Component } from "svelte";
 import { type Writable } from "svelte/store";
 /**

--- a/_types/src/modules/features/SettingDialogue/remoteConfigBuffer.d.ts
+++ b/_types/src/modules/features/SettingDialogue/remoteConfigBuffer.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ObsidianLiveSyncSettings } from "@lib/common/types.ts";
 export declare function syncActivatedRemoteSettings(target: Partial<ObsidianLiveSyncSettings>, source: ObsidianLiveSyncSettings): void;

--- a/_types/src/modules/features/SettingDialogue/settingConstants.d.ts
+++ b/_types/src/modules/features/SettingDialogue/settingConstants.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export * from "@lib/common/settingConstants.ts";

--- a/_types/src/modules/features/SettingDialogue/settingUtils.d.ts
+++ b/_types/src/modules/features/SettingDialogue/settingUtils.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type ObsidianLiveSyncSettings } from "@lib/common/types";
 /**
  * Generates a summary of P2P configuration settings

--- a/_types/src/modules/features/SetupManager.d.ts
+++ b/_types/src/modules/features/SetupManager.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type ObsidianLiveSyncSettings } from "@lib/common/types.ts";
 import { AbstractModule } from "@/modules/AbstractModule.ts";
 /**

--- a/_types/src/modules/features/SetupWizard/dialogs/setupDialogTypes.d.ts
+++ b/_types/src/modules/features/SetupWizard/dialogs/setupDialogTypes.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { BucketSyncSetting, CouchDBConnection, EncryptionSettings, ObsidianLiveSyncSettings, P2PConnectionInfo } from "@lib/common/models/setting.type";
 export declare const TYPE_IDENTICAL = "identical";
 export declare const TYPE_INDEPENDENT = "independent";

--- a/_types/src/modules/main/ModuleLiveSyncMain.d.ts
+++ b/_types/src/modules/main/ModuleLiveSyncMain.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { AbstractModule } from "@/modules/AbstractModule.ts";
 import type { InjectableServiceHub } from "@lib/services/implements/injectable/InjectableServiceHub.ts";
 import type { LiveSyncCore } from "@/main.ts";

--- a/_types/src/modules/services/ObsidianAPIService.d.ts
+++ b/_types/src/modules/services/ObsidianAPIService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { InjectableAPIService } from "@lib/services/implements/injectable/InjectableAPIService";
 import type { ObsidianServiceContext } from "@lib/services/implements/obsidian/ObsidianServiceContext";
 import { type Command } from "@/deps.ts";

--- a/_types/src/modules/services/ObsidianAppLifecycleService.d.ts
+++ b/_types/src/modules/services/ObsidianAppLifecycleService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { AppLifecycleServiceBase } from "@lib/services/implements/injectable/InjectableAppLifecycleService";
 import type { ObsidianServiceContext } from "@lib/services/implements/obsidian/ObsidianServiceContext";
 declare module "obsidian" {

--- a/_types/src/modules/services/ObsidianConfirm.d.ts
+++ b/_types/src/modules/services/ObsidianConfirm.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type App, type Plugin } from "@/deps";
 import type { Confirm } from "@lib/interfaces/Confirm";
 import type { ObsidianServiceContext } from "@lib/services/implements/obsidian/ObsidianServiceContext";

--- a/_types/src/modules/services/ObsidianDatabaseService.d.ts
+++ b/_types/src/modules/services/ObsidianDatabaseService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ObsidianServiceContext } from "@lib/services/implements/obsidian/ObsidianServiceContext";
 import { DatabaseService, type DatabaseServiceDependencies } from "@lib/services/base/DatabaseService.ts";
 export declare class ObsidianDatabaseService<T extends ObsidianServiceContext> extends DatabaseService<T> {

--- a/_types/src/modules/services/ObsidianPathService.d.ts
+++ b/_types/src/modules/services/ObsidianPathService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ObsidianServiceContext } from "@lib/services/implements/obsidian/ObsidianServiceContext";
 import { PathService } from "@lib/services/base/PathService";
 import { type BASE_IS_NEW, type TARGET_IS_NEW, type EVEN } from "@/common/utils";

--- a/_types/src/modules/services/ObsidianServiceHub.d.ts
+++ b/_types/src/modules/services/ObsidianServiceHub.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { InjectableServiceHub } from "@lib/services/implements/injectable/InjectableServiceHub";
 import { ObsidianServiceContext } from "@lib/services/implements/obsidian/ObsidianServiceContext";
 import type ObsidianLiveSyncPlugin from "@/main";

--- a/_types/src/modules/services/ObsidianServices.d.ts
+++ b/_types/src/modules/services/ObsidianServices.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { InjectableConflictService } from "@lib/services/implements/injectable/InjectableConflictService";
 import { InjectableDatabaseEventService } from "@lib/services/implements/injectable/InjectableDatabaseEventService";
 import { InjectableFileProcessingService } from "@lib/services/implements/injectable/InjectableFileProcessingService";

--- a/_types/src/modules/services/ObsidianSettingService.d.ts
+++ b/_types/src/modules/services/ObsidianSettingService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type ObsidianLiveSyncSettings } from "@lib/common/types";
 import { SettingService, type SettingServiceDependencies } from "@lib/services/base/SettingService";
 import type { ObsidianServiceContext } from "@lib/services/implements/obsidian/ObsidianServiceContext";

--- a/_types/src/modules/services/ObsidianUIService.d.ts
+++ b/_types/src/modules/services/ObsidianUIService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ConfigService } from "@lib/services/base/ConfigService";
 import type { AppLifecycleService } from "@lib/services/base/AppLifecycleService";
 import type { ReplicatorService } from "@lib/services/base/ReplicatorService";

--- a/_types/src/modules/services/ObsidianVaultService.d.ts
+++ b/_types/src/modules/services/ObsidianVaultService.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { InjectableVaultService } from "@lib/services/implements/injectable/InjectableVaultService";
 import type { ObsidianServiceContext } from "@lib/services/implements/obsidian/ObsidianServiceContext";
 import type { FilePath } from "@lib/common/types";

--- a/_types/src/serviceFeatures/onLayoutReady/enablei18n.d.ts
+++ b/_types/src/serviceFeatures/onLayoutReady/enablei18n.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 export declare const enableI18nFeature: import("@lib/interfaces/ServiceModule").ServiceFeatureFunction<keyof import("../../lib/src/services/ServiceHub").ServiceHub<import("../../lib/src/services/base/ServiceBase").ServiceContext>, keyof import("@lib/interfaces/ServiceModule").ServiceModules, Promise<boolean>>;

--- a/_types/src/serviceFeatures/redFlag.d.ts
+++ b/_types/src/serviceFeatures/redFlag.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";
 import { type LogFunction } from "@lib/services/lib/logUtils";
 import type { ObsidianLiveSyncSettings } from "@lib/common/models/setting.type";

--- a/_types/src/serviceFeatures/redFlag.simpleFetch.d.ts
+++ b/_types/src/serviceFeatures/redFlag.simpleFetch.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";
 import { type LogFunction } from "@lib/services/lib/logUtils";
 import { type FullScanOptions } from "@lib/serviceFeatures/offlineScanner";

--- a/_types/src/serviceFeatures/setupObsidian/setupManagerHandlers.d.ts
+++ b/_types/src/serviceFeatures/setupObsidian/setupManagerHandlers.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type SetupManager } from "@/modules/features/SetupManager";
 import type { SetupFeatureHost } from "@lib/serviceFeatures/setupObsidian/types";
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";

--- a/_types/src/serviceFeatures/setupObsidian/setupProtocol.d.ts
+++ b/_types/src/serviceFeatures/setupObsidian/setupProtocol.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { LogFunction } from "@lib/services/lib/logUtils";
 import type { SetupFeatureHost } from "@lib/serviceFeatures/setupObsidian/types";
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";

--- a/_types/src/serviceFeatures/useP2PReplicatorUI.d.ts
+++ b/_types/src/serviceFeatures/useP2PReplicatorUI.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";
 import { type UseP2PReplicatorResult } from "@lib/replication/trystero/UseP2PReplicatorResult";
 import { P2PLogCollector } from "@lib/replication/trystero/P2PLogCollector";

--- a/_types/src/serviceModules/DatabaseFileAccess.d.ts
+++ b/_types/src/serviceModules/DatabaseFileAccess.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { DatabaseFileAccess } from "@lib/interfaces/DatabaseFileAccess.ts";
 import { ServiceDatabaseFileAccessBase } from "@lib/serviceModules/ServiceDatabaseFileAccessBase";
 export declare class ServiceDatabaseFileAccess extends ServiceDatabaseFileAccessBase implements DatabaseFileAccess {

--- a/_types/src/serviceModules/FileAccessObsidian.d.ts
+++ b/_types/src/serviceModules/FileAccessObsidian.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type App } from "@/deps";
 import { FileAccessBase, type FileAccessBaseDependencies } from "@lib/serviceModules/FileAccessBase.ts";
 import { ObsidianFileSystemAdapter } from "./FileSystemAdapters/ObsidianFileSystemAdapter";

--- a/_types/src/serviceModules/FileHandler.d.ts
+++ b/_types/src/serviceModules/FileHandler.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { ServiceFileHandlerBase } from "@lib/serviceModules/ServiceFileHandlerBase";
 export declare class ServiceFileHandler extends ServiceFileHandlerBase {
 }

--- a/_types/src/serviceModules/FileSystemAdapters/ObsidianConversionAdapter.d.ts
+++ b/_types/src/serviceModules/FileSystemAdapters/ObsidianConversionAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { UXFileInfoStub, UXFolderInfo } from "@lib/common/types";
 import type { IConversionAdapter } from "@lib/serviceModules/adapters";
 import type { TFile, TFolder } from "obsidian";

--- a/_types/src/serviceModules/FileSystemAdapters/ObsidianFileSystemAdapter.d.ts
+++ b/_types/src/serviceModules/FileSystemAdapters/ObsidianFileSystemAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { FilePath, UXStat } from "@lib/common/types";
 import type { IFileSystemAdapter, IPathAdapter, ITypeGuardAdapter, IConversionAdapter, IStorageAdapter, IVaultAdapter } from "@lib/serviceModules/adapters";
 import type { TAbstractFile, TFile, TFolder, Stat, App } from "obsidian";

--- a/_types/src/serviceModules/FileSystemAdapters/ObsidianPathAdapter.d.ts
+++ b/_types/src/serviceModules/FileSystemAdapters/ObsidianPathAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { type TAbstractFile } from "@/deps";
 import type { FilePath } from "@lib/common/types";
 import type { IPathAdapter } from "@lib/serviceModules/adapters";

--- a/_types/src/serviceModules/FileSystemAdapters/ObsidianStorageAdapter.d.ts
+++ b/_types/src/serviceModules/FileSystemAdapters/ObsidianStorageAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { UXDataWriteOptions } from "@lib/common/types";
 import type { IStorageAdapter } from "@lib/serviceModules/adapters";
 import type { Stat, App } from "obsidian";

--- a/_types/src/serviceModules/FileSystemAdapters/ObsidianTypeGuardAdapter.d.ts
+++ b/_types/src/serviceModules/FileSystemAdapters/ObsidianTypeGuardAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { ITypeGuardAdapter } from "@lib/serviceModules/adapters";
 import { TFile, TFolder } from "obsidian";
 /**

--- a/_types/src/serviceModules/FileSystemAdapters/ObsidianVaultAdapter.d.ts
+++ b/_types/src/serviceModules/FileSystemAdapters/ObsidianVaultAdapter.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { UXDataWriteOptions } from "@lib/common/types";
 import type { IVaultAdapter } from "@lib/serviceModules/adapters";
 import type { TFile, App, TFolder } from "obsidian";

--- a/_types/src/serviceModules/ServiceFileAccessImpl.d.ts
+++ b/_types/src/serviceModules/ServiceFileAccessImpl.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import { ServiceFileAccessBase } from "@lib/serviceModules/ServiceFileAccessBase";
 import type { ObsidianFileSystemAdapter } from "./FileSystemAdapters/ObsidianFileSystemAdapter";
 export declare class ServiceFileAccessObsidian extends ServiceFileAccessBase<ObsidianFileSystemAdapter> {

--- a/_types/src/types.d.ts
+++ b/_types/src/types.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: ef1bdf0
+// REPO: https://github.com/vrtmrz/livesync-commonlib  Commit hash: a58965f
 import type { DatabaseFileAccess } from "@lib/interfaces/DatabaseFileAccess";
 import type { Rebuilder } from "@lib/interfaces/DatabaseRebuilder";
 import type { IFileHandler } from "@lib/interfaces/FileHandler";

--- a/docs/adr/2026_07_bounded_remote_activity.md
+++ b/docs/adr/2026_07_bounded_remote_activity.md
@@ -1,0 +1,110 @@
+# Architectural Decision Record: Bounded Remote Activity
+
+## Status
+
+Accepted
+
+## Context
+
+Self-hosted LiveSync performs remote work through more than one path:
+
+- finite, or bounded, replication starts for manual, event-driven, periodic, and start-up synchronisation;
+- long-running rebuild uploads, standard fetches, and fast fetches;
+- continuous replication keeps a channel open until the application lifecycle stops it; and
+- remote chunk fetching can occur independently of replication, for example while reading history.
+
+The existing API request and response counters do not cover every one of these paths. They therefore cannot, by themselves, provide an accurate remote-work indicator.
+
+Long-running finite operations can also be interrupted by platform lifecycle behaviour. A mobile or desktop display may sleep while an operation is in progress. Changing Obsidian to a hidden or minimised state normally invokes the suspension lifecycle, which closes the active replicator. The existing desktop-only `keepReplicationActiveInBackground` setting deliberately provides a broader, opt-in policy for continuous and periodic replication, and should not be made a prerequisite for completing a finite operation.
+
+Screen wake lock and background execution are related platform effects, but they are not equivalent. A screen wake lock prevents display sleep only while the platform and document visibility permit it. It does not guarantee background execution, prevent operating-system suspension, or override an explicit system sleep action.
+
+## Decision
+
+`ReplicatorService` owns a reactive `boundedRemoteActivityCount` and a `runBoundedRemoteActivity` closure boundary.
+
+The boundary has the following contract:
+
+- increment the count immediately before running a finite remote task;
+- run the task through an optional host-provided activity runner;
+- decrement the count in `finally`, including when the task rejects;
+- allow overlapping tasks, so transitions may be `0 → 1 → 2 → 1 → 0`; and
+- count logical operations, not physical connections, sockets, HTTP requests, queued work, or retry delays outside the bounded task.
+
+The Obsidian host injects the screen wake-lock manager from the `octagonal-wheels` package in the Fancy Kit monorepo as the activity runner on both mobile and desktop. Unsupported or rejected wake-lock requests remain best effort and do not prevent the remote task from running. The manager is disposed when the plug-in unloads.
+
+Finite replication enters the boundary only after readiness checks have succeeded and leaves it after `openReplication(..., continuous: false, ...)` settles. Failure handling runs afterwards so a mismatch or recovery dialogue does not retain the activity. This includes the direct start-up synchronisation path as well as manual, event-driven, and periodic calls through `ReplicationService`. Continuous replication does not enter the boundary.
+
+Manual P2P commands which bypass `ReplicationService` enter the same boundary. Direct P2P pull and push entry points also create finite transfer activities, covering the Obsidian panes, CLI, and Webapp. Automatic synchronisation on peer discovery, a pull requested by a remote peer, and a watched pull following a peer progress notification enter the same boundary. A normal P2P peer-selection dialogue represents one finite session: it remains inside the boundary while waiting for a peer and while the person may perform repeated synchronisations, then settles when the dialogue closes and any in-flight synchronisation has finished. Closing without synchronising returns a failed result and releases the boundary. The 'Start Sync & Close' action completes its synchronisation before closing. This deliberately protects peer discovery and selection, because display sleep can interrupt discovery or connection establishment and require the person to start detection again. It may therefore retain a Wake Lock longer than the network transfer alone. A transfer performed inside that session temporarily adds a nested activity; the count remains a logical-operation count rather than a connection total.
+
+`ChunkFetcher` enters the same boundary only around the actual `fetchRemoteChunks` request. Queue waiting, interval throttling, and local chunk validation or persistence remain outside the remote activity scope.
+
+Rebuild operations use the same boundary at their destructive or remote phase:
+
+- remote rebuild covers settings application, remote reset, and both upload passes, but releases before the completion dialogue;
+- rebuild everything covers local and remote reset and both upload passes, but releases before the completion dialogue;
+- standard fetch starts after any user confirmation and covers local reset, both download passes, and automatic reflection resumption; and
+- fast fetch starts after remote-type selection and covers reset, resumable download retries, reflection resumption when requested, and checkpoint removal. A non-CouchDB fallback enters only the standard-fetch boundary.
+
+Rebuilder-owned confirmation before destructive work and completion dialogues remain outside the boundary so a person cannot hold a Wake Lock indefinitely merely by leaving a dialogue open. P2P peer discovery and selection during a rebuild deliberately remain inside the boundary. They occur after destructive work has begun, and releasing protection at that point would both leave a partial rebuild unprotected and allow display sleep to interrupt peer detection, forcing the person to repeat it. The protected selection period is therefore part of the rebuild operation rather than an incidental confirmation dialogue.
+
+The deprecated database-clean-up workflow also places its connection, one-shot replication, balancing, and remote resolution inside one `database-cleanup` boundary after the user's choice. Its preliminary count and choice dialogue remain outside.
+
+On every platform, a visibility change to hidden defers the normal suspension lifecycle while the bounded count is non-zero. When the last bounded operation ends, the deferred suspension runs if the document is still hidden and the existing desktop background-replication setting does not apply. This does not bypass mobile operating-system restrictions: a hidden document loses its Screen Wake Lock, and the operating system may still pause or terminate the application. LiveSync merely avoids aborting the operation itself while it may still be able to finish.
+
+Fetch rebuilds temporarily suspend file watching. Their visibility event still records the observed hidden state and a pending lifecycle suspension while bounded activity is in progress, without committing or processing file events. A hidden application is suspended after the rebuild boundary ends and can therefore resume normally when it becomes visible. If it becomes visible before the boundary ends, the pending suspension is cancelled and no unmatched resume lifecycle is emitted.
+
+If the desktop background setting applies, its existing continuous or periodic policy remains authoritative. When a Desktop LiveSync window becomes visible during bounded activity, the normal continuous-channel teardown and resume sequence is also deferred until that activity ends, so recovery does not abort the finite operation.
+
+The status-bar remote-work indicator is shown when either the existing HTTP request balance is non-zero or the bounded remote activity count is non-zero. This preserves coverage from the existing counters while adding finite replication, peer waiting, and remote chunk fetching. The combined icon reports broader remote work, not an exact physical connection state; connection-level telemetry remains a separate concern.
+
+## Ownership
+
+`ReplicatorService` is the shared ownership point because both `ReplicationService` and `ChunkFetcher` already depend on it. Placing the activity state in `ReplicationService` would make chunk fetching depend in the opposite direction and risk a service dependency cycle. Adding another Service Hub service would introduce a wider capability surface without a distinct lifecycle owner.
+
+The platform activity runner remains injected. Common library and headless consumers can omit it while retaining the same bounded activity count and operation semantics.
+
+## Non-Goals
+
+- Do not count continuous replication as a bounded activity.
+- Do not reinterpret the count as an exact number of network connections or HTTP requests.
+- Do not use this logical-operation count as a replacement for future connection-level telemetry.
+- Do not claim or implement privileged mobile background execution.
+- Do not guarantee protection against operating-system suspension, closing a laptop lid, forced termination, network loss, or a user-initiated sleep action.
+- Do not add a lifecycle timeout which would abort an unusually slow rebuild. A genuinely stalled operation may postpone LiveSync's visibility suspension until it settles, but the platform may still suspend or terminate background work.
+- Do not broaden `keepReplicationActiveInBackground`; it remains an opt-in desktop policy for continuous and periodic operation after finite work has ended.
+- Do not include local storage reflection in this boundary. It is re-entrant and offline-capable, and needs a separate decision if activity reporting or power policy is added later.
+
+## Verification
+
+Unit tests cover:
+
+- overlapping bounded activities and their reactive count transitions;
+- count cleanup after rejection;
+- entry into the boundary only after replication readiness succeeds;
+- replication failure handling occurring after the finite activity ends;
+- start-up one-shot replication entering the boundary while continuous start-up does not;
+- start-up readiness failure avoiding the boundary;
+- direct P2P commands entering the boundary;
+- direct P2P pull and push entry points entering the boundary;
+- automatic synchronisation on peer discovery, remote pull requests, and watched peer progress entering the boundary;
+- P2P peer-selection sessions settling on close, including cancellation, repeated synchronisation, and a close during in-flight work;
+- remote chunk fetching through the shared boundary;
+- standard, fast, remote, and combined rebuild activity boundaries;
+- Rebuilder-owned confirmation and completion dialogues remaining outside rebuild activity;
+- fallback from fast fetch avoiding a nested activity boundary;
+- fast-fetch reflection resumption and checkpoint removal remaining inside the activity;
+- visibility suspension being deferred while bounded activity is in progress on desktop and mobile;
+- rebuild-time file-watching suspension preserving the deferred lifecycle action;
+- deferred suspension after the final activity ends while the document remains hidden;
+- hidden-to-visible transitions before the final activity avoiding an unmatched resume; and
+- continuous-channel recovery being deferred when a desktop window becomes visible during bounded activity.
+
+The exact Fancy Kit screen wake-lock behaviour is covered by its package and Harness tests. A real Obsidian smoke test remains appropriate when changing the platform adapter or lifecycle integration, but is not required for changes confined to the already-tested injected activity-runner contract.
+
+## Consequences
+
+- One finite activity definition drives Wake Lock, lifecycle protection, and status UI without coupling common library code to Obsidian or browser globals.
+- Callers can observe accurate logical activity even in CLI and Webapp hosts which do not inject a Wake Lock implementation.
+- Rebuild operations now retain Wake Lock and lifecycle protection across their longest interruption-sensitive phases without retaining them for Rebuilder-owned pre-operation or completion dialogues. Post-reset P2P discovery and selection remain protected as an intentional part of completing the rebuild.
+- Future remote-work indicators should distinguish logical activity from connection-level telemetry when that distinction matters to users.

--- a/docs/p2p_sync_updates_2026.md
+++ b/docs/p2p_sync_updates_2026.md
@@ -39,7 +39,11 @@ The status card now shows a stable **Room ID suffix** above **Peer ID**. The Roo
 Two actions are available per peer:
 
 - **Sync** — Starts a bidirectional synchronisation (Pull then Push) and keeps the dialogue open so you can monitor progress or sync with additional peers.
-- **Start Sync & Close** — Starts the same bidirectional sync in the background and **immediately closes the dialogue**, so you can continue working without waiting.
+- **Start Sync & Close** — Runs the same bidirectional synchronisation, waits for it to settle, then closes the dialogue. After a successful synchronisation, it also closes the signalling connection.
+
+On supported mobile and desktop devices, LiveSync keeps the screen awake while this peer-selection dialogue is open and while its synchronisations finish. This is intentional: display sleep can interrupt peer discovery or connection establishment and require detection to start again. Wake Lock support remains best effort, does not keep a hidden application running in the background, and does not override operating-system sleep or suspension.
+
+During a P2P rebuild, peer discovery and selection remain protected after the rebuild has started. Keep Obsidian visible until a peer is selected and the transfer finishes, because mobile platform restrictions can still pause or terminate a hidden application.
 
 ## 5. Syncing with Registered Targets via Command Palette
 
@@ -56,4 +60,3 @@ This command synchronises with every peer whose **SYNC** toggle is enabled in th
 - **Decoupled Architecture:** The UI is now strictly separated from the core logic, making the plug-in more stable across different platforms (Mobile, Desktop, and Web).
 - **Svelte 5 UI:** The interface has been rebuilt for better responsiveness and clearer status indicators.
 - **Security:** All data remains end-to-end encrypted. Even the signalling relay never sees your actual notes.
-

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -491,7 +491,9 @@ Sync automatically after merging files
 #### Keep replication active in the background
 
 Setting key: keepReplicationActiveInBackground
-Desktop only; uses more battery and network.
+Desktop only; uses more battery and network. This setting applies to continuous and periodic replication.
+
+Finite remote operations, including one-shot replication, P2P peer discovery and selection, rebuilds, fetches, and remote chunk fetching, request best-effort screen-awake protection automatically and do not require this setting. That protection does not guarantee execution while Obsidian is hidden or while the operating system suspends the device.
 
 ### 3. Update thinning
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
                 "markdown-it": "^14.2.0",
                 "minimatch": "^10.2.5",
                 "obsidian": "^1.13.1",
-                "octagonal-wheels": "^0.1.50",
+                "octagonal-wheels": "^0.1.51",
                 "qrcode-generator": "^1.4.4",
                 "xxhash-wasm-102": "npm:xxhash-wasm@^1.0.2"
             },
@@ -11700,9 +11700,9 @@
             "license": "MIT"
         },
         "node_modules/octagonal-wheels": {
-            "version": "0.1.50",
-            "resolved": "https://registry.npmjs.org/octagonal-wheels/-/octagonal-wheels-0.1.50.tgz",
-            "integrity": "sha512-1JUU1+hFJKaF4aUchXYfFB9fCHagoYcYiYwSq0B64qwrmh+CGmMb6lSambHM21wBpyoKkO7FO3z7N+Xs5YXPug==",
+            "version": "0.1.51",
+            "resolved": "https://registry.npmjs.org/octagonal-wheels/-/octagonal-wheels-0.1.51.tgz",
+            "integrity": "sha512-KTlfqKPjobHJg/t3A539srnFf+VHr1aXkHSmsNDDpiI5UFC7FamZ95dWpJfGE2EI/HULR5hveQDgkazmz8SAcg==",
             "license": "MIT",
             "dependencies": {
                 "idb": "^8.0.3"

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
         "markdown-it": "^14.2.0",
         "minimatch": "^10.2.5",
         "obsidian": "^1.13.1",
-        "octagonal-wheels": "^0.1.50",
+        "octagonal-wheels": "^0.1.51",
         "qrcode-generator": "^1.4.4",
         "xxhash-wasm-102": "npm:xxhash-wasm@^1.0.2"
     },

--- a/src/features/P2PSync/P2PReplicator/P2POpenReplicationPane.svelte
+++ b/src/features/P2PSync/P2PReplicator/P2POpenReplicationPane.svelte
@@ -69,18 +69,6 @@
         }
     }
 
-    async function handleSyncAndClose(peerId: string) {
-        fireAndForget(async () => {
-            try {
-                Logger(`Starting sync with ${peerId}`, logLevel);
-                await onSync(peerId);
-                Logger(`Sync completed with ${peerId}`, logLevel);
-            } catch (e) {
-                Logger(`Error during sync: ${e instanceof Error ? e.message : String(e)}`, logLevel);
-            }
-        });
-        onClose();
-    }
     async function disconnect() {
         try {
             await liveSyncReplicator.close();
@@ -142,7 +130,7 @@
                                 <button
                                     class="btn {rebuildMode ? 'btn-primary' : 'btn-secondary'}"
                                     disabled={syncingPeerId !== null}
-                                    onclick={() => handleSyncAndClose(peer.peerId)}
+                                    onclick={() => handleSyncThenClose(peer.peerId)}
                                 >
                                     {syncingPeerId === peer.peerId ? "Syncing..." : "Start Sync & Close"}
                                 </button>

--- a/src/features/P2PSync/P2PReplicator/P2PReplicationUI.ts
+++ b/src/features/P2PSync/P2PReplicator/P2PReplicationUI.ts
@@ -1,4 +1,4 @@
-import { App } from "@/deps.ts";
+import type { App } from "@/deps.ts";
 import { Logger } from "@lib/common/logger";
 import { LOG_LEVEL_NOTICE, LOG_LEVEL_INFO } from "@lib/common/types";
 import type { LiveSyncTrysteroReplicator } from "@lib/replication/trystero/LiveSyncTrysteroReplicator";
@@ -20,52 +20,54 @@ export function createOpenReplicationUI(
         (showResult: boolean): Promise<boolean | void> => {
             const logLevel = showResult ? LOG_LEVEL_NOTICE : LOG_LEVEL_INFO;
             return new Promise<boolean | void>((resolve) => {
+                let resolved = false;
+                let sessionResult = false;
+                let activeSynchronisations = 0;
+                let closed = false;
+                const safeResolve = () => {
+                    if (resolved) return;
+                    resolved = true;
+                    resolve(sessionResult);
+                };
+                const settleClosedSession = () => {
+                    if (closed && activeSynchronisations === 0) safeResolve();
+                };
+                const synchronise = async (peerId: string, closeConnection: boolean) => {
+                    activeSynchronisations++;
+                    try {
+                        // Pull first, then push only when the pull succeeds.
+                        const pullResult = await replicator.replicateFrom(peerId, showResult);
+                        if (!pullResult?.ok) {
+                            sessionResult = false;
+                            return;
+                        }
+                        const pushResult = await replicator.requestSynchroniseToPeer(peerId);
+                        sessionResult = pushResult?.ok ?? true;
+                        if (sessionResult && closeConnection) await replicator.close();
+                    } catch (e) {
+                        Logger(
+                            `Error in bidirectional sync with ${peerId}: ${e instanceof Error ? e.message : String(e)}`,
+                            logLevel
+                        );
+                        sessionResult = false;
+                    } finally {
+                        activeSynchronisations--;
+                        settleClosedSession();
+                    }
+                };
                 const modal = new P2POpenReplicationModal(
                     app,
                     replicator,
                     {
-                        onSync: async (peerId: string) => {
-                            try {
-                                // pull (replicateFrom) first; push only on success
-                                const pullResult = await replicator.replicateFrom(peerId, showResult);
-                                if (pullResult?.ok) {
-                                    const pushResult = await replicator.requestSynchroniseToPeer(peerId);
-                                    resolve(pushResult?.ok ?? true);
-                                } else {
-                                    resolve(false);
-                                }
-                            } catch (e) {
-                                Logger(
-                                    `Error in bidirectional sync with ${peerId}: ${e instanceof Error ? e.message : String(e)}`,
-                                    logLevel
-                                );
-                                resolve(false);
-                            }
-                        },
-                        onSyncAndClose: async (peerId: string) => {
-                            try {
-                                const pullResult = await replicator.replicateFrom(peerId, showResult);
-                                if (pullResult?.ok) {
-                                    const pushResult = await replicator.requestSynchroniseToPeer(peerId);
-                                    if (pushResult?.ok ?? true) {
-                                        await replicator.close();
-                                        resolve(true);
-                                    } else {
-                                        resolve(false);
-                                    }
-                                } else {
-                                    resolve(false);
-                                }
-                            } catch (e) {
-                                Logger(
-                                    `Error in bidirectional sync with ${peerId}: ${e instanceof Error ? e.message : String(e)}`,
-                                    logLevel
-                                );
-                                resolve(false);
-                            }
-                        },
+                        onSync: (peerId: string) => synchronise(peerId, false),
+                        onSyncAndClose: (peerId: string) => synchronise(peerId, true),
                     },
-                    showResult
+                    showResult,
+                    "P2P Replication",
+                    () => {
+                        closed = true;
+                        settleClosedSession();
+                    }
                 );
                 modal.open();
             });
@@ -89,27 +91,42 @@ export function createOpenRebuildUI(
             const logLevel = showResult ? LOG_LEVEL_NOTICE : LOG_LEVEL_INFO;
             return new Promise<boolean | void>((resolve) => {
                 let resolved = false;
+                let activeSynchronisations = 0;
+                let closed = false;
+                let operationCompleted = false;
+                let sessionResult = false;
                 const safeResolve = (val: boolean) => {
                     if (!resolved) {
                         resolved = true;
                         resolve(val);
                     }
                 };
+                const settleSession = () => {
+                    if (activeSynchronisations !== 0) return;
+                    if (closed || operationCompleted) safeResolve(sessionResult);
+                };
 
                 const doRebuild = async (peerId: string) => {
-                    replicator.setOnSetup();
+                    activeSynchronisations++;
                     try {
+                        replicator.setOnSetup();
                         Logger(`Rebuilding from peer ${peerId}`, logLevel);
                         const result = await replicator.replicateFrom(peerId, showResult);
-                        safeResolve(result?.ok ?? false);
+                        sessionResult = result?.ok ?? false;
                     } catch (e) {
                         Logger(
                             `Error in rebuild from ${peerId}: ${e instanceof Error ? e.message : String(e)}`,
                             logLevel
                         );
-                        safeResolve(false);
+                        sessionResult = false;
                     } finally {
-                        replicator.clearOnSetup();
+                        try {
+                            replicator.clearOnSetup();
+                        } finally {
+                            operationCompleted = true;
+                            activeSynchronisations--;
+                            settleSession();
+                        }
                     }
                 };
 
@@ -122,7 +139,10 @@ export function createOpenRebuildUI(
                     },
                     showResult,
                     "P2P Rebuild",
-                    () => safeResolve(false),
+                    () => {
+                        closed = true;
+                        settleSession();
+                    },
                     true
                 );
                 modal.open();

--- a/src/features/P2PSync/P2PReplicator/P2PReplicationUI.unit.spec.ts
+++ b/src/features/P2PSync/P2PReplicator/P2PReplicationUI.unit.spec.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const modalState = vi.hoisted(() => ({
+    instances: [] as Array<{
+        callback: {
+            onSync: (peerId: string) => Promise<void>;
+            onSyncAndClose: (peerId: string) => Promise<void>;
+        };
+        onClosed?: () => void;
+        open: ReturnType<typeof vi.fn>;
+    }>,
+}));
+
+vi.mock("@/deps.ts", () => ({ App: class {} }));
+
+vi.mock("./P2POpenReplicationModal", () => ({
+    P2POpenReplicationModal: class {
+        callback;
+        onClosed;
+        open = vi.fn();
+
+        constructor(
+            _app: unknown,
+            _replicator: unknown,
+            callback: (typeof modalState.instances)[number]["callback"],
+            _showResult: boolean,
+            _title?: string,
+            onClosed?: () => void
+        ) {
+            this.callback = callback;
+            this.onClosed = onClosed;
+            modalState.instances.push(this);
+        }
+    },
+}));
+
+import { createOpenRebuildUI, createOpenReplicationUI } from "./P2PReplicationUI";
+
+function createReplicator() {
+    return {
+        replicateFrom: vi.fn(async () => ({ ok: true })),
+        requestSynchroniseToPeer: vi.fn(async () => ({ ok: true })),
+        close: vi.fn(async () => undefined),
+        setOnSetup: vi.fn(),
+        clearOnSetup: vi.fn(),
+    } as any;
+}
+
+describe("createOpenReplicationUI", () => {
+    beforeEach(() => {
+        modalState.instances.length = 0;
+    });
+
+    it("settles a cancelled peer-selection session when the modal closes", async () => {
+        const session = createOpenReplicationUI({} as any)(createReplicator())(true);
+        const modal = modalState.instances[0];
+
+        expect(modal.onClosed).toBeTypeOf("function");
+        modal.onClosed?.();
+
+        await expect(session).resolves.toBe(false);
+    });
+
+    it("keeps repeated synchronisation inside the session boundary until the modal closes", async () => {
+        const replicator = createReplicator();
+        const session = createOpenReplicationUI({} as any)(replicator)(true);
+        const modal = modalState.instances[0];
+        let settled = false;
+        void session.finally(() => {
+            settled = true;
+        });
+
+        await modal.callback.onSync("peer-a");
+        await Promise.resolve();
+
+        expect(settled).toBe(false);
+        await modal.callback.onSync("peer-b");
+        expect(replicator.replicateFrom).toHaveBeenCalledTimes(2);
+        expect(replicator.requestSynchroniseToPeer).toHaveBeenCalledTimes(2);
+
+        modal.onClosed?.();
+        await expect(session).resolves.toBe(true);
+    });
+
+    it("waits for an in-flight synchronisation when the modal closes", async () => {
+        let finishPull!: (value: { ok: boolean }) => void;
+        const replicator = createReplicator();
+        replicator.replicateFrom.mockImplementation(
+            async () =>
+                await new Promise<{ ok: boolean }>((resolve) => {
+                    finishPull = resolve;
+                })
+        );
+        const session = createOpenReplicationUI({} as any)(replicator)(true);
+        const modal = modalState.instances[0];
+        let settled = false;
+        void session.finally(() => {
+            settled = true;
+        });
+
+        const synchronisation = modal.callback.onSync("peer-a");
+        modal.onClosed?.();
+        await Promise.resolve();
+
+        expect(settled).toBe(false);
+
+        finishPull({ ok: true });
+        await synchronisation;
+        await expect(session).resolves.toBe(true);
+    });
+
+    it("closes the P2P connection after a successful sync-and-close action", async () => {
+        const replicator = createReplicator();
+        const session = createOpenReplicationUI({} as any)(replicator)(true);
+        const modal = modalState.instances[0];
+
+        await modal.callback.onSyncAndClose("peer-a");
+
+        expect(replicator.close).toHaveBeenCalledOnce();
+        let settled = false;
+        void session.finally(() => {
+            settled = true;
+        });
+        await Promise.resolve();
+        expect(settled).toBe(false);
+
+        modal.onClosed?.();
+        await expect(session).resolves.toBe(true);
+    });
+});
+
+describe("createOpenRebuildUI", () => {
+    beforeEach(() => {
+        modalState.instances.length = 0;
+    });
+
+    it("waits for an in-flight rebuild when the modal closes", async () => {
+        let finishPull!: (value: { ok: boolean }) => void;
+        const replicator = createReplicator();
+        replicator.replicateFrom.mockImplementation(
+            async () =>
+                await new Promise<{ ok: boolean }>((resolve) => {
+                    finishPull = resolve;
+                })
+        );
+        const session = createOpenRebuildUI({} as any)(replicator)(true);
+        const modal = modalState.instances[0];
+        let settled = false;
+        void session.finally(() => {
+            settled = true;
+        });
+
+        const rebuild = modal.callback.onSyncAndClose("peer-a");
+        modal.onClosed?.();
+        await Promise.resolve();
+
+        expect(settled).toBe(false);
+
+        finishPull({ ok: true });
+        await rebuild;
+        await expect(session).resolves.toBe(true);
+        expect(replicator.setOnSetup).toHaveBeenCalledOnce();
+        expect(replicator.clearOnSetup).toHaveBeenCalledOnce();
+    });
+});

--- a/src/modules/core/ModuleReplicator.ts
+++ b/src/modules/core/ModuleReplicator.ts
@@ -133,33 +133,41 @@ Even if you choose to clean up, you will see this option again if you exit Obsid
                 await this.core.rebuilder.$performRebuildDB("localOnly");
             }
             if (ret == CHOICE_CLEAN) {
-                const replicator = this.services.replicator.getActiveReplicator();
-                if (!(replicator instanceof LiveSyncCouchDBReplicator)) return;
-                const remoteDB = await replicator.connectRemoteCouchDBWithSetting(
-                    this.settings,
-                    this.services.API.isMobile(),
-                    true
-                );
-                if (typeof remoteDB == "string") {
-                    Logger(remoteDB, LOG_LEVEL_NOTICE);
-                    return false;
-                }
+                await this.services.replicator.runBoundedRemoteActivity(
+                    async () => {
+                        const replicator = this.services.replicator.getActiveReplicator();
+                        if (!(replicator instanceof LiveSyncCouchDBReplicator)) return;
+                        const remoteDB = await replicator.connectRemoteCouchDBWithSetting(
+                            this.settings,
+                            this.services.API.isMobile(),
+                            true
+                        );
+                        if (typeof remoteDB == "string") {
+                            Logger(remoteDB, LOG_LEVEL_NOTICE);
+                            return false;
+                        }
 
-                await purgeUnreferencedChunks(this.localDatabase.localDatabase, false);
-                this.localDatabase.clearCaches();
-                // Perform the synchronisation once.
-                if (await this.core.replicator.openReplication(this.settings, false, showMessage, true)) {
-                    await balanceChunkPurgedDBs(this.localDatabase.localDatabase, remoteDB.db);
-                    await purgeUnreferencedChunks(this.localDatabase.localDatabase, false);
-                    this.localDatabase.clearCaches();
-                    await this.services.replicator.getActiveReplicator()?.markRemoteResolved(this.settings);
-                    Logger("The local database has been cleaned up.", showMessage ? LOG_LEVEL_NOTICE : LOG_LEVEL_INFO);
-                } else {
-                    Logger(
-                        "Replication has been cancelled. Please try it again.",
-                        showMessage ? LOG_LEVEL_NOTICE : LOG_LEVEL_INFO
-                    );
-                }
+                        await purgeUnreferencedChunks(this.localDatabase.localDatabase, false);
+                        this.localDatabase.clearCaches();
+                        // Perform the synchronisation once.
+                        if (await this.core.replicator.openReplication(this.settings, false, showMessage, true)) {
+                            await balanceChunkPurgedDBs(this.localDatabase.localDatabase, remoteDB.db);
+                            await purgeUnreferencedChunks(this.localDatabase.localDatabase, false);
+                            this.localDatabase.clearCaches();
+                            await this.services.replicator.getActiveReplicator()?.markRemoteResolved(this.settings);
+                            Logger(
+                                "The local database has been cleaned up.",
+                                showMessage ? LOG_LEVEL_NOTICE : LOG_LEVEL_INFO
+                            );
+                        } else {
+                            Logger(
+                                "Replication has been cancelled. Please try it again.",
+                                showMessage ? LOG_LEVEL_NOTICE : LOG_LEVEL_INFO
+                            );
+                        }
+                    },
+                    { label: "database-cleanup" }
+                );
             }
         });
     }

--- a/src/modules/core/ModuleReplicator.unit.spec.ts
+++ b/src/modules/core/ModuleReplicator.unit.spec.ts
@@ -1,4 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
+
+const chunkMocks = vi.hoisted(() => ({
+    purgeUnreferencedChunks: vi.fn(async (_db: unknown, countOnly: boolean) => (countOnly ? 2 : 0)),
+    balanceChunkPurgedDBs: vi.fn(async () => undefined),
+}));
+
+vi.mock("@lib/pouchdb/chunks", () => chunkMocks);
+vi.mock("@lib/replication/couchdb/LiveSyncReplicator", () => ({
+    LiveSyncCouchDBReplicator: class {},
+}));
+
+import { LiveSyncCouchDBReplicator } from "@lib/replication/couchdb/LiveSyncReplicator";
 import { ModuleReplicator } from "./ModuleReplicator";
 
 describe("ModuleReplicator", () => {
@@ -44,5 +56,63 @@ describe("ModuleReplicator", () => {
         await beforeReplicate!(false);
 
         expect(ensurePBKDF2Salt).toHaveBeenCalledWith({}, false, false);
+    });
+});
+
+describe("ModuleReplicator legacy cleanup", () => {
+    it("keeps its finite replication and balancing work inside the shared activity boundary", async () => {
+        const activityFinished = vi.fn();
+        const runBoundedRemoteActivity = vi.fn(async (task: () => unknown) => {
+            try {
+                return await task();
+            } finally {
+                activityFinished();
+            }
+        });
+        const openReplication = vi.fn(async () => true);
+        const activeReplicator = Object.assign(new LiveSyncCouchDBReplicator({} as any), {
+            connectRemoteCouchDBWithSetting: vi.fn(async () => ({ db: {} })),
+            markRemoteResolved: vi.fn(async () => undefined),
+        });
+        const services = {
+            API: {
+                addLog: vi.fn(),
+                addCommand: vi.fn(),
+                registerWindow: vi.fn(),
+                addRibbonIcon: vi.fn(),
+                registerProtocolHandler: vi.fn(),
+                isMobile: vi.fn(() => false),
+            },
+            setting: { saveSettingData: vi.fn(async () => undefined) },
+            appLifecycle: {
+                getUnresolvedMessages: { addHandler: vi.fn() },
+            },
+            replicator: {
+                getActiveReplicator: vi.fn(() => activeReplicator),
+                runBoundedRemoteActivity,
+            },
+        };
+        const localDatabase = {
+            localDatabase: {},
+            clearCaches: vi.fn(),
+        };
+        const core = {
+            _services: services,
+            services,
+            settings: {},
+            localDatabase,
+            confirm: { confirmWithMessage: vi.fn(async () => "Cleanup") },
+            replicator: { openReplication },
+        } as any;
+        const module = new ModuleReplicator(core);
+
+        await module.cleaned(true);
+
+        expect(runBoundedRemoteActivity).toHaveBeenCalledWith(expect.any(Function), {
+            label: "database-cleanup",
+        });
+        expect(openReplication).toHaveBeenCalledOnce();
+        expect(openReplication.mock.invocationCallOrder[0]).toBeLessThan(activityFinished.mock.invocationCallOrder[0]);
+        expect(chunkMocks.balanceChunkPurgedDBs).toHaveBeenCalledOnce();
     });
 });

--- a/src/modules/core/ModuleReplicatorCouchDB.ts
+++ b/src/modules/core/ModuleReplicatorCouchDB.ts
@@ -28,7 +28,15 @@ export class ModuleReplicatorCouchDB extends AbstractModule {
                 fireAndForget(async () => {
                     const canReplicate = await this.services.replication.isReplicationReady(false);
                     if (!canReplicate) return;
-                    void this.core.replicator.openReplication(this.settings, continuous, false, false);
+                    const openReplication = () =>
+                        this.core.replicator.openReplication(this.settings, continuous, false, false);
+                    if (continuous) {
+                        void openReplication();
+                    } else {
+                        await this.services.replicator.runBoundedRemoteActivity(openReplication, {
+                            label: "replication",
+                        });
+                    }
                 });
             }
         }

--- a/src/modules/core/ModuleReplicatorCouchDB.unit.spec.ts
+++ b/src/modules/core/ModuleReplicatorCouchDB.unit.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import { ModuleReplicatorCouchDB } from "./ModuleReplicatorCouchDB.ts";
+
+function createModule(settings: { liveSync: boolean; syncOnStart: boolean }, isReplicationReady = true) {
+    const openReplication = vi.fn(async () => true);
+    const runBoundedRemoteActivity = vi.fn(async (task: () => unknown) => await task());
+    const services = {
+        API: {
+            addLog: vi.fn(),
+            addCommand: vi.fn(),
+            registerWindow: vi.fn(),
+            addRibbonIcon: vi.fn(),
+            registerProtocolHandler: vi.fn(),
+        },
+        appLifecycle: {
+            isSuspended: vi.fn(() => false),
+            isReady: vi.fn(() => true),
+        },
+        replication: {
+            isReplicationReady: vi.fn(async () => isReplicationReady),
+        },
+        replicator: {
+            runBoundedRemoteActivity,
+        },
+        setting: {
+            saveSettingData: vi.fn(async () => undefined),
+        },
+    };
+    const core = {
+        _services: services,
+        services,
+        settings: {
+            remoteType: "",
+            ...settings,
+        },
+        replicator: { openReplication },
+    } as any;
+    return {
+        module: new ModuleReplicatorCouchDB(core),
+        openReplication,
+        runBoundedRemoteActivity,
+    };
+}
+
+describe("ModuleReplicatorCouchDB resume replication activity", () => {
+    it("runs start-up one-shot replication through bounded remote activity", async () => {
+        const { module, openReplication, runBoundedRemoteActivity } = createModule({
+            liveSync: false,
+            syncOnStart: true,
+        });
+
+        await module._everyAfterResumeProcess();
+
+        await vi.waitFor(() => expect(openReplication).toHaveBeenCalledOnce());
+        expect(runBoundedRemoteActivity).toHaveBeenCalledWith(expect.any(Function), {
+            label: "replication",
+        });
+        expect(openReplication).toHaveBeenCalledWith(expect.any(Object), false, false, false);
+    });
+
+    it("does not treat continuous replication as bounded activity", async () => {
+        const { module, openReplication, runBoundedRemoteActivity } = createModule({
+            liveSync: true,
+            syncOnStart: false,
+        });
+
+        await module._everyAfterResumeProcess();
+
+        await vi.waitFor(() => expect(openReplication).toHaveBeenCalledOnce());
+        expect(runBoundedRemoteActivity).not.toHaveBeenCalled();
+        expect(openReplication).toHaveBeenCalledWith(expect.any(Object), true, false, false);
+    });
+
+    it("does not start a one-shot activity when start-up readiness fails", async () => {
+        const { module, openReplication, runBoundedRemoteActivity } = createModule(
+            {
+                liveSync: false,
+                syncOnStart: true,
+            },
+            false
+        );
+
+        await module._everyAfterResumeProcess();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(runBoundedRemoteActivity).not.toHaveBeenCalled();
+        expect(openReplication).not.toHaveBeenCalled();
+    });
+});

--- a/src/modules/essentialObsidian/ModuleObsidianEvents.ts
+++ b/src/modules/essentialObsidian/ModuleObsidianEvents.ts
@@ -99,6 +99,54 @@ export class ModuleObsidianEvents extends AbstractObsidianModule {
 
     hasFocus = true;
     isLastHidden = false;
+    private boundedRemoteActivityEndHandler?: (value: { readonly value: number }) => unknown;
+    private deferredBoundedLifecycle?: "suspend-if-hidden" | "restart-continuous-if-visible";
+
+    private keepReplicationActiveInBackground() {
+        return (
+            this.settings.keepReplicationActiveInBackground &&
+            (this.settings.liveSync || this.settings.periodicReplication) &&
+            !this.services.API.isMobile()
+        );
+    }
+
+    private async applyDeferredBoundedActivityLifecycle() {
+        const count = this.services.replicator.boundedRemoteActivityCount;
+        if (count.value !== 0) {
+            this.deferLifecycleUntilBoundedRemoteActivityEnds();
+            return;
+        }
+        const deferredLifecycle = this.deferredBoundedLifecycle;
+        this.deferredBoundedLifecycle = undefined;
+        const keepActiveInBackground = this.keepReplicationActiveInBackground();
+        if (deferredLifecycle === "suspend-if-hidden" && activeWindow.document.hidden) {
+            if (!keepActiveInBackground) await this.services.appLifecycle.onSuspending();
+            return;
+        }
+        if (
+            deferredLifecycle === "restart-continuous-if-visible" &&
+            !activeWindow.document.hidden &&
+            keepActiveInBackground &&
+            this.settings.liveSync
+        ) {
+            await this.services.appLifecycle.onSuspending();
+            await this.services.appLifecycle.onResuming();
+            await this.services.appLifecycle.onResumed();
+        }
+    }
+
+    private deferLifecycleUntilBoundedRemoteActivityEnds() {
+        if (this.boundedRemoteActivityEndHandler) return;
+        const count = this.services.replicator.boundedRemoteActivityCount;
+        const handler = (value: { readonly value: number }) => {
+            if (value.value !== 0) return;
+            count.offChanged(handler);
+            this.boundedRemoteActivityEndHandler = undefined;
+            fireAndForget(() => this.applyDeferredBoundedActivityLifecycle());
+        };
+        this.boundedRemoteActivityEndHandler = handler;
+        count.onChanged(handler);
+    }
 
     setHasFocus(hasFocus: boolean) {
         this.hasFocus = hasFocus;
@@ -122,7 +170,19 @@ export class ModuleObsidianEvents extends AbstractObsidianModule {
     }
 
     async watchWindowVisibilityAsync() {
-        if (this.settings.suspendFileWatching) return;
+        if (this.settings.suspendFileWatching) {
+            if (
+                this.settings.isConfigured &&
+                this.services.appLifecycle.isReady() &&
+                this.services.replicator.boundedRemoteActivityCount.value > 0
+            ) {
+                const isHidden = activeWindow.document.hidden;
+                this.isLastHidden = isHidden;
+                this.deferredBoundedLifecycle = isHidden ? "suspend-if-hidden" : undefined;
+                this.deferLifecycleUntilBoundedRemoteActivityEnds();
+            }
+            return;
+        }
         if (!this.settings.isConfigured) return;
         if (!this.services.appLifecycle.isReady()) return;
 
@@ -135,6 +195,13 @@ export class ModuleObsidianEvents extends AbstractObsidianModule {
         if (this.isLastHidden === isHidden) {
             return;
         }
+
+        const boundedRemoteActivityInProgress = this.services.replicator.boundedRemoteActivityCount.value > 0;
+        if (!isHidden && boundedRemoteActivityInProgress && this.deferredBoundedLifecycle === "suspend-if-hidden") {
+            this.isLastHidden = false;
+            this.deferredBoundedLifecycle = undefined;
+            return;
+        }
         this.isLastHidden = isHidden;
 
         await this.services.fileProcessing.commitPendingFileEvents();
@@ -144,16 +211,23 @@ export class ModuleObsidianEvents extends AbstractObsidianModule {
         // modes (LiveSync's continuous replication and Periodic's timer both stall otherwise);
         // becoming visible reopens normally, and for LiveSync additionally forces a teardown first
         // (see the resume branch) so a stalled continuous channel is always replaced.
-        const keepActiveInBackground =
-            this.settings.keepReplicationActiveInBackground &&
-            (this.settings.liveSync || this.settings.periodicReplication) &&
-            !this.services.API.isMobile();
+        const keepActiveInBackground = this.keepReplicationActiveInBackground();
 
         if (isHidden) {
-            if (!keepActiveInBackground) await this.services.appLifecycle.onSuspending();
+            if (boundedRemoteActivityInProgress && !keepActiveInBackground) {
+                this.deferredBoundedLifecycle = "suspend-if-hidden";
+                this.deferLifecycleUntilBoundedRemoteActivityEnds();
+            } else if (!keepActiveInBackground) {
+                await this.services.appLifecycle.onSuspending();
+            }
         } else {
             // suspend all temporary.
             if (this.services.appLifecycle.isSuspended()) return;
+            if (boundedRemoteActivityInProgress && keepActiveInBackground && this.settings.liveSync) {
+                this.deferredBoundedLifecycle = "restart-continuous-if-visible";
+                this.deferLifecycleUntilBoundedRemoteActivityEnds();
+                return;
+            }
             // Only the continuous (LiveSync) channel can go stalled-but-not-terminated: PouchDB
             // emits paused/retry while the replicator keeps its AbortController set, so the reopen
             // below would no-op on exactly the channel that needs replacing. Force a teardown first

--- a/src/modules/essentialObsidian/ModuleObsidianEvents.unit.spec.ts
+++ b/src/modules/essentialObsidian/ModuleObsidianEvents.unit.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 
 import { ModuleObsidianEvents } from "./ModuleObsidianEvents";
 import { DEFAULT_SETTINGS, REMOTE_COUCHDB } from "@lib/common/types";
+import { reactiveSource } from "octagonal-wheels/dataobject/reactive";
 
 type SetupOptions = {
     settings?: Partial<typeof DEFAULT_SETTINGS>;
@@ -22,6 +23,7 @@ function setup(opts: SetupOptions) {
         onResumed: vi.fn(async () => true),
     };
     const fileProcessing = { commitPendingFileEvents: vi.fn(async () => true) };
+    const boundedRemoteActivityCount = reactiveSource(0);
 
     const core = {
         _services: {
@@ -36,6 +38,7 @@ function setup(opts: SetupOptions) {
             setting: { saveSettingData: vi.fn(async () => undefined) },
             appLifecycle,
             fileProcessing,
+            replicator: { boundedRemoteActivityCount },
         },
         settings: {
             ...DEFAULT_SETTINGS,
@@ -53,7 +56,7 @@ function setup(opts: SetupOptions) {
     // The handler reads `activeWindow.document.hidden`.
     (globalThis as any).activeWindow = { document: { hidden: opts.hidden } };
 
-    return { module, appLifecycle, fileProcessing };
+    return { module, appLifecycle, fileProcessing, boundedRemoteActivityCount };
 }
 
 describe("watchWindowVisibilityAsync — keepReplicationActiveInBackground", () => {
@@ -81,6 +84,106 @@ describe("watchWindowVisibilityAsync — keepReplicationActiveInBackground", () 
         expect(appLifecycle.onSuspending).toHaveBeenCalledTimes(1);
     });
 
+    it("defers desktop suspension while bounded remote activity is running", async () => {
+        const { module, appLifecycle, boundedRemoteActivityCount } = setup({
+            settings: { keepReplicationActiveInBackground: false, liveSync: false },
+            hidden: true,
+        });
+        boundedRemoteActivityCount.value = 1;
+
+        await module.watchWindowVisibilityAsync();
+
+        expect(appLifecycle.onSuspending).not.toHaveBeenCalled();
+    });
+
+    it("suspends a hidden desktop window after the final bounded remote activity ends", async () => {
+        const { module, appLifecycle, boundedRemoteActivityCount } = setup({
+            settings: { keepReplicationActiveInBackground: false, liveSync: false },
+            hidden: true,
+        });
+        boundedRemoteActivityCount.value = 1;
+        await module.watchWindowVisibilityAsync();
+
+        boundedRemoteActivityCount.value = 0;
+
+        await vi.waitFor(() => expect(appLifecycle.onSuspending).toHaveBeenCalledTimes(1));
+    });
+
+    it("defers mobile suspension while bounded remote activity is running", async () => {
+        const { module, appLifecycle, boundedRemoteActivityCount } = setup({
+            settings: { keepReplicationActiveInBackground: false, liveSync: false },
+            hidden: true,
+            isMobile: true,
+        });
+        boundedRemoteActivityCount.value = 1;
+
+        await module.watchWindowVisibilityAsync();
+
+        expect(appLifecycle.onSuspending).not.toHaveBeenCalled();
+
+        boundedRemoteActivityCount.value = 0;
+
+        await vi.waitFor(() => expect(appLifecycle.onSuspending).toHaveBeenCalledTimes(1));
+    });
+
+    it("records deferred suspension while rebuild file watching is suspended", async () => {
+        const { module, appLifecycle, boundedRemoteActivityCount, fileProcessing } = setup({
+            settings: { suspendFileWatching: true },
+            hidden: true,
+        });
+        boundedRemoteActivityCount.value = 1;
+
+        await module.watchWindowVisibilityAsync();
+
+        expect(appLifecycle.onSuspending).not.toHaveBeenCalled();
+        expect(fileProcessing.commitPendingFileEvents).not.toHaveBeenCalled();
+
+        boundedRemoteActivityCount.value = 0;
+
+        await vi.waitFor(() => expect(appLifecycle.onSuspending).toHaveBeenCalledTimes(1));
+    });
+
+    it("resumes after a hidden rebuild finishes and the window becomes visible", async () => {
+        const { module, appLifecycle, boundedRemoteActivityCount } = setup({
+            settings: { suspendFileWatching: true },
+            hidden: true,
+        });
+        boundedRemoteActivityCount.value = 1;
+
+        await module.watchWindowVisibilityAsync();
+        boundedRemoteActivityCount.value = 0;
+        await vi.waitFor(() => expect(appLifecycle.onSuspending).toHaveBeenCalledTimes(1));
+
+        (module.settings as typeof DEFAULT_SETTINGS).suspendFileWatching = false;
+        (globalThis as any).activeWindow.document.hidden = false;
+        await module.watchWindowVisibilityAsync();
+
+        expect(appLifecycle.onResuming).toHaveBeenCalledTimes(1);
+        expect(appLifecycle.onResumed).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not resume when the window becomes visible before deferred suspension runs", async () => {
+        const { module, appLifecycle, boundedRemoteActivityCount } = setup({
+            settings: { keepReplicationActiveInBackground: false, liveSync: false },
+            hidden: true,
+        });
+        boundedRemoteActivityCount.value = 1;
+        await module.watchWindowVisibilityAsync();
+
+        (globalThis as any).activeWindow.document.hidden = false;
+        await module.watchWindowVisibilityAsync();
+
+        expect(appLifecycle.onSuspending).not.toHaveBeenCalled();
+        expect(appLifecycle.onResuming).not.toHaveBeenCalled();
+        expect(appLifecycle.onResumed).not.toHaveBeenCalled();
+
+        boundedRemoteActivityCount.value = 0;
+        await Promise.resolve();
+        expect(appLifecycle.onSuspending).not.toHaveBeenCalled();
+        expect(appLifecycle.onResuming).not.toHaveBeenCalled();
+        expect(appLifecycle.onResumed).not.toHaveBeenCalled();
+    });
+
     it("forces onSuspending before the resume on becoming visible when enabled (LiveSync teardown)", async () => {
         const { module, appLifecycle } = setup({
             settings: { keepReplicationActiveInBackground: true, liveSync: true },
@@ -94,6 +197,30 @@ describe("watchWindowVisibilityAsync — keepReplicationActiveInBackground", () 
         expect(appLifecycle.onSuspending).toHaveBeenCalledTimes(1);
         expect(appLifecycle.onResuming).toHaveBeenCalledTimes(1);
         expect(appLifecycle.onResumed).toHaveBeenCalledTimes(1);
+        expect(appLifecycle.onSuspending.mock.invocationCallOrder[0]).toBeLessThan(
+            appLifecycle.onResuming.mock.invocationCallOrder[0]
+        );
+    });
+
+    it("defers the LiveSync teardown on becoming visible until bounded remote activity ends", async () => {
+        const { module, appLifecycle, boundedRemoteActivityCount } = setup({
+            settings: { keepReplicationActiveInBackground: true, liveSync: true },
+            hidden: false,
+            isLastHidden: true,
+        });
+        boundedRemoteActivityCount.value = 1;
+
+        await module.watchWindowVisibilityAsync();
+
+        expect(appLifecycle.onSuspending).not.toHaveBeenCalled();
+        expect(appLifecycle.onResuming).not.toHaveBeenCalled();
+        expect(appLifecycle.onResumed).not.toHaveBeenCalled();
+
+        boundedRemoteActivityCount.value = 0;
+
+        await vi.waitFor(() => expect(appLifecycle.onResumed).toHaveBeenCalledTimes(1));
+        expect(appLifecycle.onSuspending).toHaveBeenCalledTimes(1);
+        expect(appLifecycle.onResuming).toHaveBeenCalledTimes(1);
         expect(appLifecycle.onSuspending.mock.invocationCallOrder[0]).toBeLessThan(
             appLifecycle.onResuming.mock.invocationCallOrder[0]
         );

--- a/src/modules/features/ModuleLog.ts
+++ b/src/modules/features/ModuleLog.ts
@@ -31,6 +31,7 @@ import { LogPaneView, VIEW_TYPE_LOG } from "./Log/LogPaneView.ts";
 import { serialized } from "octagonal-wheels/concurrency/lock";
 import { $msg } from "@lib/common/i18n.ts";
 import { P2PLogCollector } from "@lib/replication/trystero/P2PLogCollector.ts";
+import { hasRemoteActivity } from "./RemoteActivityStatus.ts";
 import type { LiveSyncCore } from "@/main.ts";
 import { LiveSyncError } from "@lib/common/LSError.ts";
 import { isValidPath } from "@/common/utils.ts";
@@ -152,8 +153,13 @@ export class ModuleLog extends AbstractObsidianModule {
         const queueCountLabel = () => queueCountLabelX.value;
 
         const requestingStatLabel = computed(() => {
-            const diff = this.services.API.requestCount.value - this.services.API.responseCount.value;
-            return diff != 0 ? "📲 " : "";
+            return hasRemoteActivity(
+                this.services.API.requestCount.value,
+                this.services.API.responseCount.value,
+                this.services.replicator.boundedRemoteActivityCount.value
+            )
+                ? "📲 "
+                : "";
         });
 
         const replicationStatLabel = computed(() => {

--- a/src/modules/features/ModuleLog.unit.spec.ts
+++ b/src/modules/features/ModuleLog.unit.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { hasRemoteActivity } from "./RemoteActivityStatus.ts";
+
+describe("hasRemoteActivity", () => {
+    it("preserves the existing HTTP request balance signal", () => {
+        expect(hasRemoteActivity(2, 1, 0)).toBe(true);
+        expect(hasRemoteActivity(2, 2, 0)).toBe(false);
+    });
+
+    it("reports bounded remote activity without an HTTP request imbalance", () => {
+        expect(hasRemoteActivity(2, 2, 1)).toBe(true);
+    });
+});

--- a/src/modules/features/RemoteActivityStatus.ts
+++ b/src/modules/features/RemoteActivityStatus.ts
@@ -1,0 +1,4 @@
+/** Returns whether the status UI should report HTTP traffic or a finite remote operation in progress. */
+export function hasRemoteActivity(requestCount: number, responseCount: number, boundedRemoteActivityCount: number) {
+    return requestCount - responseCount !== 0 || boundedRemoteActivityCount !== 0;
+}

--- a/src/modules/services/ObsidianServiceHub.ts
+++ b/src/modules/services/ObsidianServiceHub.ts
@@ -22,6 +22,7 @@ import { ObsidianAppLifecycleService } from "./ObsidianAppLifecycleService";
 import { ObsidianPathService } from "./ObsidianPathService";
 import { ObsidianVaultService } from "./ObsidianVaultService";
 import { ObsidianUIService } from "./ObsidianUIService";
+import { createScreenWakeLockManager } from "octagonal-wheels/browser/wakeLock";
 
 // InjectableServiceHub
 
@@ -55,6 +56,11 @@ export class ObsidianServiceHub extends InjectableServiceHub<ObsidianServiceCont
         const path = new ObsidianPathService(context, {
             settingService: setting,
         });
+        const screenWakeLock = createScreenWakeLockManager();
+        appLifecycle.onUnload.addHandler(async () => {
+            await screenWakeLock.dispose();
+            return true;
+        });
         const database = new ObsidianDatabaseService(context, {
             path: path,
             vault: vault,
@@ -74,6 +80,7 @@ export class ObsidianServiceHub extends InjectableServiceHub<ObsidianServiceCont
             settingService: setting,
             appLifecycleService: appLifecycle,
             databaseEventService: databaseEvents,
+            activityRunner: screenWakeLock,
         });
         const replication = new ObsidianReplicationService(context, {
             APIService: API,

--- a/src/serviceFeatures/useP2PReplicatorUI.ts
+++ b/src/serviceFeatures/useP2PReplicatorUI.ts
@@ -83,6 +83,15 @@ export function useP2PReplicatorUI(
         }
         return api.showWindow(VIEW_TYPE_P2P_SERVER_STATUS);
     };
+    const runOpenReplication = () => {
+        const activeReplicator = replicator.replicator;
+        if (!activeReplicator) return;
+        const settings = host.services.setting.currentSettings();
+        void host.services.replicator.runBoundedRemoteActivity(
+            () => activeReplicator.openReplication(settings, false, true, false),
+            { label: "replication" }
+        );
+    };
     api.registerWindow(viewType, factory);
     api.registerWindow(VIEW_TYPE_P2P_SERVER_STATUS, statusFactory);
 
@@ -115,7 +124,7 @@ export function useP2PReplicatorUI(
                     if (settings.remoteType == REMOTE_P2P) return false;
                     return replicator.replicator?.server?.isServing ?? false;
                 }
-                void replicator.replicator?.openReplication(settings, false, true, false);
+                runOpenReplication();
             },
         });
         host.services.API.addCommand({
@@ -127,7 +136,7 @@ export function useP2PReplicatorUI(
                     if (settings.remoteType == REMOTE_P2P) return false;
                     return replicator.replicator?.server?.isServing ?? false;
                 }
-                void replicator.replicator?.openReplication(settings, false, true, false);
+                runOpenReplication();
             },
         });
 

--- a/src/serviceFeatures/useP2PReplicatorUI.unit.spec.ts
+++ b/src/serviceFeatures/useP2PReplicatorUI.unit.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/features/P2PSync/P2PReplicator/P2PReplicatorPaneView", () => ({
+    P2PReplicatorPaneView: class {},
+    VIEW_TYPE_P2P: "p2p",
+}));
+vi.mock("@/features/P2PSync/P2PReplicator/P2PServerStatusPaneView", () => ({
+    P2PServerStatusPaneView: class {},
+    VIEW_TYPE_P2P_SERVER_STATUS: "p2p-status",
+}));
+
+import { useP2PReplicatorUI } from "./useP2PReplicatorUI";
+
+describe("useP2PReplicatorUI commands", () => {
+    it("runs a direct modal P2P replication command through the shared activity boundary", async () => {
+        const commands: Array<{ id: string; checkCallback?: (isChecking: boolean) => unknown }> = [];
+        let initialise: (() => Promise<unknown>) | undefined;
+        const openReplication = vi.fn(async () => true);
+        const runBoundedRemoteActivity = vi.fn(async (task: () => unknown) => await task());
+        const host = {
+            services: {
+                API: {
+                    showWindow: vi.fn(async () => undefined),
+                    registerWindow: vi.fn(),
+                    addCommand: vi.fn((command) => commands.push(command)),
+                    addRibbonIcon: vi.fn(),
+                    getPlatform: vi.fn(() => "obsidian"),
+                },
+                appLifecycle: {
+                    onInitialise: {
+                        addHandler: vi.fn((handler) => {
+                            initialise = handler;
+                        }),
+                    },
+                    onLayoutReady: { addHandler: vi.fn() },
+                },
+                setting: { currentSettings: vi.fn(() => ({ remoteType: "COUCHDB" })) },
+                replicator: { runBoundedRemoteActivity },
+            },
+        } as any;
+        const p2p = {
+            replicator: {
+                server: { isServing: true },
+                openReplication,
+                replicateFromCommand: vi.fn(),
+            },
+        } as any;
+
+        useP2PReplicatorUI(host, {} as any, p2p);
+        await initialise?.();
+        commands.find((command) => command.id === "replicate-now-by-p2p")?.checkCallback?.(false);
+
+        await vi.waitFor(() => expect(openReplication).toHaveBeenCalledOnce());
+        expect(runBoundedRemoteActivity).toHaveBeenCalledWith(expect.any(Function), {
+            label: "replication",
+        });
+    });
+});

--- a/updates.md
+++ b/updates.md
@@ -8,6 +8,12 @@ The head note of 0.25 is now in [updates_old.md](https://github.com/vrtmrz/obsid
 ### Fixed
 
 - Refresh the remote Security Seed before each replication, preventing a client that remained open during a remote database rebuild from uploading data encrypted with the previous seed (#1018).
+- The P2P **Start Sync & Close** action now waits for synchronisation to settle before closing the dialogue, avoiding premature release of screen-awake protection while work remains in flight.
+
+### Improved
+
+- On supported mobile and desktop devices, one-shot replication, P2P peer discovery and selection, database rebuild and fetch operations, and remote chunk fetching now keep the screen awake for the duration of these finite remote operations. LiveSync also postpones its normal visibility suspension until the operation finishes, although platform restrictions may still pause or terminate background work.
+- The 📲 status-bar indicator now covers finite remote work as well as HTTP requests. It reports broad remote activity, such as P2P peer selection and remote chunk fetching, rather than an exact physical connection count.
 
 ## 0.25.81
 


### PR DESCRIPTION
## Summary

- keep supported mobile and desktop screens awake during finite remote work, including one-shot replication, P2P peer discovery and selection, rebuilds, fetches, and remote chunk fetching;
- defer LiveSync's normal visibility suspension until the final bounded operation settles;
- extend the 📲 status-bar indicator from HTTP requests to broader logical remote activity;
- make **Start Sync & Close** wait for the active synchronisation before closing; and
- document the lifecycle contract, ownership, platform limitations, and verification in an ADR.

## Why

Finite remote work enters LiveSync through several paths. The existing HTTP request counters did not cover P2P transfers, peer waiting, rebuild operations, or history-triggered remote chunk fetching. Visibility changes could therefore close the active replicator while a finite operation was still able to finish, and the status indicator could disappear while meaningful remote work remained in progress.

This change gives those operations one reference-counted boundary. The Obsidian host injects the Fancy Kit screen wake-lock manager, while `ReplicatorService` owns the logical activity count and lifecycle decision. This keeps platform policy out of commonlib and allows CLI and Webapp consumers to retain direct execution without browser dependencies.

## User-visible behaviour

- Finite remote operations request best-effort screen-awake protection automatically on supported mobile and desktop devices.
- LiveSync postpones its own visibility suspension while such an operation is active, then suspends if the application is still hidden when the final operation finishes.
- Platform restrictions may still pause or terminate hidden work; this is not privileged background execution.
- Continuous and periodic replication remain governed by the existing desktop-only **Keep replication active in the background** setting.
- The 📲 icon now means broad remote activity, not an exact physical connection count.

## Dependency and review checklist

- [x] Merge [livesync-commonlib #70](https://github.com/vrtmrz/livesync-commonlib/pull/70).
- [x] Update `src/lib` to merged commonlib commit `a58965f` and regenerate `_types` with the matching commit stamp.
- [x] Use `octagonal-wheels` 0.1.51 for the tested screen wake-lock manager.
- [x] Keep non-English README and settings translations unchanged for separate language review.

## Verification

- Added 41 regression test cases across LiveSync and commonlib, without removing existing cases.
- Confirmed the new automatic-P2P regression tests fail against the previous implementation because the activity boundary is not entered.
- Passed 1,422 unit tests after rebasing onto the Security Seed refresh from PR #1019.
- Passed `npm run check`, including TypeScript, lint, Svelte checking, and compatibility checks. Svelte reported the existing 22 warnings and no errors.
- Passed the production build and the post-build iOS 15 compatibility check.
- Confirmed generated declarations reference merged commonlib commit `a58965f`.

The detailed operation boundaries and non-goals are recorded in `docs/adr/2026_07_bounded_remote_activity.md`.
