### PR TITLE
Define synchronising devices terminology

### DIFF
--- a/docs/terms.md
+++ b/docs/terms.md
@@ -43,7 +43,7 @@ All guidelines and conventions listed below are disclosed and maintained solely 
 - Database Suffix (additionalSuffixOfDatabaseName)
     - A unique suffix appended to the database name to allow synchronising multiple vaults with the same name on the same remote server.
 - E2EE Algorithm
-    - The cryptographic algorithm version used for end-to-end encryption. All devices in the synchronisation group must be configured with a compatible version (such as `V2` or `V1`).
+    - The cryptographic algorithm version used for end-to-end encryption. All synchronising devices must be configured with a compatible version (such as `V2` or `V1`).
 - Eden (Eden Chunks)
     - A performance optimisation where newly created chunks are held within the document until they stabilise, before graduating to independent chunks.
 - Fast Setup (Simple Fetch)
@@ -110,6 +110,8 @@ Avoid **live revision** in prose because it can ambiguously mean either a curren
     - A data transfer method that downloads database documents as a continuous stream of events. It is significantly faster than traditional chunk-by-chunk HTTP requests and is used during Fast Setup to retrieve remote metadata quickly.
 - Sync Mode
     - The replication trigger mechanism. Users can select from `On Events` (synchronising on local file changes), `Periodic and Events` (synchronising at fixed intervals as well as on events), or `LiveSync` (continuous, real-time synchronisation).
+- Synchronising devices
+    - Devices which participate in the same synchronisation for a Vault. The term describes membership rather than current activity, so it includes offline and idle devices.
 - TURN Server (WebRTC P2P)
     - A Traversal Using Relays around NAT server used as an optional fallback to relay encrypted WebRTC traffic when strict NAT or firewall rules block a direct peer connection. It is distinct from the signalling relay.
 - Update Thinning (Batch database update)


### PR DESCRIPTION
This documentation change defines ‘synchronising devices’ as devices participating in the same Vault synchronisation, including while they are offline or idle.

## Summary

- add ‘Synchronising devices’ to the terminology guide;
- clarify that the term describes membership rather than current activity; and
- use the term in the E2EE compatibility guidance instead of the undefined ‘synchronisation group’.

## Verification

- `git diff --check`
