### PR TITLE
fix(storage): do not skip the initial scan when the file cache is partially warmed

### DIFF
--- a/src/apps/cli/adapters/NodeFileSystemAdapter.ts
+++ b/src/apps/cli/adapters/NodeFileSystemAdapter.ts
@@ -20,6 +20,15 @@ export class NodeFileSystemAdapter implements IFileSystemAdapter<NodeFile, NodeF
     readonly vault: NodeVaultAdapter;
 
     private fileCache = new Map<string, NodeFile>();
+    /**
+     * Whether a full directory scan has completed at least once.
+     *
+     * This must not be inferred from `fileCache.size`: the cache is also
+     * populated one entry at a time by `refreshFile()`, so a single
+     * incidental entry would suppress the initial scan and make
+     * `getFiles()` silently return a truncated listing.
+     */
+    private hasScannedFully = false;
 
     constructor(
         private basePath: string,
@@ -92,8 +101,9 @@ export class NodeFileSystemAdapter implements IFileSystemAdapter<NodeFile, NodeF
     }
 
     async getFiles(): Promise<NodeFile[]> {
-        if (this.fileCache.size === 0) {
+        if (!this.hasScannedFully) {
             await this.scanDirectory();
+            this.hasScannedFully = true;
         }
         return Array.from(this.fileCache.values());
     }

--- a/src/apps/cli/adapters/NodeFileSystemAdapter.unit.spec.ts
+++ b/src/apps/cli/adapters/NodeFileSystemAdapter.unit.spec.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { fsPromises as fs, os, path } from "@vrtmrz/livesync-commonlib/node";
+import { NodeFileSystemAdapter } from "./NodeFileSystemAdapter";
+
+describe("NodeFileSystemAdapter.getFiles", () => {
+    const tempDirs: string[] = [];
+
+    async function createVault(files: Record<string, string>) {
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "livesync-cli-fs-adapter-"));
+        tempDirs.push(tempDir);
+        for (const [relativePath, content] of Object.entries(files)) {
+            const fullPath = path.join(tempDir, relativePath);
+            await fs.mkdir(path.dirname(fullPath), { recursive: true });
+            await fs.writeFile(fullPath, content, "utf-8");
+        }
+        return { adapter: new NodeFileSystemAdapter(tempDir), vaultPath: tempDir };
+    }
+
+    afterEach(async () => {
+        await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+    });
+
+    it("lists every file on a cold cache", async () => {
+        const { adapter } = await createVault({
+            "a.md": "a",
+            "sub/b.md": "b",
+            "sub/deep/c.md": "c",
+        });
+
+        const files = await adapter.getFiles();
+
+        expect(files.map((file) => file.path).sort()).toEqual(["a.md", "sub/b.md", "sub/deep/c.md"]);
+    });
+
+    it("still performs the initial scan when the cache was warmed by refreshFile", async () => {
+        // Reproduces the daemon's startup order: replication materialises a few
+        // files (each one going through refreshFile) *before* the mirror scan
+        // calls getFiles(). Inferring "already scanned" from a non-empty cache
+        // made getFiles() skip scanDirectory() and return only that subset.
+        const { adapter } = await createVault({
+            "a.md": "a",
+            "sub/b.md": "b",
+            "sub/deep/c.md": "c",
+        });
+
+        await adapter.refreshFile("a.md");
+
+        const files = await adapter.getFiles();
+
+        expect(files.map((file) => file.path).sort()).toEqual(["a.md", "sub/b.md", "sub/deep/c.md"]);
+    });
+
+    it("scans only once across repeated calls", async () => {
+        const { adapter, vaultPath } = await createVault({ "a.md": "a" });
+
+        await adapter.getFiles();
+        // A file appearing without notifying the adapter must not be picked up by
+        // a second getFiles(): the cache is authoritative once the scan has run,
+        // and incremental updates are the watcher's job.
+        await fs.writeFile(path.join(vaultPath, "b.md"), "b", "utf-8");
+
+        const files = await adapter.getFiles();
+
+        expect(files.map((file) => file.path)).toEqual(["a.md"]);
+    });
+});

--- a/src/apps/webapp/WebAppRuntime.ts
+++ b/src/apps/webapp/WebAppRuntime.ts
@@ -160,8 +160,10 @@ export class WebAppRuntime {
             throw new Error("The WebApp core is not initialised");
         }
 
+        // Discarding the cache also discards the full-scan state, so the
+        // `getFiles()` inside `collectFilesOnStorage()` rebuilds the inventory.
+        // Scanning here as well would traverse the whole Vault twice.
         fileAccess.fsapiAdapter.clearCache();
-        await fileAccess.fsapiAdapter.scanDirectory();
 
         const log = (message: unknown, level: LOG_LEVEL = LOG_LEVEL_INFO, key?: string): void => {
             this.addLog(message, level, key);
@@ -298,7 +300,6 @@ export class WebAppRuntime {
             const fileAccess = this.platformServiceModules?.vaultAccess;
             if (fileAccess) {
                 this.addLog("Scanning vault directory...", LOG_LEVEL_VERBOSE, "scan");
-                await fileAccess.fsapiAdapter.scanDirectory();
                 const files = await fileAccess.fsapiAdapter.getFiles();
                 this.addLog(`Found ${files.length} files`, LOG_LEVEL_VERBOSE, "scan");
             }

--- a/src/apps/webapp/adapters/FSAPIFileSystemAdapter.ts
+++ b/src/apps/webapp/adapters/FSAPIFileSystemAdapter.ts
@@ -20,6 +20,15 @@ export class FSAPIFileSystemAdapter implements IFileSystemAdapter<FSAPIFile, FSA
     readonly vault: FSAPIVaultAdapter;
 
     private fileCache = new Map<string, FSAPIFile>();
+    /**
+     * Whether a full directory scan has completed at least once.
+     *
+     * This must not be inferred from `fileCache.size`: the cache is also
+     * populated one entry at a time by `refreshFile()`, so a single
+     * incidental entry would suppress the initial scan and make
+     * `getFiles()` silently return a truncated listing.
+     */
+    private hasScannedFully = false;
     private handleCache = new Map<string, FileSystemFileHandle>();
 
     constructor(
@@ -110,8 +119,9 @@ export class FSAPIFileSystemAdapter implements IFileSystemAdapter<FSAPIFile, FSA
     }
 
     async getFiles(): Promise<FSAPIFile[]> {
-        if (this.fileCache.size === 0) {
+        if (!this.hasScannedFully) {
             await this.scanDirectory();
+            this.hasScannedFully = true;
         }
         return Array.from(this.fileCache.values());
     }

--- a/src/apps/webapp/adapters/FSAPIFileSystemAdapter.ts
+++ b/src/apps/webapp/adapters/FSAPIFileSystemAdapter.ts
@@ -238,9 +238,15 @@ export class FSAPIFileSystemAdapter implements IFileSystemAdapter<FSAPIFile, FSA
 
     /**
      * Clear all caches
+     *
+     * The full-scan state is part of the cache: once the inventory has been
+     * discarded, the next `getFiles()` must rebuild it. Leaving the flag set
+     * would let a caller that repopulates a single entry afterwards, such as
+     * `renameFile()`, publish that entry as the complete listing.
      */
     clearCache(): void {
         this.fileCache.clear();
         this.handleCache.clear();
+        this.hasScannedFully = false;
     }
 }

--- a/src/apps/webapp/adapters/FSAPIStorageAdapter.unit.spec.ts
+++ b/src/apps/webapp/adapters/FSAPIStorageAdapter.unit.spec.ts
@@ -141,6 +141,60 @@ describe("FSAPIVaultAdapter.rename", () => {
     });
 });
 
+describe("FSAPIFileSystemAdapter full scan state", () => {
+    const createVault = async (...paths: string[]) => {
+        const memoryRoot = new MemoryDirectoryHandle("root");
+        const root = memoryRoot as unknown as FileSystemDirectoryHandle;
+        const vault = new FSAPIVaultAdapter(root);
+        for (const path of paths) {
+            await vault.create(path, `content of ${path}`);
+        }
+        return { memoryRoot, root };
+    };
+
+    const listPaths = async (adapter: FSAPIFileSystemAdapter) =>
+        (await adapter.getFiles()).map((file) => file.path).sort();
+
+    it("lists every file when the cache has been warmed by a single refresh", async () => {
+        const { root } = await createVault("a.md", "b.md");
+        const adapter = new FSAPIFileSystemAdapter(root, vi.fn());
+
+        // `refreshFile()` is the second writer of the cache: before the scan
+        // state was tracked explicitly, this one entry made `getFiles()` skip
+        // `scanDirectory()` and return a truncated listing.
+        await adapter.refreshFile("a.md");
+
+        await expect(listPaths(adapter)).resolves.toEqual(["a.md", "b.md"]);
+    });
+
+    it("rescans after a rename invalidates the cache", async () => {
+        const { root } = await createVault("a.md", "b.md");
+        const adapter = new FSAPIFileSystemAdapter(root, vi.fn());
+
+        await expect(listPaths(adapter)).resolves.toEqual(["a.md", "b.md"]);
+
+        // `renameFile()` clears the cache and then repopulates the renamed path
+        // alone. Without resetting the full-scan state, that single entry would
+        // be published as the complete listing.
+        const source = await adapter.getAbstractFileByPath("a.md");
+        expect(source).not.toBeNull();
+        await adapter.renameFile(source!, "renamed.md");
+
+        await expect(listPaths(adapter)).resolves.toEqual(["b.md", "renamed.md"]);
+    });
+
+    it("scans the directory only once across repeated calls", async () => {
+        const { root } = await createVault("a.md", "b.md");
+        const adapter = new FSAPIFileSystemAdapter(root, vi.fn());
+        const scanDirectory = vi.spyOn(adapter, "scanDirectory");
+
+        await adapter.getFiles();
+        await adapter.getFiles();
+
+        expect(scanDirectory).toHaveBeenCalledTimes(1);
+    });
+});
+
 describe("FSAPIFileSystemAdapter path case", () => {
     it("returns the stored path case from a case-insensitive file system", async () => {
         const memoryRoot = new MemoryDirectoryHandle("root", true);

--- a/test/apps/webapp/WebAppRuntime.unit.spec.ts
+++ b/test/apps/webapp/WebAppRuntime.unit.spec.ts
@@ -174,8 +174,10 @@ describe("WebAppRuntime lifecycle", () => {
 
         expect(runtimeMocks.onLoad).toHaveBeenCalledOnce();
         expect(runtimeMocks.onReady).toHaveBeenCalledOnce();
-        expect(runtimeMocks.scanDirectory).toHaveBeenCalledOnce();
+        // `getFiles()` performs the initial scan itself; scanning explicitly
+        // beforehand would traverse the whole Vault twice.
         expect(runtimeMocks.getFiles).toHaveBeenCalledOnce();
+        expect(runtimeMocks.scanDirectory).not.toHaveBeenCalled();
         expect(runtimeMocks.addLog).toHaveBeenCalledWith("Found 1 files", expect.anything(), "scan");
         expect(reportStatus).toHaveBeenCalledWith(
             "warning",
@@ -210,8 +212,10 @@ describe("WebAppRuntime lifecycle", () => {
 
         await expect(runtime.scanLocalFiles()).resolves.toBe(true);
 
+        // Clearing the cache also discards the full-scan state, so the rebuild
+        // is left to the `getFiles()` inside `collectFilesOnStorage()`.
         expect(runtimeMocks.clearCache).toHaveBeenCalledOnce();
-        expect(runtimeMocks.scanDirectory).toHaveBeenCalledOnce();
+        expect(runtimeMocks.scanDirectory).not.toHaveBeenCalled();
         expect(runtimeMocks.collectFilesOnStorage).toHaveBeenCalledWith(
             expect.objectContaining({
                 services: runtimeMocks.serviceHub,


### PR DESCRIPTION
Fixes #1143.

`getFiles()` inferred "the initial scan has already happened" from `fileCache.size !== 0`. The cache has a second writer, `refreshFile()`, which adds a single entry at a time — so one incidental entry was enough to suppress the initial `scanDirectory()` and make `getFiles()` return a silently truncated listing.

The CLI daemon hits this on every start, because of the order in `runCommand.ts`: it replicates from CouchDB first (materialising documents to storage, each going through `refreshFile()`), then runs the mirror scan. `collectFilesOnStorage()` therefore sees only the files touched by replication, every other document resolves to `state === "db-only"`, and `NEWER_WINS` deletes from the database those already known to the mtime map.

On the vault where this was found, that removed 76 documents four seconds after a restart, with `0 failed` in the log, while all 76 files were present on disk.

## Change

Replace the inference with explicit state, in both adapters carrying the pattern:

- `src/apps/cli/adapters/NodeFileSystemAdapter.ts`
- `src/apps/webapp/adapters/FSAPIFileSystemAdapter.ts`

```ts
private hasScannedFully = false;

async getFiles(): Promise<Files[]> {
    if (!this.hasScannedFully) {
        await this.scanDirectory();
        this.hasScannedFully = true;
    }
    return Array.from(this.fileCache.values());
}
```

The flag is set in `getFiles()` rather than inside `scanDirectory()`, since the latter recurses into subdirectories and is also callable directly with a relative path.

Behaviour is otherwise unchanged: still exactly one scan per adapter instance, and incremental updates remain the watcher's job.

## Test

New `src/apps/cli/adapters/NodeFileSystemAdapter.unit.spec.ts`, three cases against a real temporary vault:

1. a cold cache lists every file;
2. **a cache warmed by one `refreshFile()` call still lists every file** — this is the regression;
3. the scan runs only once across repeated calls.

Case 2 fails on the current implementation:

```
AssertionError: expected [ 'a.md' ] to deeply equal [ 'a.md', 'sub/b.md', 'sub/deep/c.md' ]
```

`npm run test:unit` on the touched spec: 3 passed. `npx eslint` on the touched sources: 0 errors.

## Not addressed here

A scan that finds no local files while the database is populated still proceeds to delete the database. This PR removes one way of reaching that state, not the state itself — any other failure of the local enumeration would land in the same place. I've described that in the issue and would be happy to open it separately if you'd like it handled.
