### PR TITLE
Adopt Commonlib revision and chunk-fetch fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "@smithy/types": "^4.14.3",
                 "@smithy/util-retry": "^4.4.5",
                 "@vrtmrz/browser-ui-kit": "0.1.0",
-                "@vrtmrz/livesync-commonlib": "0.1.2-rc.0",
+                "@vrtmrz/livesync-commonlib": "0.1.2",
                 "@vrtmrz/obsidian-plugin-kit": "0.1.3",
                 "@vrtmrz/ui-interactions": "0.1.2",
                 "diff-match-patch": "^1.0.5",
@@ -4775,9 +4775,9 @@
             }
         },
         "node_modules/@vrtmrz/livesync-commonlib": {
-            "version": "0.1.2-rc.0",
-            "resolved": "https://registry.npmjs.org/@vrtmrz/livesync-commonlib/-/livesync-commonlib-0.1.2-rc.0.tgz",
-            "integrity": "sha512-X8/nd6N+GQYgxH7kVo72EwjM+BeBuDsIsBRrACk71nEvzg0ENmTf9Zx26gNLza5wZY+LUbbaqmDDvmQhrdJyHA==",
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@vrtmrz/livesync-commonlib/-/livesync-commonlib-0.1.2.tgz",
+            "integrity": "sha512-o4nHy8d4wxfUR6CcOv50vQnVc+vFZDZTI612/DPBJY3ObGm0749IobdJJ04l6iBjmVkNaB9nnaSsl7BWHuuY+A==",
             "license": "MIT",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.808.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "@smithy/types": "^4.14.3",
                 "@smithy/util-retry": "^4.4.5",
                 "@vrtmrz/browser-ui-kit": "0.1.0",
-                "@vrtmrz/livesync-commonlib": "0.1.0",
+                "@vrtmrz/livesync-commonlib": "0.1.2-rc.0",
                 "@vrtmrz/obsidian-plugin-kit": "0.1.3",
                 "@vrtmrz/ui-interactions": "0.1.2",
                 "diff-match-patch": "^1.0.5",
@@ -4775,9 +4775,9 @@
             }
         },
         "node_modules/@vrtmrz/livesync-commonlib": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@vrtmrz/livesync-commonlib/-/livesync-commonlib-0.1.0.tgz",
-            "integrity": "sha512-rdzEubzLStioanE67pps2XSGZ2UGyMIyeEoKsdPztQLLW8wM05PWApOPbJujIydHcDr2hFanbDFe89Lk7Mn4XQ==",
+            "version": "0.1.2-rc.0",
+            "resolved": "https://registry.npmjs.org/@vrtmrz/livesync-commonlib/-/livesync-commonlib-0.1.2-rc.0.tgz",
+            "integrity": "sha512-X8/nd6N+GQYgxH7kVo72EwjM+BeBuDsIsBRrACk71nEvzg0ENmTf9Zx26gNLza5wZY+LUbbaqmDDvmQhrdJyHA==",
             "license": "MIT",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
         "@smithy/types": "^4.14.3",
         "@smithy/util-retry": "^4.4.5",
         "@vrtmrz/browser-ui-kit": "0.1.0",
-        "@vrtmrz/livesync-commonlib": "0.1.2-rc.0",
+        "@vrtmrz/livesync-commonlib": "0.1.2",
         "@vrtmrz/obsidian-plugin-kit": "0.1.3",
         "@vrtmrz/ui-interactions": "0.1.2",
         "diff-match-patch": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
         "@smithy/types": "^4.14.3",
         "@smithy/util-retry": "^4.4.5",
         "@vrtmrz/browser-ui-kit": "0.1.0",
-        "@vrtmrz/livesync-commonlib": "0.1.0",
+        "@vrtmrz/livesync-commonlib": "0.1.2-rc.0",
         "@vrtmrz/obsidian-plugin-kit": "0.1.3",
         "@vrtmrz/ui-interactions": "0.1.2",
         "diff-match-patch": "^1.0.5",

--- a/updates.md
+++ b/updates.md
@@ -12,6 +12,13 @@ Earlier releases remain available in the 0.25 release history and the legacy rel
 
 ## Unreleased
 
+### Synchronisation and storage
+
+#### Fixed
+
+- File consistency checks no longer read older revisions after the current Vault content matches known synchronised history, avoiding unnecessary 'Missing document content' warnings from obsolete unreadable revisions.
+- Remote chunk fetching now retains chunks which were returned successfully when another chunk in the same request is unavailable, so the available content can still be processed (#771).
+
 ### P2P and experimental browser applications
 
 #### Improved


### PR DESCRIPTION
This dependency update adopts Commonlib 0.1.2 so Self-hosted LiveSync avoids redundant reads of obsolete revisions and retains successful chunks from partially unsuccessful remote requests.

## Problem

File consistency checks could continue through revision history after the current Vault content had already matched known synchronised content exactly. When an obsolete revision was no longer readable, the unnecessary follow-up read emitted a 'Missing document content' warning even though the current file was valid.

Remote chunk fetching could also treat a complete CouchDB `_all_docs` batch as unsuccessful when any single row was unavailable. Because the request queue can contain chunks for several files, this discarded successfully returned rows and could report otherwise available chunks as missing. This is the batch-level failure mode identified in the latest investigation of #771; confirmation of the reporter's exact start-up scenario remains pending.

## Change

- Pin `@vrtmrz/livesync-commonlib` to the immutable `0.1.2` registry release in `package.json` and `package-lock.json`.
- Adopt the Commonlib revision-history and partial chunk-fetch fixes.
- Record both user-visible changes under `## Unreleased` in `updates.md`.

This branch is based directly on the merge commit of #1066. That prerequisite lets the CLI replace Commonlib's default headless log handler, which is required by the newer Commonlib package.

## Verification

- [x] `npm ci`
- [x] `npm run build`
- [x] Focused Commonlib package-boundary and service-context unit tests: 4 files and 5 tests passed with one worker.
- [x] `git diff --check`
- [x] The exact registry release candidate passed real Obsidian 1.12.7 `revision-repair`, `couchdb-upload`, and `startup-scan` E2E scenarios, including real CouchDB chunk retrieval and persistence.
- [x] The published `0.1.2` registry artefact matched its reviewed staged artefact byte for byte. Its package payload differs from the tested release candidate only in the package version metadata.
- [x] Commonlib's package verification passed 69 test files and 1,216 tests, together with type, package-boundary, release-selection, build, and packed-consumer checks.

Related to #771.
