### PR TITLE
Update Commonlib to 0.1.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "@smithy/types": "^4.14.3",
                 "@smithy/util-retry": "^4.4.5",
                 "@vrtmrz/browser-ui-kit": "0.1.0",
-                "@vrtmrz/livesync-commonlib": "0.1.18",
+                "@vrtmrz/livesync-commonlib": "0.1.19-rc.0",
                 "@vrtmrz/obsidian-plugin-kit": "0.1.3",
                 "@vrtmrz/ui-interactions": "0.1.2",
                 "diff-match-patch": "^1.0.5",
@@ -4771,9 +4771,9 @@
             }
         },
         "node_modules/@vrtmrz/livesync-commonlib": {
-            "version": "0.1.18",
-            "resolved": "https://registry.npmjs.org/@vrtmrz/livesync-commonlib/-/livesync-commonlib-0.1.18.tgz",
-            "integrity": "sha512-CgqYGRFrbTFT/bhI/x2Tqws4V3Py94al/UCAx8J5CLhNHuQGQmuGtRAXmbZbo/3JyfVEuo7euITEm58nEWLoYw==",
+            "version": "0.1.19-rc.0",
+            "resolved": "https://registry.npmjs.org/@vrtmrz/livesync-commonlib/-/livesync-commonlib-0.1.19-rc.0.tgz",
+            "integrity": "sha512-HCc8qLtXlnVMVgxw4W/CeX2bDPXUsXA10MknrzDBOe66IvTKnzdxu6MAB7sPDwi4DtC9vd/whbNFKCK24giY7w==",
             "license": "MIT",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.808.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "@smithy/types": "^4.14.3",
                 "@smithy/util-retry": "^4.4.5",
                 "@vrtmrz/browser-ui-kit": "0.1.0",
-                "@vrtmrz/livesync-commonlib": "0.1.19-rc.0",
+                "@vrtmrz/livesync-commonlib": "0.1.19",
                 "@vrtmrz/obsidian-plugin-kit": "0.1.3",
                 "@vrtmrz/ui-interactions": "0.1.2",
                 "diff-match-patch": "^1.0.5",
@@ -4771,9 +4771,9 @@
             }
         },
         "node_modules/@vrtmrz/livesync-commonlib": {
-            "version": "0.1.19-rc.0",
-            "resolved": "https://registry.npmjs.org/@vrtmrz/livesync-commonlib/-/livesync-commonlib-0.1.19-rc.0.tgz",
-            "integrity": "sha512-HCc8qLtXlnVMVgxw4W/CeX2bDPXUsXA10MknrzDBOe66IvTKnzdxu6MAB7sPDwi4DtC9vd/whbNFKCK24giY7w==",
+            "version": "0.1.19",
+            "resolved": "https://registry.npmjs.org/@vrtmrz/livesync-commonlib/-/livesync-commonlib-0.1.19.tgz",
+            "integrity": "sha512-sVQcVJaelm575xoopay1yUWsIlfh2Um6Oi70Jp4WLdO3vlPCoYUbCKH+zGDwU/r05BbB2xGwU+kgy6OjxyxGeQ==",
             "license": "MIT",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
         "@smithy/types": "^4.14.3",
         "@smithy/util-retry": "^4.4.5",
         "@vrtmrz/browser-ui-kit": "0.1.0",
-        "@vrtmrz/livesync-commonlib": "0.1.19-rc.0",
+        "@vrtmrz/livesync-commonlib": "0.1.19",
         "@vrtmrz/obsidian-plugin-kit": "0.1.3",
         "@vrtmrz/ui-interactions": "0.1.2",
         "diff-match-patch": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
         "@smithy/types": "^4.14.3",
         "@smithy/util-retry": "^4.4.5",
         "@vrtmrz/browser-ui-kit": "0.1.0",
-        "@vrtmrz/livesync-commonlib": "0.1.18",
+        "@vrtmrz/livesync-commonlib": "0.1.19-rc.0",
         "@vrtmrz/obsidian-plugin-kit": "0.1.3",
         "@vrtmrz/ui-interactions": "0.1.2",
         "diff-match-patch": "^1.0.5",

--- a/src/apps/cli/serviceModules/CLIServiceModules.ts
+++ b/src/apps/cli/serviceModules/CLIServiceModules.ts
@@ -111,6 +111,7 @@ export function initialiseServiceModulesCLI(
         UI: services.UI,
         vault: services.vault,
         fileHandler: fileHandler,
+        fileProcessing: services.fileProcessing,
         storageAccess: storageAccess,
         control: services.control,
     });

--- a/src/apps/webapp/serviceModules/FSAPIServiceModules.ts
+++ b/src/apps/webapp/serviceModules/FSAPIServiceModules.ts
@@ -102,6 +102,7 @@ export function initialiseServiceModulesFSAPI(
         UI: services.UI,
         vault: services.vault,
         fileHandler: fileHandler,
+        fileProcessing: services.fileProcessing,
         storageAccess: storageAccess,
         control: services.control,
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -120,6 +120,7 @@ export default class ObsidianLiveSyncPlugin extends Plugin {
             UI: services.UI,
             vault: services.vault,
             fileHandler: fileHandler,
+            fileProcessing: services.fileProcessing,
             storageAccess: storageAccess,
             control: services.control,
         });


### PR DESCRIPTION
This change integrates the stable Commonlib 0.1.19 release so database rebuilds finish deferred file-event processing before readiness is reported.

## Summary

- Pin `@vrtmrz/livesync-commonlib` to the published `0.1.19` package.
- Supply the host file-processing service to `ServiceRebuilder` in the Obsidian plug-in, CLI, and WebApp compositions.
- Keep the pull request in draft while the exact stable registry artefact completes downstream review.

## Rationale

Commonlib 0.1.19 makes rebuild completion explicitly commit pending file events before the host reports readiness. `ServiceRebuilder` therefore requires the host file-processing service. Wiring that dependency through every LiveSync host keeps the lifecycle contract consistent across the Obsidian plug-in, CLI, and WebApp.

## Verification

- Exact npm registry package `@vrtmrz/livesync-commonlib@0.1.19`, with lockfile integrity matching the trusted published artefact
- `NODE_OPTIONS=--max-old-space-size=3072 npm run check`
- `NODE_OPTIONS=--max-old-space-size=3072 npm run test:unit -- --maxWorkers=1` — 93 test files and 654 tests passed
- Production builds for the Obsidian plug-in, CLI, WebApp, and WebPeer
- CLI `test:setup-put-cat` E2E — 9 steps passed
- Real Obsidian configured restart and start-up scan E2E against the stable package
- Earlier exact-RC real Obsidian validation: manual CouchDB onboarding, server rebuild, second-device Fast Fetch, and bidirectional note round-trip
