### PR TITLE
Add 1.0.15 release notes

### DIFF
--- a/updates.md
+++ b/updates.md
@@ -12,6 +12,18 @@ Earlier releases remain available in the 1.0 release history, the 1.0 preview hi
 
 ## Unreleased
 
+### Synchronisation and storage
+
+#### Improved
+
+- Start-up offline scanning is now faster, especially for larger Vaults using path obfuscation (Commonlib 0.1.15).
+
+### Interface and translation
+
+#### Improved
+
+- The Traditional Chinese translation catalogue has been completed and polished for broader coverage and more natural, consistent terminology (PR #1106). Thank you to @nimula for the contribution!
+
 ## 1.0.14
 
 14th August, 2026


### PR DESCRIPTION
This documentation change records the user-facing improvements intended for Self-hosted LiveSync 1.0.15 before the release workflow prepares version metadata.

## Summary

- note the faster start-up offline scan provided by Commonlib 0.1.15
- record the completed and polished Traditional Chinese translation catalogue
- thank @nimula for the translation contribution in PR #1106

## Verification

- `git diff --check`
