### PR TITLE
fix(storage): floor write-option timestamps in Obsidian adapters

### DIFF
--- a/src/serviceModules/FileSystemAdapters/ObsidianStorageAdapter.ts
+++ b/src/serviceModules/FileSystemAdapters/ObsidianStorageAdapter.ts
@@ -2,6 +2,7 @@ import type { UXDataWriteOptions } from "@lib/common/types";
 import type { IStorageAdapter } from "@lib/serviceModules/adapters";
 import { toArrayBuffer } from "@lib/serviceModules/FileAccessBase";
 import type { Stat, App } from "obsidian";
+import { toIntegerTimestamps } from "./sanitizeWriteOptions";
 
 /**
  * Storage adapter implementation for Obsidian
@@ -40,15 +41,15 @@ export class ObsidianStorageAdapter implements IStorageAdapter<Stat> {
     }
 
     async write(path: string, data: string, options?: UXDataWriteOptions): Promise<void> {
-        return await this.app.vault.adapter.write(path, data, options);
+        return await this.app.vault.adapter.write(path, data, toIntegerTimestamps(options));
     }
 
     async writeBinary(path: string, data: ArrayBuffer, options?: UXDataWriteOptions): Promise<void> {
-        return await this.app.vault.adapter.writeBinary(path, toArrayBuffer(data), options);
+        return await this.app.vault.adapter.writeBinary(path, toArrayBuffer(data), toIntegerTimestamps(options));
     }
 
     async append(path: string, data: string, options?: UXDataWriteOptions): Promise<void> {
-        return await this.app.vault.adapter.append(path, data, options);
+        return await this.app.vault.adapter.append(path, data, toIntegerTimestamps(options));
     }
 
     list(basePath: string): Promise<{ files: string[]; folders: string[] }> {

--- a/src/serviceModules/FileSystemAdapters/ObsidianVaultAdapter.ts
+++ b/src/serviceModules/FileSystemAdapters/ObsidianVaultAdapter.ts
@@ -2,6 +2,7 @@ import type { UXDataWriteOptions } from "@lib/common/types";
 import type { IVaultAdapter } from "@lib/serviceModules/adapters";
 import { toArrayBuffer } from "@lib/serviceModules/FileAccessBase";
 import type { TFile, App, TFolder } from "obsidian";
+import { toIntegerTimestamps } from "./sanitizeWriteOptions";
 
 /**
  * Vault adapter implementation for Obsidian
@@ -22,19 +23,19 @@ export class ObsidianVaultAdapter implements IVaultAdapter<TFile, TFolder> {
     }
 
     async modify(file: TFile, data: string, options?: UXDataWriteOptions): Promise<void> {
-        return await this.app.vault.modify(file, data, options);
+        return await this.app.vault.modify(file, data, toIntegerTimestamps(options));
     }
 
     async modifyBinary(file: TFile, data: ArrayBuffer, options?: UXDataWriteOptions): Promise<void> {
-        return await this.app.vault.modifyBinary(file, toArrayBuffer(data), options);
+        return await this.app.vault.modifyBinary(file, toArrayBuffer(data), toIntegerTimestamps(options));
     }
 
     async create(path: string, data: string, options?: UXDataWriteOptions): Promise<TFile> {
-        return await this.app.vault.create(path, data, options);
+        return await this.app.vault.create(path, data, toIntegerTimestamps(options));
     }
 
     async createBinary(path: string, data: ArrayBuffer, options?: UXDataWriteOptions): Promise<TFile> {
-        return await this.app.vault.createBinary(path, toArrayBuffer(data), options);
+        return await this.app.vault.createBinary(path, toArrayBuffer(data), toIntegerTimestamps(options));
     }
 
     async delete(file: TFile | TFolder, force = false): Promise<void> {

--- a/src/serviceModules/FileSystemAdapters/sanitizeWriteOptions.ts
+++ b/src/serviceModules/FileSystemAdapters/sanitizeWriteOptions.ts
@@ -1,0 +1,25 @@
+import type { UXDataWriteOptions } from "@lib/common/types";
+
+/**
+ * Coerce the timestamp fields of a write-options object to integer milliseconds.
+ *
+ * On mobile, Obsidian forwards `mtime`/`ctime` to Capacitor's
+ * Filesystem.setTimes, whose native binding casts the value to a Java `Long`.
+ * A non-integer (float) timestamp makes that cast throw
+ * `ClassCastException: Double cannot be cast to Long`, which crashes the app on
+ * launch as soon as such a document is replicated in. Float timestamps can
+ * enter the database from any client that stores `fs.Stats.mtimeMs` without
+ * flooring. Flooring at the storage boundary guarantees every Obsidian write
+ * carries an integer, so a float timestamp already present in the mesh cannot
+ * brick the app.
+ *
+ * Returns a shallow copy so the caller's options object is not mutated; passes
+ * `undefined` through unchanged.
+ */
+export function toIntegerTimestamps(options?: UXDataWriteOptions): UXDataWriteOptions | undefined {
+    if (!options) return options;
+    const sanitized: UXDataWriteOptions = { ...options };
+    if (typeof sanitized.mtime === "number") sanitized.mtime = Math.floor(sanitized.mtime);
+    if (typeof sanitized.ctime === "number") sanitized.ctime = Math.floor(sanitized.ctime);
+    return sanitized;
+}


### PR DESCRIPTION
### Summary

Same root cause as #1037, but from the consumer side. My phone kept crash-looping on launch even after the bad timestamps were cleaned out of the remote database, because its local replica still held a document with a fractional mtime and applied it on startup before it could re-sync.

On mobile, Obsidian hands mtime/ctime straight through to Capacitor's `Filesystem.setTimes`, whose native binding casts the value to a Java `Long`. A float makes that cast throw `ClassCastException: Double cannot be cast to Long`, which takes down the whole app before it finishes loading. A float can arrive from any client that stored `fs.Stats.mtimeMs` without flooring, so I wanted a guard that doesn't rely on every writer in the mesh getting it right.

This coerces mtime/ctime to integer milliseconds at the Obsidian vault and storage adapter write boundary, which is the last point in this repo before the native call. With it in place the app launches again, then re-syncs and self-heals its local copy against a clean remote.

### Testing

tsc-check clean and the full plugin build succeeds. I also verified it on a real device: reproduced the launch crash from a float-mtime document, then confirmed the built plugin launches cleanly and stays up.

### Trade-offs and Alternatives

The single right choke point is `dbToStorage` in livesync-commonlib, where the timestamp is read off the DB document once for every platform. A guard there would cover the CLI and webapp too, but it's in the `src/lib` submodule so it can't go in this PR. Guarding per write method here does leave a drift risk: a future write method added to the adapter could forget the wrapper. I considered a construction-time proxy that intercepts the write family instead, but that trades explicit type-checked calls for string-matched method interception, which isn't worth it for two small adapters.
