### PR TITLE
Update Commonlib to 0.1.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "@smithy/types": "^4.14.3",
                 "@smithy/util-retry": "^4.4.5",
                 "@vrtmrz/browser-ui-kit": "0.1.0",
-                "@vrtmrz/livesync-commonlib": "0.1.10",
+                "@vrtmrz/livesync-commonlib": "0.1.11",
                 "@vrtmrz/obsidian-plugin-kit": "0.1.3",
                 "@vrtmrz/ui-interactions": "0.1.2",
                 "diff-match-patch": "^1.0.5",
@@ -4775,9 +4775,9 @@
             }
         },
         "node_modules/@vrtmrz/livesync-commonlib": {
-            "version": "0.1.10",
-            "resolved": "https://registry.npmjs.org/@vrtmrz/livesync-commonlib/-/livesync-commonlib-0.1.10.tgz",
-            "integrity": "sha512-1t1e8EPM2fuIbC107jJQXbSivWXcspD7kR/3AOgT29O9E5UbGFZR6vj1f84D6vOe8BiHhv8Ng9GvrCV6U+gGXg==",
+            "version": "0.1.11",
+            "resolved": "https://registry.npmjs.org/@vrtmrz/livesync-commonlib/-/livesync-commonlib-0.1.11.tgz",
+            "integrity": "sha512-7hwQSTND9GFdJqIz6UhWN/W6BC0uehtKXjm2q6He2vk4s2xLMnTKwmTqJH5iiQQFVvmMROJUA3eqUm5K2W2/tw==",
             "license": "MIT",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
         "@smithy/types": "^4.14.3",
         "@smithy/util-retry": "^4.4.5",
         "@vrtmrz/browser-ui-kit": "0.1.0",
-        "@vrtmrz/livesync-commonlib": "0.1.10",
+        "@vrtmrz/livesync-commonlib": "0.1.11",
         "@vrtmrz/obsidian-plugin-kit": "0.1.3",
         "@vrtmrz/ui-interactions": "0.1.2",
         "diff-match-patch": "^1.0.5",

--- a/updates.md
+++ b/updates.md
@@ -12,6 +12,13 @@ Earlier releases remain available in the 0.25 release history and the legacy rel
 
 ## Unreleased
 
+### Synchronisation and storage
+
+#### Fixed
+
+- Start-up and recovery scans now keep failed database-to-Vault writes retryable instead of recording them as successful and later mistaking the still-missing file for a local deletion ([Commonlib PR #106](https://github.com/vrtmrz/livesync-commonlib/pull/106)).
+    - Files over the size limit or in conflict remain deliberate skips, while actual write failures are reported to Fast Setup, CLI mirror, and daemon callers.
+
 ## 1.0.11
 
 9th August, 2026


### PR DESCRIPTION
Update Commonlib to 0.1.11 so offline scans preserve failed database-to-Vault writes as retryable failures rather than later treating still-missing files as local deletions.

## Summary

- Lock `@vrtmrz/livesync-commonlib` to the reviewed and published `0.1.11` artefact.
- Record the corrected start-up and recovery scan behaviour under `Unreleased`.
- Keep files over the size limit or in conflict as deliberate skips, while propagating actual write failures to their callers.

## Rationale

A database-to-Vault write which returned `false` could previously receive success side effects. Its database modification time could then be persisted as though the file had existed locally, allowing a later newer-wins scan to mistake the still-missing file for an offline local deletion. Commonlib 0.1.11 distinguishes completed, skipped, and failed pair outcomes and records reflection provenance only after a successful write.

## Verification

- `npm ci --no-audit --no-fund`
- Focused LiveSync unit tests: 149 passed
- `NODE_OPTIONS=--max-old-space-size=3072 npm run check`
- CLI mirror E2E: 6 cases passed
- Exact published-package consumer validation covered the plug-in, CLI, WebApp, and WebPeer builds, together with the real Obsidian start-up scan workflow.
