### PR TITLE
Update Commonlib to 0.1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "@smithy/types": "^4.14.3",
                 "@smithy/util-retry": "^4.4.5",
                 "@vrtmrz/browser-ui-kit": "0.1.0",
-                "@vrtmrz/livesync-commonlib": "0.1.8",
+                "@vrtmrz/livesync-commonlib": "0.1.9",
                 "@vrtmrz/obsidian-plugin-kit": "0.1.3",
                 "@vrtmrz/ui-interactions": "0.1.2",
                 "diff-match-patch": "^1.0.5",
@@ -4775,9 +4775,9 @@
             }
         },
         "node_modules/@vrtmrz/livesync-commonlib": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/@vrtmrz/livesync-commonlib/-/livesync-commonlib-0.1.8.tgz",
-            "integrity": "sha512-Kn1AF41h2Dog37ThU7KgLcKxItCCerLEBWg1eSGAUoTk3TyPBYynvtmVFwWhy6LCePcuwB/+x7EQNTL3Sgzkyg==",
+            "version": "0.1.9",
+            "resolved": "https://registry.npmjs.org/@vrtmrz/livesync-commonlib/-/livesync-commonlib-0.1.9.tgz",
+            "integrity": "sha512-qacNUbRAqt32j756XTTdI5K+/co8oc2BKjzsUAhEsDHC8tc18q4a3cQrUHNJuxYO+nYnx0FKhf9lHMZcCX+Scg==",
             "license": "MIT",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
         "@smithy/types": "^4.14.3",
         "@smithy/util-retry": "^4.4.5",
         "@vrtmrz/browser-ui-kit": "0.1.0",
-        "@vrtmrz/livesync-commonlib": "0.1.8",
+        "@vrtmrz/livesync-commonlib": "0.1.9",
         "@vrtmrz/obsidian-plugin-kit": "0.1.3",
         "@vrtmrz/ui-interactions": "0.1.2",
         "diff-match-patch": "^1.0.5",

--- a/updates.md
+++ b/updates.md
@@ -12,6 +12,12 @@ Earlier releases remain available in the 0.25 release history and the legacy rel
 
 ## Unreleased
 
+### Setup and compatibility
+
+#### Fixed
+
+- Fast Setup now sends configured CouchDB custom headers with every changes-feed request, allowing reverse proxies such as Cloudflare Access to authenticate initial setup in the same way as ordinary synchronisation ([Commonlib PR #82](https://github.com/vrtmrz/livesync-commonlib/pull/82)). Thank you to @nimula for the contribution!
+
 ## 1.0.9
 
 8th August, 2026


### PR DESCRIPTION
This updates Self-hosted LiveSync to consume Commonlib 0.1.9, allowing Fast Setup to forward configured CouchDB custom headers consistently.

## Summary

- lock `@vrtmrz/livesync-commonlib` to the reviewed, published 0.1.9 artefact
- forward configured CouchDB custom headers during Fast Setup so reverse proxies such as Cloudflare Access can authenticate every changes-feed request
- record the user-facing fix under `Unreleased`, retaining credit for [Commonlib PR #82](https://github.com/vrtmrz/livesync-commonlib/pull/82) and @nimula

## Verification

- `npm ci`
- `npm run check`
- `npm run test:unit -- --maxWorkers=1` — 87 files and 627 tests passed
- production plug-in, CLI, WebApp, and WebPeer builds
- CLI setup and file-operation E2E — 1 test and 9 steps passed
- `npm run test:setup-tools` — 6 tests passed
