### PR TITLE
Add Metadata document ID repair release note

### DIFF
--- a/updates.md
+++ b/updates.md
@@ -12,6 +12,13 @@ Earlier releases remain available in the 0.25 release history and the legacy rel
 
 ## Unreleased
 
+### Conflict handling and recovery
+
+#### Improved
+
+- **Inspect conflicts and file/database differences** now reports local Metadata whose stored document ID does not match the ID derived from its recorded path. Ordinary scans leave unresolved entries and their corresponding Vault paths unchanged, while allowing consistently addressed Metadata for the same logical path to proceed normally.
+    - When one live, unconflicted entry has an unambiguous target, its wrench menu can repair that one local Metadata document after separate confirmation. The target is written and verified before the mismatched source ID is removed; ambiguous or otherwise unsafe entries remain read-only.
+
 ## 1.0.12
 
 11th August, 2026


### PR DESCRIPTION
Adds the release note for the new Metadata document ID inspection and repair workflow.