### PR TITLE
Fix Deno setup for release preparation

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -45,6 +45,11 @@ jobs:
                   node-version: "24.x"
                   cache: npm
 
+            - name: Use Deno
+              uses: denoland/setup-deno@v2
+              with:
+                  deno-version: v2.x
+
             - name: Install dependencies
               run: npm ci
 

--- a/utils/release-process.unit.spec.ts
+++ b/utils/release-process.unit.spec.ts
@@ -113,6 +113,15 @@ describe("release workflow", () => {
         expect(workflow).toMatch(/git add[^\n]*_types/);
     });
 
+    it("installs Deno before post-processing fallback type definitions", () => {
+        const workflow = readFileSync(prepareReleaseWorkflow, "utf8");
+        const setupDeno = workflow.indexOf("denoland/setup-deno@v2");
+        const buildTypes = workflow.indexOf("npm run build:lib:types");
+
+        expect(setupDeno).toBeGreaterThan(-1);
+        expect(setupDeno).toBeLessThan(buildTypes);
+    });
+
     it("keeps the release PR in draft until BRAT validation", () => {
         const workflow = readFileSync(prepareReleaseWorkflow, "utf8");
 


### PR DESCRIPTION
## Summary

- install Deno explicitly in the `Prepare Release PR` workflow before fallback type definitions are generated
- add a release-workflow regression test that keeps Deno setup ahead of type generation

## Root cause

Release preparation runs a Deno post-processor after TypeScript declaration generation, but the workflow relied on Deno being present in the runner image. The runner no longer provided the `deno` command, so release preparation stopped before it could create the release branch or draft pull request.

## Impact

This restores deterministic release preparation without changing plug-in runtime behaviour.

## Verification

- focused release-workflow regression test passed
- affected files passed Prettier validation
- `git diff --check` passed
- fallback type generation completed locally with Deno available
