### PR TITLE
Keep replicated document application active

### DIFF
--- a/docs/adr/2026_07_bounded_remote_activity.md
+++ b/docs/adr/2026_07_bounded_remote_activity.md
@@ -37,9 +37,9 @@ The Obsidian host injects the screen wake-lock manager from the `octagonal-wheel
 
 Finite replication enters both counts only after readiness checks have succeeded and leaves them after `openReplication(..., continuous: false, ...)` settles. A successful completion has reached the latest sequence in that operation's scope and is therefore an authoritative quiescence boundary for chunk retrieval. A failed operation does not prove latest state, but can no longer deliver documents from that attempt. Failure handling runs afterwards so a mismatch or recovery dialogue does not retain the activity. This includes the direct start-up synchronisation path as well as manual, event-driven, and periodic calls through `ReplicationService`. The unbounded continuous channel does not enter either boundary, but its finite initial pull-only catch-up does; the one-shot parameter fallback chain remains inside that boundary.
 
-Delivery into the local database and application to the Obsidian Vault are deliberately separate lifetimes. A mobile device can have only a short opportunity to obtain remote data, while applying a large downloaded batch to the Vault is durable, offline-capable work which can continue or resume later. The replication-result queue and its recovery snapshot therefore remain outside `boundedRemoteActivityCount`. Finite remote activity ends when the transfer operation settles, even when the `📥` queue still contains documents awaiting Vault application.
+Delivery into the local database and application to the Obsidian Vault are deliberately separate lifetimes. Finite remote activity ends when the transfer operation settles, even when the `📥` queue still contains documents awaiting Vault application. The Obsidian host tracks that queue through a separate `boundedLocalApplicationActivityCount`, so local Vault writes do not increment either remote-activity count or keep the `📲` indicator visible.
 
-This separation also keeps the activity indicators truthful: `📲` describes a finite remote operation and must not remain active solely because local Vault writes are pending. The existing replication-result count continues to describe that local queue. If a future feature offers screen-awake protection while applying downloaded documents, it must use a separately typed local-application activity or power-policy boundary, preserve the current behaviour by default, and avoid incrementing either remote-activity count.
+Applying downloaded document changes enters one local-application boundary from the first queued document until the queue and its in-progress set are both empty. The final empty recovery snapshot is attempted before the boundary settles; snapshot failure is logged and still releases the boundary. Additional batches share the existing boundary. Suspending replication-result processing releases it, and resuming reacquires it while work remains. The same host activity runner supplies best-effort Wake Lock protection, while the visibility lifecycle waits for both remote and local bounded activity to finish.
 
 Manual P2P commands which bypass `ReplicationService` enter the broad boundary. Direct P2P pull and push entry points are therefore both protected as finite remote work, covering the Obsidian panes, CLI, and Webapp. A pull or bidirectional synchronisation also enters the narrower finite-replication boundary because it can place documents in the local database. A push-only request remains broad-only: it cannot satisfy a local missing-chunk read and must not present itself as a delivery source. Automatic synchronisation on peer discovery, a pull requested by a remote peer, and a watched pull following a peer progress notification enter both boundaries because each can deliver local documents. A normal P2P peer-selection dialogue represents one broad finite session: it remains inside the boundary while waiting for a peer and while the person may perform repeated synchronisations, then settles when the dialogue closes and any in-flight synchronisation has finished. Closing without synchronising returns a failed result and releases the boundary. The 'Start Sync & Close' action completes its synchronisation before closing. This deliberately protects peer discovery and selection, because display sleep can interrupt discovery or connection establishment and require the person to start detection again. It may therefore retain a Wake Lock longer than the network transfer alone. A transfer performed inside that session temporarily adds a nested activity; the count remains a logical-operation count rather than a connection total.
 
@@ -76,6 +76,8 @@ P2P does not yet contribute to the physical-request count because it does not ha
 
 The platform activity runner remains injected. Common library and headless consumers can omit it while retaining the same bounded activity count and operation semantics.
 
+The Obsidian-specific `ObsidianReplicatorService` owns `boundedLocalApplicationActivityCount` and reuses the injected activity runner. It is deliberately absent from the common service contract: CLI and Webapp processing continue directly, while the Obsidian host uses the count for Wake Lock and visibility-lifecycle policy without changing remote-operation reporting.
+
 ## Non-Goals
 
 - Do not count continuous replication as a bounded activity.
@@ -85,11 +87,11 @@ The platform activity runner remains injected. Common library and headless consu
 - Do not guarantee protection against operating-system suspension, closing a laptop lid, forced termination, network loss, or a user-initiated sleep action.
 - Do not add a lifecycle timeout which would abort an unusually slow rebuild. A genuinely stalled operation may postpone LiveSync's visibility suspension until it settles, but the platform may still suspend or terminate background work.
 - Do not broaden `keepReplicationActiveInBackground`; it remains an opt-in desktop policy for continuous and periodic operation after finite work has ended.
-- Do not include offline scans, unrelated local storage reflection, or the durable replication-result queue in this boundary. They are offline-capable and require a separate decision if activity reporting or power policy is added later.
+- Do not include offline scans, unrelated local storage reflection, or the durable replication-result queue in either remote-activity count. The queue uses its separate local-application boundary.
 
 ## Verification
 
-Before changing the transfer/application separation, add a deterministic regression scenario which leaves downloaded documents queued after finite transfer settles, verifies that remote activity has ended, persists the queued state, and resumes Vault application after suspension or restart. An optional local-application Wake Lock feature requires its own enabled and disabled cases; existing remote-operation E2E is not evidence for that separate policy.
+Before changing the transfer/application separation, keep deterministic coverage which leaves downloaded documents queued after finite transfer settles, verifies that remote activity has ended, and retains the separate local-application boundary until Vault application and the final recovery snapshot settle.
 
 Unit tests cover:
 
@@ -106,6 +108,8 @@ Unit tests cover:
 - remote chunk fetching remaining inside the shared boundary from synchronous queue acceptance through local persistence and terminal notification;
 - missing-chunk waiters rechecking local storage when observed per-identifier claims and finite replication have settled;
 - the finite-replication count excluding other bounded work;
+- replicated document application sharing one local boundary, settling after the final recovery snapshot, and releasing around processing suspension;
+- local application activity leaving both remote-activity counts unchanged;
 - standard, fast, remote, and combined rebuild activity boundaries;
 - Rebuilder-owned confirmation and completion dialogues remaining outside rebuild activity;
 - fallback from fast fetch avoiding a nested activity boundary;
@@ -125,5 +129,5 @@ The exact Fancy Kit screen wake-lock behaviour is covered by its package and Har
 - One finite activity definition drives Wake Lock, lifecycle protection, and status UI without coupling common library code to Obsidian or browser globals.
 - Callers can observe accurate logical activity even in CLI and Webapp hosts which do not inject a Wake Lock implementation.
 - Rebuild operations now retain Wake Lock and lifecycle protection across their longest interruption-sensitive phases without retaining them for Rebuilder-owned pre-operation or completion dialogues. Post-reset P2P discovery and selection remain protected as an intentional part of completing the rebuild.
-- Downloaded documents may remain in the durable Vault-application queue after remote activity has ended, allowing transfer and offline application to follow different mobile lifetimes without presenting local writes as communication.
+- Downloaded documents may remain in the durable Vault-application queue after remote activity has ended, while a separate local-application boundary retains best-effort Wake Lock and lifecycle protection without presenting local writes as communication.
 - Users can now distinguish the lifetime of a finite remote operation from approximate request activity within it.

--- a/src/modules/core/ReplicateResultProcessor.ts
+++ b/src/modules/core/ReplicateResultProcessor.ts
@@ -24,9 +24,16 @@ import type { ReactiveSource } from "octagonal-wheels/dataobject/reactive_v2";
 import type { LiveSyncBaseCore } from "@/LiveSyncBaseCore";
 import { isNotFoundError } from "@vrtmrz/livesync-commonlib/compat/common/utils.doc";
 import type PouchDB from "pouchdb-core";
+import { promiseWithResolvers, type PromiseWithResolvers } from "octagonal-wheels/promises";
 
 const KV_KEY_REPLICATION_RESULT_PROCESSOR_SNAPSHOT = "replicationResultProcessorSnapshot";
 const REPROCESS_BATCH_SIZE = 100;
+type LocalApplicationActivityOwner = {
+    runBoundedLocalApplicationActivity<T>(
+        task: () => T | PromiseLike<T>,
+        options?: { label?: string }
+    ): Promise<T>;
+};
 type ReplicateResultProcessorState = {
     queued: PouchDB.Core.ExistingDocument<EntryDoc>[];
     processing: PouchDB.Core.ExistingDocument<EntryDoc>[];
@@ -67,9 +74,11 @@ export class ReplicateResultProcessor {
 
     public suspend() {
         this._suspended = true;
+        this.updateProcessingActivity();
     }
     public resume() {
         this._suspended = false;
+        this.updateProcessingActivity();
         fireAndForget(() => this.runProcessQueue());
     }
 
@@ -251,6 +260,40 @@ export class ReplicateResultProcessor {
      */
     private _processingChanges: PouchDB.Core.ExistingDocument<EntryDoc>[] = [];
 
+    private _processingActivity?: Promise<void>;
+    private _processingActivityDone?: PromiseWithResolvers<void>;
+
+    private updateProcessingActivity() {
+        if (this.isSuspended) {
+            this._processingActivityDone?.resolve();
+            return;
+        }
+        const hasPendingDocuments = this._queuedChanges.length > 0 || this._processingChanges.length > 0;
+        if (!hasPendingDocuments) {
+            this._processingActivityDone?.resolve();
+            return;
+        }
+        if (this._processingActivity) return;
+
+        const activityDone = promiseWithResolvers<void>();
+        this._processingActivityDone = activityDone;
+        const activityOwner = this.services.replicator as typeof this.services.replicator &
+            Partial<LocalApplicationActivityOwner>;
+        this._processingActivity = (
+            activityOwner.runBoundedLocalApplicationActivity
+                ? activityOwner.runBoundedLocalApplicationActivity(() => activityDone.promise, {
+                      label: "replicated-document-application",
+                  })
+                : activityDone.promise
+        )
+            .catch((error) => this.logError(error))
+            .finally(() => {
+                if (this._processingActivityDone === activityDone) this._processingActivityDone = undefined;
+                this._processingActivity = undefined;
+                this.updateProcessingActivity();
+            });
+    }
+
     /**
      * Enqueue the given document change for processing.
      * @param doc Document change to enqueue
@@ -278,6 +321,7 @@ export class ReplicateResultProcessor {
         }
         // Enqueue the change
         this._queuedChanges.push(doc);
+        this.updateProcessingActivity();
         this.triggerTakeSnapshot();
         this.triggerProcessQueue();
     }
@@ -385,7 +429,19 @@ export class ReplicateResultProcessor {
         } finally {
             // Remove from processing queue
             this._processingChanges = this._processingChanges.filter((e) => e !== change);
-            this.triggerTakeSnapshot();
+            try {
+                if (this._queuedChanges.length === 0 && this._processingChanges.length === 0) {
+                    try {
+                        await this._takeSnapshot();
+                    } catch (error) {
+                        this.logError(error);
+                    }
+                } else {
+                    this.triggerTakeSnapshot();
+                }
+            } finally {
+                this.updateProcessingActivity();
+            }
         }
     }
 

--- a/src/modules/core/ReplicateResultProcessor.unit.spec.ts
+++ b/src/modules/core/ReplicateResultProcessor.unit.spec.ts
@@ -1,8 +1,67 @@
+import { promiseWithResolvers } from "octagonal-wheels/promises";
+import { reactiveSource } from "octagonal-wheels/dataobject/reactive";
 import { describe, expect, it, vi } from "vitest";
 import type { EntryDoc } from "@vrtmrz/livesync-commonlib/compat/common/types";
 import { ReplicateResultProcessor } from "./ReplicateResultProcessor";
 
-describe("ReplicateResultProcessor target-filter reprocessing", () => {
+function note(id: string): PouchDB.Core.ExistingDocument<EntryDoc> {
+    return {
+        _id: id,
+        _rev: "1-test",
+        path: `${id}.md`,
+        ctime: 1,
+        mtime: 2,
+        size: 1,
+        children: [],
+        datatype: "plain",
+        type: "plain",
+        eden: {},
+    } as unknown as PouchDB.Core.ExistingDocument<EntryDoc>;
+}
+
+type SetupOptions = {
+    processSynchroniseResult?: (entry: unknown) => Promise<void>;
+    setSnapshot?: (key: string, value: unknown) => Promise<unknown>;
+};
+
+function setup(options: SetupOptions = {}) {
+    const processSynchroniseResult = vi.fn(options.processSynchroniseResult ?? (async () => undefined));
+    const setSnapshot = vi.fn(options.setSnapshot ?? (async () => undefined));
+    const runBoundedLocalApplicationActivity = vi.fn(async (task: () => Promise<void>) => await task());
+    const core = {
+        services: {
+            appLifecycle: { isReady: true, isSuspended: () => false },
+            path: { getPath: (entry: { path: string }) => entry.path },
+            replication: {
+                databaseQueueCount: reactiveSource(0),
+                storageApplyingCount: reactiveSource(0),
+                replicationResultCount: reactiveSource(0),
+                processVirtualDocument: vi.fn(async () => false),
+                processOptionalSynchroniseResult: vi.fn(async () => false),
+                processSynchroniseResult,
+            },
+            replicator: { runBoundedLocalApplicationActivity },
+            vault: {
+                isTargetFile: vi.fn(async () => true),
+                isFileSizeTooLarge: vi.fn(() => false),
+                isValidPath: vi.fn(() => true),
+            },
+        },
+        kvDB: { set: setSnapshot },
+        localDatabase: {
+            getRaw: vi.fn(async (id: string) => ({ _id: id, _rev: "1-test" })),
+            getDBEntryFromMeta: vi.fn(async (entry: object) => ({ ...entry, data: "x" })),
+        },
+        replicator: { closeReplication: vi.fn() },
+    };
+    const processor = new ReplicateResultProcessor({
+        core,
+        settings: { maxMTimeForReflectEvents: 0, suspendParseReplicationResult: false },
+    } as never);
+    return { processor, processSynchroniseResult, runBoundedLocalApplicationActivity };
+}
+
+describe("ReplicateResultProcessor", () => {
     it("scans normal-file metadata without loading chunk documents and requeues it", async () => {
         const documents = [
             { _id: "first", _rev: "1-a", type: "plain", path: "first.md" },
@@ -21,5 +80,68 @@ describe("ReplicateResultProcessor target-filter reprocessing", () => {
         expect(findAllNormalDocs).toHaveBeenCalledOnce();
         expect(enqueueAll).toHaveBeenCalledOnce();
         expect(enqueueAll).toHaveBeenCalledWith(documents);
+    });
+
+    it("keeps one local application activity until every replicated document has been applied", async () => {
+        const applying = promiseWithResolvers<void>();
+        let activityFinished = false;
+        const { processor, processSynchroniseResult, runBoundedLocalApplicationActivity } = setup({
+            processSynchroniseResult: async () => applying.promise,
+        });
+        runBoundedLocalApplicationActivity.mockImplementation(async (task: () => Promise<void>) => {
+            await task();
+            activityFinished = true;
+        });
+
+        processor.enqueueAll([note("one"), note("two")]);
+
+        await vi.waitFor(() => expect(processSynchroniseResult).toHaveBeenCalledTimes(2));
+        expect(runBoundedLocalApplicationActivity).toHaveBeenCalledTimes(1);
+        expect(runBoundedLocalApplicationActivity).toHaveBeenCalledWith(expect.any(Function), {
+            label: "replicated-document-application",
+        });
+        expect(activityFinished).toBe(false);
+
+        applying.resolve();
+
+        await vi.waitFor(() => expect(activityFinished).toBe(true));
+    });
+
+    it("settles local application activity when the final recovery snapshot fails", async () => {
+        let activityFinished = false;
+        const { processor, runBoundedLocalApplicationActivity } = setup({
+            setSnapshot: async () => Promise.reject(new Error("snapshot failed")),
+        });
+        runBoundedLocalApplicationActivity.mockImplementation(async (task: () => Promise<void>) => {
+            await task();
+            activityFinished = true;
+        });
+
+        processor.enqueueAll([note("one")]);
+
+        await vi.waitFor(() => expect(activityFinished).toBe(true));
+    });
+
+    it("releases and reacquires local application activity around processing suspension", async () => {
+        const applying = promiseWithResolvers<void>();
+        let completedActivities = 0;
+        const { processor, processSynchroniseResult, runBoundedLocalApplicationActivity } = setup({
+            processSynchroniseResult: async () => applying.promise,
+        });
+        runBoundedLocalApplicationActivity.mockImplementation(async (task: () => Promise<void>) => {
+            await task();
+            completedActivities++;
+        });
+        processor.enqueueAll([note("one")]);
+        await vi.waitFor(() => expect(processSynchroniseResult).toHaveBeenCalledOnce());
+
+        processor.suspend();
+        await vi.waitFor(() => expect(completedActivities).toBe(1));
+
+        processor.resume();
+        await vi.waitFor(() => expect(runBoundedLocalApplicationActivity).toHaveBeenCalledTimes(2));
+
+        applying.resolve();
+        await vi.waitFor(() => expect(completedActivities).toBe(2));
     });
 });

--- a/src/modules/essentialObsidian/ModuleObsidianEvents.ts
+++ b/src/modules/essentialObsidian/ModuleObsidianEvents.ts
@@ -113,8 +113,19 @@ export class ModuleObsidianEvents extends AbstractObsidianModule {
 
     hasFocus = true;
     isLastHidden = false;
-    private boundedRemoteActivityEndHandler?: (value: { readonly value: number }) => unknown;
+    private boundedActivityEndHandler?: (value: { readonly value: number }) => unknown;
     private deferredBoundedLifecycle?: "suspend-if-hidden" | "restart-continuous-if-visible";
+
+    private get boundedActivityCounts(): ReactiveSource<number>[] {
+        const replicator = this.services.replicator as typeof this.services.replicator & {
+            boundedLocalApplicationActivityCount: ReactiveSource<number>;
+        };
+        return [replicator.boundedRemoteActivityCount, replicator.boundedLocalApplicationActivityCount];
+    }
+
+    private hasBoundedActivity() {
+        return this.boundedActivityCounts.some((count) => count.value > 0);
+    }
 
     private keepReplicationActiveInBackground() {
         return (
@@ -125,9 +136,8 @@ export class ModuleObsidianEvents extends AbstractObsidianModule {
     }
 
     private async applyDeferredBoundedActivityLifecycle() {
-        const count = this.services.replicator.boundedRemoteActivityCount;
-        if (count.value !== 0) {
-            this.deferLifecycleUntilBoundedRemoteActivityEnds();
+        if (this.hasBoundedActivity()) {
+            this.deferLifecycleUntilBoundedActivityEnds();
             return;
         }
         const deferredLifecycle = this.deferredBoundedLifecycle;
@@ -149,17 +159,17 @@ export class ModuleObsidianEvents extends AbstractObsidianModule {
         }
     }
 
-    private deferLifecycleUntilBoundedRemoteActivityEnds() {
-        if (this.boundedRemoteActivityEndHandler) return;
-        const count = this.services.replicator.boundedRemoteActivityCount;
-        const handler = (value: { readonly value: number }) => {
-            if (value.value !== 0) return;
-            count.offChanged(handler);
-            this.boundedRemoteActivityEndHandler = undefined;
+    private deferLifecycleUntilBoundedActivityEnds() {
+        if (this.boundedActivityEndHandler) return;
+        const counts = this.boundedActivityCounts;
+        const handler = () => {
+            if (this.hasBoundedActivity()) return;
+            for (const count of counts) count.offChanged(handler);
+            this.boundedActivityEndHandler = undefined;
             fireAndForget(() => this.applyDeferredBoundedActivityLifecycle());
         };
-        this.boundedRemoteActivityEndHandler = handler;
-        count.onChanged(handler);
+        this.boundedActivityEndHandler = handler;
+        for (const count of counts) count.onChanged(handler);
     }
 
     setHasFocus(hasFocus: boolean) {
@@ -188,12 +198,12 @@ export class ModuleObsidianEvents extends AbstractObsidianModule {
             if (
                 this.settings.isConfigured &&
                 this.services.appLifecycle.isReady() &&
-                this.services.replicator.boundedRemoteActivityCount.value > 0
+                this.hasBoundedActivity()
             ) {
                 const isHidden = activeWindow.document.hidden;
                 this.isLastHidden = isHidden;
                 this.deferredBoundedLifecycle = isHidden ? "suspend-if-hidden" : undefined;
-                this.deferLifecycleUntilBoundedRemoteActivityEnds();
+                this.deferLifecycleUntilBoundedActivityEnds();
             }
             return;
         }
@@ -210,8 +220,8 @@ export class ModuleObsidianEvents extends AbstractObsidianModule {
             return;
         }
 
-        const boundedRemoteActivityInProgress = this.services.replicator.boundedRemoteActivityCount.value > 0;
-        if (!isHidden && boundedRemoteActivityInProgress && this.deferredBoundedLifecycle === "suspend-if-hidden") {
+        const boundedActivityInProgress = this.hasBoundedActivity();
+        if (!isHidden && boundedActivityInProgress && this.deferredBoundedLifecycle === "suspend-if-hidden") {
             this.isLastHidden = false;
             this.deferredBoundedLifecycle = undefined;
             return;
@@ -228,18 +238,18 @@ export class ModuleObsidianEvents extends AbstractObsidianModule {
         const keepActiveInBackground = this.keepReplicationActiveInBackground();
 
         if (isHidden) {
-            if (boundedRemoteActivityInProgress && !keepActiveInBackground) {
+            if (boundedActivityInProgress && !keepActiveInBackground) {
                 this.deferredBoundedLifecycle = "suspend-if-hidden";
-                this.deferLifecycleUntilBoundedRemoteActivityEnds();
+                this.deferLifecycleUntilBoundedActivityEnds();
             } else if (!keepActiveInBackground) {
                 await this.services.appLifecycle.onSuspending();
             }
         } else {
             // suspend all temporary.
             if (this.services.appLifecycle.isSuspended()) return;
-            if (boundedRemoteActivityInProgress && keepActiveInBackground && this.settings.liveSync) {
+            if (boundedActivityInProgress && keepActiveInBackground && this.settings.liveSync) {
                 this.deferredBoundedLifecycle = "restart-continuous-if-visible";
-                this.deferLifecycleUntilBoundedRemoteActivityEnds();
+                this.deferLifecycleUntilBoundedActivityEnds();
                 return;
             }
             // Only the continuous (LiveSync) channel can go stalled-but-not-terminated: PouchDB

--- a/src/modules/essentialObsidian/ModuleObsidianEvents.unit.spec.ts
+++ b/src/modules/essentialObsidian/ModuleObsidianEvents.unit.spec.ts
@@ -24,6 +24,7 @@ function setup(opts: SetupOptions) {
     };
     const fileProcessing = { commitPendingFileEvents: vi.fn(async () => true) };
     const boundedRemoteActivityCount = reactiveSource(0);
+    const boundedLocalApplicationActivityCount = reactiveSource(0);
 
     const core = {
         _services: {
@@ -38,7 +39,7 @@ function setup(opts: SetupOptions) {
             setting: { saveSettingData: vi.fn(async () => undefined) },
             appLifecycle,
             fileProcessing,
-            replicator: { boundedRemoteActivityCount },
+            replicator: { boundedRemoteActivityCount, boundedLocalApplicationActivityCount },
         },
         settings: {
             ...DEFAULT_SETTINGS,
@@ -56,7 +57,13 @@ function setup(opts: SetupOptions) {
     // The handler reads `activeWindow.document.hidden`.
     (globalThis as any).activeWindow = { document: { hidden: opts.hidden } };
 
-    return { module, appLifecycle, fileProcessing, boundedRemoteActivityCount };
+    return {
+        module,
+        appLifecycle,
+        fileProcessing,
+        boundedRemoteActivityCount,
+        boundedLocalApplicationActivityCount,
+    };
 }
 
 describe("watchWindowVisibilityAsync — keepReplicationActiveInBackground", () => {
@@ -106,6 +113,21 @@ describe("watchWindowVisibilityAsync — keepReplicationActiveInBackground", () 
 
         boundedRemoteActivityCount.value = 0;
 
+        await vi.waitFor(() => expect(appLifecycle.onSuspending).toHaveBeenCalledTimes(1));
+    });
+
+    it("defers suspension while local document application is active", async () => {
+        const { module, appLifecycle, boundedLocalApplicationActivityCount } = setup({
+            settings: { keepReplicationActiveInBackground: false, liveSync: false },
+            hidden: true,
+        });
+        boundedLocalApplicationActivityCount.value = 1;
+
+        await module.watchWindowVisibilityAsync();
+
+        expect(appLifecycle.onSuspending).not.toHaveBeenCalled();
+
+        boundedLocalApplicationActivityCount.value = 0;
         await vi.waitFor(() => expect(appLifecycle.onSuspending).toHaveBeenCalledTimes(1));
     });
 

--- a/src/modules/services/ObsidianServices.ts
+++ b/src/modules/services/ObsidianServices.ts
@@ -10,11 +10,32 @@ import { ConfigServiceBrowserCompat } from "@vrtmrz/livesync-commonlib/compat/se
 import type { ObsidianServiceContext } from "@/modules/services/ObsidianServiceContext";
 import { KeyValueDBService } from "@vrtmrz/livesync-commonlib/compat/services/base/KeyValueDBService";
 import { ControlService } from "@vrtmrz/livesync-commonlib/compat/services/base/ControlService";
+import { reactiveSource } from "octagonal-wheels/dataobject/reactive";
+
+type ActivityOptions = {
+    label?: string;
+};
 
 export class ObsidianDatabaseEventService extends InjectableDatabaseEventService<ObsidianServiceContext> {}
 
 // InjectableReplicatorService
-export class ObsidianReplicatorService extends InjectableReplicatorService<ObsidianServiceContext> {}
+export class ObsidianReplicatorService extends InjectableReplicatorService<ObsidianServiceContext> {
+    readonly boundedLocalApplicationActivityCount = reactiveSource(0);
+
+    async runBoundedLocalApplicationActivity<T>(
+        task: () => T | PromiseLike<T>,
+        options?: ActivityOptions
+    ): Promise<T> {
+        this.boundedLocalApplicationActivityCount.value++;
+        try {
+            return this.dependencies.activityRunner
+                ? await this.dependencies.activityRunner.run(task, options)
+                : await task();
+        } finally {
+            this.boundedLocalApplicationActivityCount.value--;
+        }
+    }
+}
 // InjectableFileProcessingService
 export class ObsidianFileProcessingService extends InjectableFileProcessingService<ObsidianServiceContext> {}
 // InjectableReplicationService

--- a/src/modules/services/ObsidianServices.unit.spec.ts
+++ b/src/modules/services/ObsidianServices.unit.spec.ts
@@ -1,0 +1,35 @@
+import { promiseWithResolvers } from "octagonal-wheels/promises";
+import { describe, expect, it, vi } from "vitest";
+import { ObsidianReplicatorService } from "./ObsidianServices";
+
+function handler() {
+    return { addHandler: vi.fn() };
+}
+
+describe("ObsidianReplicatorService", () => {
+    it("tracks local application activity without extending remote activity", async () => {
+        const activity = promiseWithResolvers<void>();
+        const service = new ObsidianReplicatorService({ events: {}, translate: String } as never, {
+            settingService: { onRealiseSetting: handler() },
+            appLifecycleService: { onSuspending: handler(), getUnresolvedMessages: handler() },
+            databaseEventService: {
+                onResetDatabase: handler(),
+                onDatabaseInitialisation: handler(),
+                onDatabaseInitialised: handler(),
+                onDatabaseHasReady: handler(),
+            },
+            activityRunner: { run: vi.fn(async (task: () => Promise<void>) => await task()) },
+        } as never);
+
+        const running = service.runBoundedLocalApplicationActivity(() => activity.promise);
+
+        expect(service.boundedLocalApplicationActivityCount.value).toBe(1);
+        expect(service.boundedRemoteActivityCount.value).toBe(0);
+
+        activity.resolve();
+        await running;
+
+        expect(service.boundedLocalApplicationActivityCount.value).toBe(0);
+        expect(service.boundedRemoteActivityCount.value).toBe(0);
+    });
+});

--- a/updates.md
+++ b/updates.md
@@ -12,6 +12,10 @@ Earlier releases remain available in the 0.25 release history and the legacy rel
 
 ## Unreleased
 
+### Improved
+
+- Downloaded document batches retain best-effort screen-awake and lifecycle protection until every queued file has been applied to local storage, without extending the remote-activity indicator.
+
 ## 1.0.1
 
 29th July, 2026


### PR DESCRIPTION
## Summary

- retain one broad remote-activity boundary while downloaded documents remain queued or in progress for local application;
- settle the final empty recovery snapshot before normally releasing that boundary, and release or reacquire it around explicit processing suspension; and
- keep the existing ten-document concurrency limit unchanged.

Closes #1031.

## Why

A finite remote operation can finish after it has delivered documents into the local database but before `ReplicateResultProcessor` has applied them to the vault. With a large batch, the status bar may therefore show thousands of `📥` unprocessed transferred items after the network operation has already settled.

The activity work introduced in #1021 ends with the remote operation. On Android, moving Obsidian to the home screen can then invoke or permit suspension while the downloaded-document queue is still draining. The queue is snapshotted and resumes later, but a person may need to keep Obsidian visible for several minutes.

## Behaviour and boundaries

The first queued replicated document enters `runBoundedRemoteActivity` with the label `replicated-document-application`. Further documents and replication batches share the same boundary. It settles only when both the queue and in-progress set are empty and the final recovery snapshot has been attempted.

Explicitly suspending replication-result processing releases the boundary. Resuming reacquires it when queued work remains. Offline scans and unrelated local storage reflection are unchanged.

This remains best effort. A Screen Wake Lock does not guarantee hidden execution, and Android may still pause or terminate Obsidian. This change only prevents LiveSync from ending its own lifecycle protection before the delivered documents have been applied.

No concurrency setting is added. `ReplicateResultProcessor` already uses `Semaphore(10)`, which is higher than the proposed eight-way mobile value. Raising it without device evidence could increase IndexedDB and file-system contention, memory use, battery consumption, and thermal throttling without improving throughput.

## Verification

- Added a regression test covering two concurrent document applications sharing one boundary and retaining it until both settle. Before the implementation, it failed because the boundary was called zero times.
- `npm run test:unit`: 89 files and 1,505 tests passed.
- `npm run check`: TypeScript, ESLint, Svelte checking, and compatibility checks passed. The existing one ESLint warning and 22 Svelte warnings remain unchanged.
- `npm run build`: production build passed.
- `npm run check:compatibility`: the rebuilt `main.js` passed the iOS 15 compatibility rules.
- Regenerated the fallback declaration for `ReplicateResultProcessor`.
