### PR TITLE
Update Commonlib to 0.1.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "@smithy/types": "^4.14.3",
                 "@smithy/util-retry": "^4.4.5",
                 "@vrtmrz/browser-ui-kit": "0.1.0",
-                "@vrtmrz/livesync-commonlib": "0.1.12",
+                "@vrtmrz/livesync-commonlib": "0.1.13",
                 "@vrtmrz/obsidian-plugin-kit": "0.1.3",
                 "@vrtmrz/ui-interactions": "0.1.2",
                 "diff-match-patch": "^1.0.5",
@@ -32,7 +32,7 @@
                 "markdown-it": "^14.2.0",
                 "minimatch": "^10.2.5",
                 "obsidian": "^1.13.1",
-                "octagonal-wheels": "^0.1.52",
+                "octagonal-wheels": "^0.1.53",
                 "qrcode-generator": "^1.4.4",
                 "xxhash-wasm-102": "npm:xxhash-wasm@^1.0.2"
             },
@@ -4775,9 +4775,9 @@
             }
         },
         "node_modules/@vrtmrz/livesync-commonlib": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/@vrtmrz/livesync-commonlib/-/livesync-commonlib-0.1.12.tgz",
-            "integrity": "sha512-SYqUsMcz9241qEUqmnIwVKOPXJB4/FXjXQh8nHPmX004KkV5PUnAm4ClhNwlQzvYfpTI5IHYKej+JIndiQYXmw==",
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/@vrtmrz/livesync-commonlib/-/livesync-commonlib-0.1.13.tgz",
+            "integrity": "sha512-yWzmq+2sGX39gIB37igrjvctJKD5N3jlWT+ATavm81aOjEp6VUOIT2FzUpOq/3BEM8eE83uzu3N6/rXEpksEiw==",
             "license": "MIT",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.808.0",
@@ -4793,7 +4793,7 @@
                 "idb": "^8.0.3",
                 "markdown-it": "^14.2.0",
                 "minimatch": "^10.2.5",
-                "octagonal-wheels": "^0.1.51",
+                "octagonal-wheels": "^0.1.53",
                 "pouchdb-adapter-http": "^9.0.0",
                 "pouchdb-adapter-idb": "^9.0.0",
                 "pouchdb-adapter-indexeddb": "^9.0.0",
@@ -11532,9 +11532,9 @@
             "license": "MIT"
         },
         "node_modules/octagonal-wheels": {
-            "version": "0.1.52",
-            "resolved": "https://registry.npmjs.org/octagonal-wheels/-/octagonal-wheels-0.1.52.tgz",
-            "integrity": "sha512-9WJN2UveNh90Op1S07cIso1WyNrQbO/unibDLfUGnpomIcU4g6F+p8reZHW0Ed8sGzKF5qGnQp991Y9MB1TwNg==",
+            "version": "0.1.53",
+            "resolved": "https://registry.npmjs.org/octagonal-wheels/-/octagonal-wheels-0.1.53.tgz",
+            "integrity": "sha512-4NJsb96Sk6rJXhrTyjAY5GRIoWMFJsFp56b5ba9fV8/87ys2HCjMo0hior4F8k4ma72pLTJT7i6DvuihHxSsMA==",
             "license": "MIT",
             "dependencies": {
                 "idb": "^8.0.3"
@@ -15928,7 +15928,7 @@
             "dependencies": {
                 "chokidar": "^4.0.0",
                 "minimatch": "^10.2.5",
-                "octagonal-wheels": "^0.1.52",
+                "octagonal-wheels": "^0.1.53",
                 "pouchdb-adapter-http": "^9.0.0",
                 "pouchdb-adapter-leveldb": "^9.0.0",
                 "pouchdb-core": "^9.0.0",
@@ -15951,7 +15951,7 @@
             "name": "livesync-webapp",
             "version": "1.0.13-webapp",
             "dependencies": {
-                "octagonal-wheels": "^0.1.52"
+                "octagonal-wheels": "^0.1.53"
             },
             "devDependencies": {
                 "@sveltejs/vite-plugin-svelte": "^7.1.2",
@@ -15963,7 +15963,7 @@
         "src/apps/webpeer": {
             "version": "1.0.13-webpeer",
             "dependencies": {
-                "octagonal-wheels": "^0.1.52"
+                "octagonal-wheels": "^0.1.53"
             },
             "devDependencies": {
                 "@sveltejs/vite-plugin-svelte": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
         "@smithy/types": "^4.14.3",
         "@smithy/util-retry": "^4.4.5",
         "@vrtmrz/browser-ui-kit": "0.1.0",
-        "@vrtmrz/livesync-commonlib": "0.1.12",
+        "@vrtmrz/livesync-commonlib": "0.1.13",
         "@vrtmrz/obsidian-plugin-kit": "0.1.3",
         "@vrtmrz/ui-interactions": "0.1.2",
         "diff-match-patch": "^1.0.5",
@@ -186,7 +186,7 @@
         "markdown-it": "^14.2.0",
         "minimatch": "^10.2.5",
         "obsidian": "^1.13.1",
-        "octagonal-wheels": "^0.1.52",
+        "octagonal-wheels": "^0.1.53",
         "qrcode-generator": "^1.4.4",
         "xxhash-wasm-102": "npm:xxhash-wasm@^1.0.2"
     },

--- a/src/apps/cli/package.json
+++ b/src/apps/cli/package.json
@@ -37,7 +37,7 @@
     "dependencies": {
         "chokidar": "^4.0.0",
         "minimatch": "^10.2.5",
-        "octagonal-wheels": "^0.1.52",
+        "octagonal-wheels": "^0.1.53",
         "pouchdb-adapter-http": "^9.0.0",
         "pouchdb-adapter-leveldb": "^9.0.0",
         "pouchdb-core": "^9.0.0",

--- a/src/apps/webapp/package.json
+++ b/src/apps/webapp/package.json
@@ -15,7 +15,7 @@
         "test:browser": "deno test -A --no-check --frozen --config ../../../test/browser-apps/deno.json --lock ../../../test/browser-apps/deno.lock ../../../test/browser-apps/webapp/browser-smoke.test.ts"
     },
     "dependencies": {
-        "octagonal-wheels": "^0.1.52"
+        "octagonal-wheels": "^0.1.53"
     },
     "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^7.1.2",

--- a/src/apps/webpeer/package.json
+++ b/src/apps/webpeer/package.json
@@ -15,7 +15,7 @@
         "test:browser": "deno test -A --no-check --frozen --config ../../../test/browser-apps/deno.json --lock ../../../test/browser-apps/deno.lock ../../../test/browser-apps/webpeer/browser-smoke.test.ts"
     },
     "dependencies": {
-        "octagonal-wheels": "^0.1.52"
+        "octagonal-wheels": "^0.1.53"
     },
     "devDependencies": {
         "eslint-plugin-svelte": "^3.19.0",


### PR DESCRIPTION
This dependency-only change adopts Commonlib 0.1.13 and Octagonal Wheels 0.1.53 so their published TypeScript entry points remain available to legacy module-resolution consumers without changing LiveSync runtime behaviour.

## Summary

- Update `@vrtmrz/livesync-commonlib` from 0.1.12 to 0.1.13.
- Align direct `octagonal-wheels` dependencies on 0.1.53 in the plug-in, CLI, WebApp, and WebPeer.
- Refresh only the corresponding lockfile entries.

## Rationale

These package releases add generated `typesVersions` mappings alongside their existing `exports` metadata. This allows the published root and subpath declarations to resolve under the legacy TypeScript Node10 module resolver as well as the modern resolver used by LiveSync.

A fresh external Community Review report retained its existing type-analysis warnings, while focused local community lint did not reproduce them. This pull request therefore does not claim to resolve those warnings; the review-environment difference remains separate from this dependency update.

The update does not require an immediate LiveSync release and may be included in the next normal release.

## Verification

- Clean installation of the exact published registry packages.
- Node10 resolution of all 116 declared Commonlib type entry points.
- `npm run check`
- `npm run test:unit` — 90 test files and 638 tests passed with one worker.
- Production plug-in, CLI, WebApp, and WebPeer builds.
- Focused Community Review lint of representative previously reported files.
