### PR TITLE
Prepare 1.0.5 release notes

### DIFF
--- a/updates.md
+++ b/updates.md
@@ -18,6 +18,16 @@ Earlier releases remain available in the 0.25 release history and the legacy rel
 
 - Added settings to control whether finite synchronisation operations keep the screen awake. Desktop devices now allow automatic sleep by default, while mobile devices retain screen-awake protection unless the general option is enabled (#1073).
 
+### Interface and translation
+
+#### Improved
+
+- Korean translations now cover the complete current catalogue across Setup, P2P, remote configuration, diagnostics, and maintenance (PR #1075). Thank you to @motolies for the improvement!
+
+#### Fixed
+
+- The in-editor LiveSync status on iOS now remains below the view-header controls instead of overlapping them (PR #1067). Thank you to @Hsiii for the improvement!
+
 ## 1.0.4
 
 5th August, 2026
@@ -49,7 +59,6 @@ Earlier releases remain available in the 0.25 release history and the legacy rel
 
 #### Fixed
 
-- The in-editor LiveSync status on iOS now remains below the view-header controls instead of overlapping them.
 - The Remediation setting now displays its configured modification-time limit without raising a `HierarchyRequestError`.
 
 ## 1.0.2


### PR DESCRIPTION
Prepare the Unreleased notes for the three user-facing changes intended for Self-hosted LiveSync 1.0.5.

## Summary

- Retain the screen-awake preference changes for finite synchronisation operations under `Unreleased` (#1073).
- Add the completed Korean translation coverage and credit @motolies (PR #1075).
- Move the iOS in-editor status correction out of the published 1.0.3 section and credit @Hsiii (PR #1067).

## Rationale

Both contributor pull requests were merged after 1.0.4. This keeps the historical 1.0.3 notes accurate and gives both contributors durable credit in the next release notes.

## Verification

- `git diff --check`

This is a documentation-only change.
