### PR TITLE
Use octagonal-wheels 0.1.52 for Node base64 fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
                 "markdown-it": "^14.2.0",
                 "minimatch": "^10.2.5",
                 "obsidian": "^1.13.1",
-                "octagonal-wheels": "^0.1.51",
+                "octagonal-wheels": "^0.1.52",
                 "qrcode-generator": "^1.4.4",
                 "xxhash-wasm-102": "npm:xxhash-wasm@^1.0.2"
             },
@@ -11532,9 +11532,9 @@
             "license": "MIT"
         },
         "node_modules/octagonal-wheels": {
-            "version": "0.1.51",
-            "resolved": "https://registry.npmjs.org/octagonal-wheels/-/octagonal-wheels-0.1.51.tgz",
-            "integrity": "sha512-KTlfqKPjobHJg/t3A539srnFf+VHr1aXkHSmsNDDpiI5UFC7FamZ95dWpJfGE2EI/HULR5hveQDgkazmz8SAcg==",
+            "version": "0.1.52",
+            "resolved": "https://registry.npmjs.org/octagonal-wheels/-/octagonal-wheels-0.1.52.tgz",
+            "integrity": "sha512-9WJN2UveNh90Op1S07cIso1WyNrQbO/unibDLfUGnpomIcU4g6F+p8reZHW0Ed8sGzKF5qGnQp991Y9MB1TwNg==",
             "license": "MIT",
             "dependencies": {
                 "idb": "^8.0.3"
@@ -15928,7 +15928,7 @@
             "dependencies": {
                 "chokidar": "^4.0.0",
                 "minimatch": "^10.2.5",
-                "octagonal-wheels": "^0.1.51",
+                "octagonal-wheels": "^0.1.52",
                 "pouchdb-adapter-http": "^9.0.0",
                 "pouchdb-adapter-leveldb": "^9.0.0",
                 "pouchdb-core": "^9.0.0",
@@ -15951,7 +15951,7 @@
             "name": "livesync-webapp",
             "version": "1.0.1-webapp",
             "dependencies": {
-                "octagonal-wheels": "^0.1.51"
+                "octagonal-wheels": "^0.1.52"
             },
             "devDependencies": {
                 "@sveltejs/vite-plugin-svelte": "^7.1.2",
@@ -15963,7 +15963,7 @@
         "src/apps/webpeer": {
             "version": "1.0.1-webpeer",
             "dependencies": {
-                "octagonal-wheels": "^0.1.51"
+                "octagonal-wheels": "^0.1.52"
             },
             "devDependencies": {
                 "@sveltejs/vite-plugin-svelte": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
         "markdown-it": "^14.2.0",
         "minimatch": "^10.2.5",
         "obsidian": "^1.13.1",
-        "octagonal-wheels": "^0.1.51",
+        "octagonal-wheels": "^0.1.52",
         "qrcode-generator": "^1.4.4",
         "xxhash-wasm-102": "npm:xxhash-wasm@^1.0.2"
     },

--- a/src/apps/cli/package.json
+++ b/src/apps/cli/package.json
@@ -37,7 +37,7 @@
     "dependencies": {
         "chokidar": "^4.0.0",
         "minimatch": "^10.2.5",
-        "octagonal-wheels": "^0.1.51",
+        "octagonal-wheels": "^0.1.52",
         "pouchdb-adapter-http": "^9.0.0",
         "pouchdb-adapter-leveldb": "^9.0.0",
         "pouchdb-core": "^9.0.0",

--- a/src/apps/webapp/package.json
+++ b/src/apps/webapp/package.json
@@ -15,7 +15,7 @@
         "test:browser": "deno test -A --no-check --frozen --config ../../../test/browser-apps/deno.json --lock ../../../test/browser-apps/deno.lock ../../../test/browser-apps/webapp/browser-smoke.test.ts"
     },
     "dependencies": {
-        "octagonal-wheels": "^0.1.51"
+        "octagonal-wheels": "^0.1.52"
     },
     "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^7.1.2",

--- a/src/apps/webpeer/package.json
+++ b/src/apps/webpeer/package.json
@@ -15,7 +15,7 @@
         "test:browser": "deno test -A --no-check --frozen --config ../../../test/browser-apps/deno.json --lock ../../../test/browser-apps/deno.lock ../../../test/browser-apps/webpeer/browser-smoke.test.ts"
     },
     "dependencies": {
-        "octagonal-wheels": "^0.1.51"
+        "octagonal-wheels": "^0.1.52"
     },
     "devDependencies": {
         "eslint-plugin-svelte": "^3.19.0",


### PR DESCRIPTION
This dependency update adopts `octagonal-wheels` 0.1.52 so that Self-hosted LiveSync includes the published Node.js fallback for large-buffer base64 encoding.

## Summary

- Raise the minimum `octagonal-wheels` version from `^0.1.51` to `^0.1.52` in the root package, CLI, WebApp, and WebPeer.
- Update the lockfile to select the reviewed `octagonal-wheels@0.1.52` registry artefact.
- Incorporate the upstream fix from vrtmrz/fancy-kit#44, which uses `Buffer` when `FileReader` is unavailable and covers both `arrayBufferToBase64` and `encodeBinary`.

## Rationale

The existing lockfile selects `octagonal-wheels@0.1.51`, so `npm ci` continues to install the version which can reach the browser-only `FileReader` path on Node.js 22 and 24. Updating both the workspace requirements and lockfile ensures that LiveSync builds include the reviewed and published fix.

The fallback preserves sliced-view offsets and lengths, avoids an additional input-buffer copy, and leaves browser behaviour unchanged.

## Verification

- Confirmed that `octagonal-wheels@0.1.51` throws `ReferenceError: FileReader is not defined` for both affected APIs with a 64 KiB input on Node.js 24 without DOM globals.
- Confirmed that `octagonal-wheels@0.1.52` correctly encodes the same input through both APIs.
- Confirmed that the root package, Commonlib, CLI, WebApp, and WebPeer resolve a single `octagonal-wheels@0.1.52` installation.
- Verified the exact published package on Node.js 22 and 24 with approximately 8 MiB inputs.
- Ran `npm ci`.
- Ran `npm run test:unit` — 80 test files and 581 tests passed.
- Ran `npm run check`.
- Ran `npm run build`.
- Ran `npm run build --workspace self-hosted-livesync-cli`.
- Ran `npm run build:browser-apps`.
- Ran the generated CLI with `--help`.

## Remaining validation

The reporter has not yet confirmed the original encrypted headless CLI workflow in their environment. Issue #1036 should therefore remain open for that confirmation after the next LiveSync release.

Refs #1036
