### PR TITLE
fix(ios): position sync status below header controls

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -481,6 +481,11 @@ span.ls-mark-cr::after {
     font-size: 80%;
 }
 
+.is-mobile.is-ios .livesync-status {
+    box-sizing: border-box;
+    top: calc(var(--header-height) + var(--view-header-height, var(--header-height)) + var(--size-4-2));
+}
+
 div.workspace-leaf-content[data-type="bases"] .livesync-status {
     top: calc(var(--bases-header-height) + var(--header-height));
     padding: 5px;
@@ -491,6 +496,13 @@ div.workspace-leaf-content[data-type="bases"] .livesync-status {
     top: calc(var(--bases-header-height) + var(--view-header-height));
     padding: 6px;
     padding-right: 18px;
+}
+
+.is-mobile.is-ios div.workspace-leaf-content[data-type="bases"] .livesync-status {
+    top: calc(
+        var(--bases-header-height) + var(--header-height) + var(--view-header-height, var(--header-height)) +
+            var(--size-4-2)
+    );
 }
 
 .livesync-status div {

--- a/updates.md
+++ b/updates.md
@@ -22,6 +22,7 @@ Earlier releases remain available in the 0.25 release history and the legacy rel
 
 #### Fixed
 
+- The in-editor LiveSync status on iOS now remains below the view-header controls instead of overlapping them.
 - The Remediation setting now displays its configured modification-time limit without raising a `HierarchyRequestError`.
 
 ## 1.0.2


### PR DESCRIPTION
## Description

On iOS, the in-editor LiveSync status can overlap Obsidian's top-right view controls. This change positions it below the controls with an Obsidian spacing token. The override is limited to `.is-mobile.is-ios`, so Android and desktop layouts are unchanged. Bases retains its additional header offset.

## Comparison

| Before | After |
| --- | --- |
| ![Sync status overlapping the iOS header controls](https://media.hsichen.dev/29/29d903159335a28839d4def9d3efc3b21adfe10244878c76063d6dd8eb9122c4.jpg) | ![Sync status positioned below the iOS header controls](https://media.hsichen.dev/1a/1a4986d8b0b2d2748ade02f6af27186858134572475876bc7a6302bed9f26504.jpg) |

## Testing

- `npm run check` passed; one pre-existing settings-search warning remains.
- `npm run test:unit` passed: 86 files and 604 tests.
- Manually verified with Obsidian 1.13.4 on a physical iPhone 16e running iOS 26.5.2.
- Please run CI tests.
