### PR TITLE
Close finite remote database connections owned by LiveSync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "@smithy/types": "^4.14.3",
                 "@smithy/util-retry": "^4.4.5",
                 "@vrtmrz/browser-ui-kit": "0.1.0",
-                "@vrtmrz/livesync-commonlib": "0.1.13",
+                "@vrtmrz/livesync-commonlib": "0.1.14",
                 "@vrtmrz/obsidian-plugin-kit": "0.1.3",
                 "@vrtmrz/ui-interactions": "0.1.2",
                 "diff-match-patch": "^1.0.5",
@@ -4771,9 +4771,9 @@
             }
         },
         "node_modules/@vrtmrz/livesync-commonlib": {
-            "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/@vrtmrz/livesync-commonlib/-/livesync-commonlib-0.1.13.tgz",
-            "integrity": "sha512-yWzmq+2sGX39gIB37igrjvctJKD5N3jlWT+ATavm81aOjEp6VUOIT2FzUpOq/3BEM8eE83uzu3N6/rXEpksEiw==",
+            "version": "0.1.14",
+            "resolved": "https://registry.npmjs.org/@vrtmrz/livesync-commonlib/-/livesync-commonlib-0.1.14.tgz",
+            "integrity": "sha512-ndHo1cKyEf4n9An5uovlTGbf56cpHjGARjOjSwMmzizC+qVJVEkRg7Ym94Eoa+KoheWTY614BweEtyAl9rKCfw==",
             "license": "MIT",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
         "@smithy/types": "^4.14.3",
         "@smithy/util-retry": "^4.4.5",
         "@vrtmrz/browser-ui-kit": "0.1.0",
-        "@vrtmrz/livesync-commonlib": "0.1.13",
+        "@vrtmrz/livesync-commonlib": "0.1.14",
         "@vrtmrz/obsidian-plugin-kit": "0.1.3",
         "@vrtmrz/ui-interactions": "0.1.2",
         "diff-match-patch": "^1.0.5",

--- a/src/apps/cli/commands/runCommand.ts
+++ b/src/apps/cli/commands/runCommand.ts
@@ -58,7 +58,11 @@ async function verifyRemoteState(
                 standardIo.writeStderr(`[Verification] Failed to connect to remote CouchDB: ${dbRet}\n`);
                 return false;
             }
-            milestone = await dbRet.db.get(MILESTONE_DOCID);
+            try {
+                milestone = await dbRet.db.get(MILESTONE_DOCID);
+            } finally {
+                await dbRet.db.close();
+            }
         } else if (settings.remoteType === REMOTE_MINIO) {
             milestone = await (replicator as LiveSyncJournalReplicator).client.downloadJson("_00000000-milestone.json");
         }

--- a/src/apps/cli/commands/runCommand.unit.spec.ts
+++ b/src/apps/cli/commands/runCommand.unit.spec.ts
@@ -708,6 +708,18 @@ describe("runCommand abnormal cases", () => {
     describe("mark-resolved and unlock-remote commands", () => {
         it("mark-resolved without args runs on active database", async () => {
             const core = createCoreMock();
+            const remoteDatabase = {
+                close: vi.fn(async () => undefined),
+                get: vi.fn(async () => ({
+                    locked: false,
+                    accepted_nodes: ["test-node-id"],
+                })),
+            };
+            core.services.replicator.getActiveReplicator.mockReturnValueOnce({
+                nodeid: "test-node-id",
+                initializeDatabaseForReplication: vi.fn(async () => undefined),
+                connectRemoteCouchDBWithSetting: vi.fn(async () => ({ db: remoteDatabase })),
+            });
             const result = await runCommand(makeOptions("mark-resolved", []), {
                 ...context,
                 core,
@@ -715,6 +727,7 @@ describe("runCommand abnormal cases", () => {
             expect(result).toBe(true);
             expect(core.services.replication.markResolved).toHaveBeenCalledTimes(1);
             expect(core.services.control.applySettings).not.toHaveBeenCalled();
+            expect(remoteDatabase.close).toHaveBeenCalledOnce();
         });
 
         it("mark-resolved with remote-id temporarily activates it and runs markResolved", async () => {

--- a/src/features/LocalDatabaseMainte/CmdLocalDatabaseMainte.integration.spec.ts
+++ b/src/features/LocalDatabaseMainte/CmdLocalDatabaseMainte.integration.spec.ts
@@ -95,18 +95,19 @@ function requiredEnvironment(name: "hostname" | "username" | "password"): string
 describe("LocalDatabaseMaintenance Garbage Collection V3 with CouchDB", () => {
     it("propagates collection safely, completes compaction, and permits content-addressed chunk recreation", async () => {
         const databaseName = `livesync-gcv3-${crypto.randomUUID()}`;
-        const local = new PouchDB<FixtureContent>(`${databaseName}-source`, { adapter: "memory" });
-        const replica = new PouchDB<FixtureContent>(`${databaseName}-replica`, { adapter: "memory" });
-        const remote = new PouchDB<FixtureContent>(
-            `${requiredEnvironment("hostname").replace(/\/+$/u, "")}/${databaseName}`,
-            {
+        const createRemote = () =>
+            new PouchDB<FixtureContent>(`${requiredEnvironment("hostname").replace(/\/+$/u, "")}/${databaseName}`, {
                 adapter: "http",
                 auth: {
                     username: requiredEnvironment("username"),
                     password: requiredEnvironment("password"),
                 },
-            }
-        );
+            });
+        const local = new PouchDB<FixtureContent>(`${databaseName}-source`, { adapter: "memory" });
+        const replica = new PouchDB<FixtureContent>(`${databaseName}-replica`, { adapter: "memory" });
+        const remote = createRemote();
+        const maintenanceRemote = createRemote();
+        const closeMaintenanceRemote = vi.spyOn(maintenanceRemote, "close");
 
         try {
             await remote.info();
@@ -178,7 +179,7 @@ describe("LocalDatabaseMaintenance Garbage Collection V3 with CouchDB", () => {
                         },
                     })
                 ),
-                connectRemoteCouchDBWithSetting: vi.fn(() => Promise.resolve({ db: remote })),
+                connectRemoteCouchDBWithSetting: vi.fn(() => Promise.resolve({ db: maintenanceRemote })),
             };
             const notice = vi.fn();
             const maintenance = Object.create(LocalDatabaseMaintenance.prototype) as LocalDatabaseMaintenance;
@@ -201,6 +202,7 @@ describe("LocalDatabaseMaintenance Garbage Collection V3 with CouchDB", () => {
 
             await maintenance.gcv3();
 
+            expect(closeMaintenanceRemote).toHaveBeenCalledOnce();
             expect(replicationModes).toEqual(["sync", "pushOnly"]);
             expect(clearHash).toHaveBeenCalledOnce();
             expect(notice).toHaveBeenCalledWith("Compaction on remote database completed successfully.", "gc-compact");
@@ -251,6 +253,9 @@ describe("LocalDatabaseMaintenance Garbage Collection V3 with CouchDB", () => {
                 data: "recreated",
             });
         } finally {
+            if (closeMaintenanceRemote.mock.calls.length === 0) {
+                await maintenanceRemote.close();
+            }
             await Promise.all([local.destroy(), replica.destroy(), remote.destroy()]);
         }
     }, 30_000);

--- a/src/features/LocalDatabaseMainte/CmdLocalDatabaseMainte.ts
+++ b/src/features/LocalDatabaseMainte/CmdLocalDatabaseMainte.ts
@@ -747,29 +747,33 @@ Success: ${successCount}, Errored: ${errored}`;
             this._notice(`Failed to connect to remote for compaction. ${remote}`, "gc-compact");
             return;
         }
-        const compactResult = await remote.db.compact({
-            interval: 1000,
-        });
-        // Probably no need to wait, but just in case.
-        let timeout = 2 * 60 * 1000; // 2 minutes
-        for (;;) {
-            const status = await remote.db.info();
-            if ("compact_running" in status && status?.compact_running) {
-                this._notice("Compaction in progress on remote database...", "gc-compact");
-                await delay(2000);
-                timeout -= 2000;
-                if (timeout <= 0) {
-                    this._notice("Compaction on remote database timed out.", "gc-compact");
-                    return;
+        try {
+            const compactResult = await remote.db.compact({
+                interval: 1000,
+            });
+            // Probably no need to wait, but just in case.
+            let timeout = 2 * 60 * 1000; // 2 minutes
+            for (;;) {
+                const status = await remote.db.info();
+                if ("compact_running" in status && status?.compact_running) {
+                    this._notice("Compaction in progress on remote database...", "gc-compact");
+                    await delay(2000);
+                    timeout -= 2000;
+                    if (timeout <= 0) {
+                        this._notice("Compaction on remote database timed out.", "gc-compact");
+                        return;
+                    }
+                } else {
+                    break;
                 }
-            } else {
-                break;
             }
-        }
-        if (compactResult && "ok" in compactResult) {
-            this._notice("Compaction on remote database completed successfully.", "gc-compact");
-        } else {
-            this._notice("Compaction on remote database failed.", "gc-compact");
+            if (compactResult && "ok" in compactResult) {
+                this._notice("Compaction on remote database completed successfully.", "gc-compact");
+            } else {
+                this._notice("Compaction on remote database failed.", "gc-compact");
+            }
+        } finally {
+            await remote.db.close();
         }
     }
 

--- a/src/features/LocalDatabaseMainte/CmdLocalDatabaseMainte.unit.spec.ts
+++ b/src/features/LocalDatabaseMainte/CmdLocalDatabaseMainte.unit.spec.ts
@@ -222,6 +222,7 @@ describe("LocalDatabaseMaintenance Garbage Collection V3", () => {
         const remoteDatabase = {
             compact: vi.fn(async () => ({ ok: true })),
             info: vi.fn(async () => ({ compact_running: true })),
+            close: vi.fn(async () => undefined),
         };
         Object.assign(maintenance, {
             core: {
@@ -243,6 +244,7 @@ describe("LocalDatabaseMaintenance Garbage Collection V3", () => {
             "Compaction on remote database completed successfully.",
             "gc-compact"
         );
+        expect(remoteDatabase.close).toHaveBeenCalledOnce();
     });
 
     it.each([

--- a/src/modules/core/ModuleReplicator.ts
+++ b/src/modules/core/ModuleReplicator.ts
@@ -187,27 +187,31 @@ Even if you choose to clean up, you will see this option again if you exit Obsid
                             return false;
                         }
 
-                        await purgeUnreferencedChunks(this.localDatabase.localDatabase, false);
-                        this.localDatabase.clearCaches();
-                        // Perform the synchronisation once.
-                        const replicated = await this.services.replicator.runFiniteReplicationActivity(
-                            () => this.core.replicator.openReplication(this.settings, false, showMessage, true),
-                            { label: "replication" }
-                        );
-                        if (replicated) {
-                            await balanceChunkPurgedDBs(this.localDatabase.localDatabase, remoteDB.db);
+                        try {
                             await purgeUnreferencedChunks(this.localDatabase.localDatabase, false);
                             this.localDatabase.clearCaches();
-                            await this.services.replicator.getActiveReplicator()?.markRemoteResolved(this.settings);
-                            Logger(
-                                "The local database has been cleaned up.",
-                                showMessage ? LOG_LEVEL_NOTICE : LOG_LEVEL_INFO
+                            // Perform the synchronisation once.
+                            const replicated = await this.services.replicator.runFiniteReplicationActivity(
+                                () => this.core.replicator.openReplication(this.settings, false, showMessage, true),
+                                { label: "replication" }
                             );
-                        } else {
-                            Logger(
-                                "Replication has been cancelled. Please try it again.",
-                                showMessage ? LOG_LEVEL_NOTICE : LOG_LEVEL_INFO
-                            );
+                            if (replicated) {
+                                await balanceChunkPurgedDBs(this.localDatabase.localDatabase, remoteDB.db);
+                                await purgeUnreferencedChunks(this.localDatabase.localDatabase, false);
+                                this.localDatabase.clearCaches();
+                                await this.services.replicator.getActiveReplicator()?.markRemoteResolved(this.settings);
+                                Logger(
+                                    "The local database has been cleaned up.",
+                                    showMessage ? LOG_LEVEL_NOTICE : LOG_LEVEL_INFO
+                                );
+                            } else {
+                                Logger(
+                                    "Replication has been cancelled. Please try it again.",
+                                    showMessage ? LOG_LEVEL_NOTICE : LOG_LEVEL_INFO
+                                );
+                            }
+                        } finally {
+                            await remoteDB.db.close();
                         }
                     },
                     { label: "database-cleanup" }

--- a/src/modules/core/ModuleReplicator.unit.spec.ts
+++ b/src/modules/core/ModuleReplicator.unit.spec.ts
@@ -128,8 +128,11 @@ describe("compatibility: cleaned-remote reconciliation for IndexedDB clients", (
         });
         const runFiniteReplicationActivity = vi.fn(async (task: () => unknown) => await task());
         const openReplication = vi.fn(async () => true);
+        const remoteDatabase = {
+            close: vi.fn(async () => undefined),
+        };
         const activeReplicator = Object.assign(new LiveSyncCouchDBReplicator({} as any), {
-            connectRemoteCouchDBWithSetting: vi.fn(async () => ({ db: {} })),
+            connectRemoteCouchDBWithSetting: vi.fn(async () => ({ db: remoteDatabase })),
             markRemoteResolved: vi.fn(async () => undefined),
         });
         const services = {
@@ -177,5 +180,9 @@ describe("compatibility: cleaned-remote reconciliation for IndexedDB clients", (
         expect(openReplication).toHaveBeenCalledOnce();
         expect(openReplication.mock.invocationCallOrder[0]).toBeLessThan(activityFinished.mock.invocationCallOrder[0]);
         expect(chunkMocks.balanceChunkPurgedDBs).toHaveBeenCalledOnce();
+        expect(remoteDatabase.close).toHaveBeenCalledOnce();
+        expect(remoteDatabase.close.mock.invocationCallOrder[0]).toBeLessThan(
+            activityFinished.mock.invocationCallOrder[0]
+        );
     });
 });

--- a/src/modules/features/SettingDialogue/ObsidianLiveSyncSettingTab.ts
+++ b/src/modules/features/SettingDialogue/ObsidianLiveSyncSettingTab.ts
@@ -547,7 +547,8 @@ export class ObsidianLiveSyncSettingTab extends PluginSettingTab {
         if (typeof db === "string") {
             Logger($msg("obsidianLiveSyncSettingTab.logCheckPassphraseFailed", { db }), LOG_LEVEL_NOTICE);
             return false;
-        } else {
+        }
+        try {
             if (await checkSyncInfo(db.db)) {
                 // Logger($msg("obsidianLiveSyncSettingTab.logDatabaseConnected"), LOG_LEVEL_NOTICE);
                 return true;
@@ -555,6 +556,8 @@ export class ObsidianLiveSyncSettingTab extends PluginSettingTab {
                 Logger($msg("obsidianLiveSyncSettingTab.logPassphraseNotCompatible"), LOG_LEVEL_NOTICE);
                 return false;
             }
+        } finally {
+            await db.db.close();
         }
     };
     isPassphraseValid = async () => {

--- a/src/modules/features/SettingDialogue/ObsidianLiveSyncSettingTab.unit.spec.ts
+++ b/src/modules/features/SettingDialogue/ObsidianLiveSyncSettingTab.unit.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_SETTINGS, REMOTE_COUCHDB } from "@vrtmrz/livesync-commonlib/compat/common/types";
+
+const negotiationMocks = vi.hoisted(() => ({
+    checkSyncInfo: vi.fn(async () => true),
+}));
+
+vi.mock("@/deps.ts", () => ({
+    App: class {},
+    Component: class {},
+    PluginSettingTab: class {},
+}));
+vi.mock("@/main.ts", () => ({ default: class {} }));
+vi.mock("@/common/events.ts", () => ({
+    EVENT_REQUEST_RELOAD_SETTING_TAB: "request-reload-setting-tab",
+    eventHub: { onEvent: vi.fn() },
+}));
+vi.mock("@vrtmrz/livesync-commonlib/compat/pouchdb/negotiation", () => negotiationMocks);
+vi.mock("@vrtmrz/livesync-commonlib/compat/replication/couchdb/LiveSyncReplicator", () => ({
+    LiveSyncCouchDBReplicator: class {},
+}));
+vi.mock("./LiveSyncSetting.ts", () => ({ LiveSyncSetting: class {} }));
+vi.mock("./SettingPane.ts", () => ({
+    enableOnly: vi.fn(() => vi.fn()),
+    setLevelClass: vi.fn(),
+    setStyle: vi.fn(),
+    visibleOnly: vi.fn(() => vi.fn()),
+}));
+vi.mock("./PaneChangeLog.ts", () => ({ paneChangeLog: vi.fn() }));
+vi.mock("./PaneSetup.ts", () => ({ paneSetup: vi.fn() }));
+vi.mock("./PaneGeneral.ts", () => ({ paneGeneral: vi.fn() }));
+vi.mock("./PaneRemoteConfig.ts", () => ({ paneRemoteConfig: vi.fn() }));
+vi.mock("./PaneSelector.ts", () => ({ paneSelector: vi.fn() }));
+vi.mock("./PaneSyncSettings.ts", () => ({ paneSyncSettings: vi.fn() }));
+vi.mock("./PaneCustomisationSync.ts", () => ({ paneCustomisationSync: vi.fn() }));
+vi.mock("./PaneHatch.ts", () => ({ paneHatch: vi.fn() }));
+vi.mock("./PaneAdvanced.ts", () => ({ paneAdvanced: vi.fn() }));
+vi.mock("./PanePowerUsers.ts", () => ({ panePowerUsers: vi.fn() }));
+vi.mock("./PanePatches.ts", () => ({ panePatches: vi.fn() }));
+vi.mock("./PaneMaintenance.ts", () => ({ paneMaintenance: vi.fn() }));
+
+import { LiveSyncCouchDBReplicator } from "@vrtmrz/livesync-commonlib/compat/replication/couchdb/LiveSyncReplicator";
+import { ObsidianLiveSyncSettingTab } from "./ObsidianLiveSyncSettingTab";
+
+describe("ObsidianLiveSyncSettingTab passphrase verification", () => {
+    it("closes the finite remote connection after checking synchronisation information", async () => {
+        const remoteDatabase = {
+            close: vi.fn(async () => undefined),
+        };
+        const replicator = Object.assign(new LiveSyncCouchDBReplicator({} as never), {
+            connectRemoteCouchDBWithSetting: vi.fn(async () => ({ db: remoteDatabase })),
+        });
+        const plugin = {
+            app: {},
+            core: {
+                services: {
+                    API: { isMobile: vi.fn(() => false) },
+                    replicator: { getNewReplicator: vi.fn(() => replicator) },
+                },
+            },
+        };
+        const tab = new ObsidianLiveSyncSettingTab({} as never, plugin as never);
+        Object.assign(tab, {
+            _editingSettings: {
+                ...DEFAULT_SETTINGS,
+                remoteType: REMOTE_COUCHDB,
+            },
+        });
+
+        await expect(tab.checkWorkingPassphrase()).resolves.toBe(true);
+
+        expect(negotiationMocks.checkSyncInfo).toHaveBeenCalledWith(remoteDatabase);
+        expect(remoteDatabase.close).toHaveBeenCalledOnce();
+    });
+});

--- a/src/modules/features/SetupWizard/dialogs/couchDBConnectionProbe.ts
+++ b/src/modules/features/SetupWizard/dialogs/couchDBConnectionProbe.ts
@@ -8,7 +8,7 @@ export type CouchDBConnectionProbeResult = { ok: true } | { ok: false; reason: s
 type CouchDBConnectionResult =
     | string
     | {
-          db: unknown;
+          db: { close(): Promise<void> };
           info: unknown;
       };
 
@@ -50,7 +50,11 @@ export async function probeCouchDBConnection(
     if (typeof result === "string") {
         return { ok: false, reason: result };
     }
-    return { ok: true };
+    try {
+        return { ok: true };
+    } finally {
+        await result.db.close();
+    }
 }
 
 export function isValidCouchDBServerURL(value: string): boolean {

--- a/src/modules/features/SetupWizard/dialogs/couchDBConnectionProbe.unit.spec.ts
+++ b/src/modules/features/SetupWizard/dialogs/couchDBConnectionProbe.unit.spec.ts
@@ -14,8 +14,9 @@ describe("CouchDB setup connection policy", () => {
     ] as const)(
         "%s can %s without changing the Commonlib connection contract",
         async (createIfMissing, _description) => {
+            const close = vi.fn(async () => undefined);
             const connectRemoteCouchDBWithSetting = vi.fn(async () => ({
-                db: {},
+                db: { close },
                 info: { db_name: "notes" },
             }));
             const replicator = {
@@ -27,6 +28,7 @@ describe("CouchDB setup connection policy", () => {
             await expect(probeCouchDBConnection(replicator, settings, createIfMissing)).resolves.toEqual({ ok: true });
             expect(connectRemoteCouchDBWithSetting).toHaveBeenCalledWith(settings, false, createIfMissing, false);
             expect(replicator.tryConnectRemote).not.toHaveBeenCalled();
+            expect(close).toHaveBeenCalledOnce();
         }
     );
 


### PR DESCRIPTION
Close finite CouchDB connections owned by LiveSync and adopt Commonlib 0.1.14 so temporary remote PouchDB instances are released after finite operations.

## Summary

- Update the exact Commonlib dependency to 0.1.14, which closes remote database handles wholly owned within Commonlib.
- Close the remote connection used by command-line milestone verification.
- Close remote maintenance connections after compaction and database clean-up, including timeout and cancellation paths.
- Close connections created for settings passphrase checks and Setup Wizard connection probes.
- Add regression coverage which verifies that each acquired finite connection is closed.

## Rationale

Commonlib 0.1.14 closes remote database handles whose lifecycle begins and ends within Commonlib. However, `connectRemoteCouchDBWithSetting()` returns a caller-owned handle, so finite LiveSync operations must close that handle after completing their work.

PouchDB retains unclosed HTTP database instances and their destruction listeners. These remaining LiveSync-owned paths can therefore contribute to the periodic growth reported in #1034. Continuous replication connections retain their existing lifecycle.

This change is expected to address the remaining identified ownership paths. Issue #1034 should remain open until a long-running heap snapshot confirms that retained remote instances remain at a constant level.

## Verification

- [x] Clean installation with npm 10.9.2 and npm 11.18.0 using `npm ci --ignore-scripts`.
- [x] Focused unit tests: 5 files and 62 tests.
- [x] Focused real CouchDB integration tests: 4 files and 4 tests.
- [x] Full `NODE_OPTIONS=--max-old-space-size=3072 npm run check`.
- [x] Production plug-in, CLI, webapp, and webpeer builds.
- [x] GitHub Actions unit, integration, CLI/Deno matrix, Pages, and security checks.
- [x] `git diff --check origin/main...HEAD`.
