### PR TITLE
Preserve UTF-8 BOMs during Vault ingestion

### DIFF
--- a/src/serviceModules/FileSystemAdapters/ObsidianVaultAdapter.ts
+++ b/src/serviceModules/FileSystemAdapters/ObsidianVaultAdapter.ts
@@ -10,7 +10,8 @@ export class ObsidianVaultAdapter implements IVaultAdapter<TFile, TFolder> {
     constructor(private app: App) {}
 
     async read(file: TFile): Promise<string> {
-        return await this.app.vault.read(file);
+        // Vault.read strips a leading UTF-8 BOM, leaving the content size inconsistent with TFile.stat.
+        return await this.app.vault.adapter.read(file.path);
     }
 
     async cachedRead(file: TFile): Promise<string> {

--- a/src/serviceModules/FileSystemAdapters/ObsidianVaultAdapter.unit.spec.ts
+++ b/src/serviceModules/FileSystemAdapters/ObsidianVaultAdapter.unit.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+import type { App, TFile } from "obsidian";
+import { ObsidianVaultAdapter } from "./ObsidianVaultAdapter";
+
+describe("ObsidianVaultAdapter.read", () => {
+    it("preserves a UTF-8 BOM so the content size matches the file stat", async () => {
+        const path = "Transcripts/字幕.md";
+        const contentWithoutBom = "字幕の検証行です。\n";
+        const contentWithBom = `\ufeff${contentWithoutBom}`;
+        const read = vi.fn().mockResolvedValue(contentWithoutBom);
+        const adapterRead = vi.fn().mockResolvedValue(contentWithBom);
+        const app = {
+            vault: {
+                read,
+                adapter: {
+                    read: adapterRead,
+                },
+            },
+        } as unknown as App;
+        const file = {
+            path,
+            stat: {
+                ctime: 1,
+                mtime: 2,
+                size: new Blob([contentWithBom]).size,
+            },
+        } as TFile;
+        const adapter = new ObsidianVaultAdapter(app);
+
+        const result = await adapter.read(file);
+
+        expect(new Blob([result]).size).toBe(file.stat.size);
+        expect(result.charCodeAt(0)).toBe(0xfeff);
+        expect(adapterRead).toHaveBeenCalledWith(path);
+        expect(read).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
This preserves leading UTF-8 BOMs during Obsidian vault ingestion, keeping stored content sizes consistent with file metadata.

## Problem

Obsidian's `Vault.read` removes a leading UTF-8 BOM, while `TFile.stat.size` reflects the original three BOM bytes. LiveSync therefore stores BOM-stripped content but compares it with the raw file size, producing a persistent three-byte integrity mismatch which repair cannot resolve.

## Changes

- Read uncached text through Obsidian's `DataAdapter.read(path)` API, which preserves the BOM, instead of `Vault.read`.
- Avoid a binary/raw read and a separate local decoding pass.
- Add a focused regression test which verifies BOM preservation, byte-size consistency, and use of the adapter API.

## Verification

- Confirmed that the regression test fails against the unmodified implementation with a 28-byte result for a 31-byte file.
- `npm run test:unit` — 81 test files and 582 tests passed.
- `npm run check`
- Real Obsidian 1.12.7 verification with a 168,003-byte BOM-prefixed CJK file: file metadata, adapter text, recorded content, reconstructed content, and stored content all remained 168,003 bytes; the database retained the BOM, and both initial ingestion and repair completed without an integrity mismatch.
- `git diff --check`

Related to #1056.
