### PR TITLE
Fix CLI start-up with the Commonlib headless log handler

### DIFF
--- a/src/apps/cli/main.log-handler.unit.spec.ts
+++ b/src/apps/cli/main.log-handler.unit.spec.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const mocks = vi.hoisted(() => ({
+    setLogHandler: vi.fn(),
+}));
+
+vi.mock("./services/NodeServiceHub", () => ({
+    NodeServiceContext: class {},
+    NodeServiceHub: class {
+        API = {
+            addLog: {
+                setHandler: mocks.setLogHandler,
+            },
+        };
+    },
+}));
+
+import { main } from "./main";
+
+function createStandardIoMock() {
+    return {
+        readStdin: vi.fn(async () => ""),
+        prompt: vi.fn(async () => ""),
+        writeStdout: vi.fn(),
+        writeStderr: vi.fn(),
+    };
+}
+
+describe("CLI log handler", () => {
+    const originalArgv = process.argv.slice();
+    let databasePath: string;
+
+    beforeEach(async () => {
+        databasePath = await mkdtemp(join(tmpdir(), "livesync-cli-log-handler-"));
+        mocks.setLogHandler.mockReset();
+        mocks.setLogHandler.mockImplementation(() => {
+            throw new Error("__LOG_HANDLER_CONFIGURED__");
+        });
+    });
+
+    afterEach(async () => {
+        process.argv = originalArgv.slice();
+        await rm(databasePath, { recursive: true, force: true });
+    });
+
+    it("replaces the default Headless API log handler", async () => {
+        process.argv = ["node", "livesync-cli", databasePath, "remote-ls"];
+
+        await expect(main(createStandardIoMock())).rejects.toThrow("__LOG_HANDLER_CONFIGURED__");
+        expect(mocks.setLogHandler).toHaveBeenCalledWith(expect.any(Function), true);
+    });
+});

--- a/src/apps/cli/main.ts
+++ b/src/apps/cli/main.ts
@@ -399,7 +399,7 @@ export async function main(
             if (!options.verbose) return;
         }
         writeStderrLine(standardIo, prefix, message);
-    });
+    }, true);
     // Prevent replication result from being processed automatically in non-daemon commands.
     // In daemon mode the default handler must run so changes are applied to the filesystem.
     if (options.command !== "daemon") {


### PR DESCRIPTION
This fix lets the CLI replace Commonlib's default headless log handler, preventing start-up failures with newer Commonlib packages.

## Problem

`HeadlessAPIService` installs a default `addLog` handler. The CLI then installs its output-aware handler. With `@vrtmrz/livesync-commonlib@0.1.2-rc.0`, assigning the second handler without explicit replacement stops start-up with `Handler addLog is already assigned.` before `setup` can run.

The incompatibility was exposed by [Commonlib downstream CI](https://github.com/vrtmrz/livesync-commonlib/actions/runs/30788646551) for [Commonlib PR #87](https://github.com/vrtmrz/livesync-commonlib/pull/87).

## Change

- Pass the explicit replacement flag when configuring the CLI log handler.
- Add a focused regression test which verifies that the CLI replaces the existing handler.

## Verification

- [x] Confirmed that the focused regression test fails against the unmodified implementation because the replacement flag is absent.
- [x] `npx vitest run --config vitest.config.unit.ts src/apps/cli/main.log-handler.unit.spec.ts --maxWorkers=1`
- [x] `NODE_OPTIONS=--max-old-space-size=3072 npm run build --workspace self-hosted-livesync-cli`
- [x] `deno task --cwd src/apps/cli/testdeno test:setup-put-cat`
  - Passed one scenario with nine steps using the exact `@vrtmrz/livesync-commonlib@0.1.2-rc.0` tarball built from `51fbefc`.
