### PR TITLE
Update Commonlib to 0.1.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "@smithy/types": "^4.14.3",
                 "@smithy/util-retry": "^4.4.5",
                 "@vrtmrz/browser-ui-kit": "0.1.0",
-                "@vrtmrz/livesync-commonlib": "0.1.14",
+                "@vrtmrz/livesync-commonlib": "0.1.15",
                 "@vrtmrz/obsidian-plugin-kit": "0.1.3",
                 "@vrtmrz/ui-interactions": "0.1.2",
                 "diff-match-patch": "^1.0.5",
@@ -4771,9 +4771,9 @@
             }
         },
         "node_modules/@vrtmrz/livesync-commonlib": {
-            "version": "0.1.14",
-            "resolved": "https://registry.npmjs.org/@vrtmrz/livesync-commonlib/-/livesync-commonlib-0.1.14.tgz",
-            "integrity": "sha512-ndHo1cKyEf4n9An5uovlTGbf56cpHjGARjOjSwMmzizC+qVJVEkRg7Ym94Eoa+KoheWTY614BweEtyAl9rKCfw==",
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/@vrtmrz/livesync-commonlib/-/livesync-commonlib-0.1.15.tgz",
+            "integrity": "sha512-uQxxzOdzu0MVcS6g20AxNLNj933Q3N5j/gZ2o6sem36vlsXQPKnsjGjTzrYcYAXNJ9mkR82EvC8qmKnOZvjEPg==",
             "license": "MIT",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
         "@smithy/types": "^4.14.3",
         "@smithy/util-retry": "^4.4.5",
         "@vrtmrz/browser-ui-kit": "0.1.0",
-        "@vrtmrz/livesync-commonlib": "0.1.14",
+        "@vrtmrz/livesync-commonlib": "0.1.15",
         "@vrtmrz/obsidian-plugin-kit": "0.1.3",
         "@vrtmrz/ui-interactions": "0.1.2",
         "diff-match-patch": "^1.0.5",


### PR DESCRIPTION
This dependency update adopts Commonlib 0.1.15 so startup offline scans no longer repeat redundant path-hash work.

## Summary

- pin the LiveSync runtime dependency and root lockfile to `@vrtmrz/livesync-commonlib@0.1.15`;
- retain the independently validated Commonlib version used by the standalone Setup utilities; and
- preserve the npm 10-compatible lockfile structure used by Community Review.

This should reduce startup scan time most noticeably for larger Vaults using path obfuscation. Commonlib 0.1.15 changes only the redundant digest work; the resulting document identifiers remain unchanged.

## Verification

- `npx --yes npm@10.9.2 ci --ignore-scripts`
- `npm run check`
- clean installation of the exact registry artefact
- 153 focused unit tests
- production build and iOS 15 compatibility check
- Obsidian 1.12.7 startup-scan E2E using the exact registry artefact
