### PR TITLE
fix(cli): floor watch-mode stat timestamps to integer milliseconds

### DIFF
--- a/src/apps/cli/managers/CLIStorageEventManagerAdapter.ts
+++ b/src/apps/cli/managers/CLIStorageEventManagerAdapter.ts
@@ -116,8 +116,11 @@ class CLIWatchAdapter implements IStorageEventWatchAdapter {
         return {
             path: path.relative(this.basePath, filePath).replace(/\\/g, "/") as FilePath,
             stat: {
-                ctime: stats?.ctimeMs ?? Date.now(),
-                mtime: stats?.mtimeMs ?? Date.now(),
+                // Floor to integer milliseconds: Linux fs.Stats.*Ms carry sub-millisecond
+                // precision, and a non-integer mtime stored in the database crashes mobile
+                // clients when Capacitor's Filesystem.setTimes casts it to a Java Long.
+                ctime: Math.floor(stats?.ctimeMs ?? Date.now()),
+                mtime: Math.floor(stats?.mtimeMs ?? Date.now()),
                 size: stats?.size ?? 0,
                 type: "file",
             },

--- a/src/apps/cli/managers/CLIStorageEventManagerAdapter.unit.spec.ts
+++ b/src/apps/cli/managers/CLIStorageEventManagerAdapter.unit.spec.ts
@@ -84,6 +84,27 @@ describe("CLIStorageEventManagerAdapter", () => {
         expect(created.stat?.size).toBe(42);
     });
 
+    it("floors sub-millisecond stat timestamps so mobile clients do not receive floats", async () => {
+        const basePath = "/vault/base";
+        const adapter = new CLIStorageEventManagerAdapter(basePath, undefined, true);
+        const handlers = makeHandlers();
+
+        await adapter.watch.beginWatch(handlers);
+
+        const addCallback = mockWatcher.on.mock.calls.find(([event]) => event === "add")![1] as (
+            filePath: string,
+            stats: any
+        ) => void;
+
+        // Linux fs.Stats carry nanosecond-derived sub-millisecond precision.
+        const floatStats = { ctimeMs: 1778511180024.462, mtimeMs: 1778511180999.913, size: 7 };
+        addCallback(`${basePath}/note.md`, floatStats);
+
+        const created = (handlers.onCreate as ReturnType<typeof vi.fn>).mock.calls[0][0] as NodeFile;
+        expect(created.stat?.ctime).toBe(1778511180024);
+        expect(created.stat?.mtime).toBe(1778511180999);
+    });
+
     it("close() calls watcher.close()", async () => {
         const adapter = new CLIStorageEventManagerAdapter("/base", undefined, true);
         const handlers = makeHandlers();


### PR DESCRIPTION
### Summary

My phone's Obsidian started crash-looping on launch after I'd been running the headless CLI as a sync daemon. adb logcat pointed straight at a native `ClassCastException: Double cannot be cast to Long` inside Capacitor's `Filesystem.setTimes`: a synced document had a fractional-millisecond mtime, and the Java binding only accepts an integer `Long`.

It turns out the CLI is where the float gets in. On Linux `fs.Stats.mtimeMs`/`ctimeMs` come back with sub-millisecond precision, e.g. `1778511180024.462`. The earlier fix (3f7bb047) floored these at the scan/stat adapters, but the chokidar watch adapter was missed, and that's exactly the path the daemon runs on once it's up. So every live edit kept writing a float timestamp into the database, and any mobile client that replicated one would crash on its next launch.

This floors mtime/ctime at the watch site too, the same way the other adapters already do it, so watch-mode documents carry integer milliseconds like the rest of the mesh.

### Testing

tsc-check clean, and the CLI unit tests pass (7/7, including a new case that a fractional stat gets floored). I haven't run the CLI E2E suite locally though. 

### Trade-offs and Alternatives

The floor call is now hand-rolled at a handful of CLI stat-read sites. A shared `fs.Stats` to `UXStat` converter that floors once would be a nicer home for it and would make it impossible to add a new stat-read site that forgets, but that's a wider refactor across pre-existing code so I've left it as a follow-up. The deepest fix sits in commonlib's `dbToStorage`, where the timestamp is read from the DB document once for every platform, but that lives in the `src/lib` submodule.
