### PR TITLE
fix(cli): rebuild full vault inventory before mirror scan

### DIFF
--- a/src/apps/cli/adapters/NodeFileSystemAdapter.ts
+++ b/src/apps/cli/adapters/NodeFileSystemAdapter.ts
@@ -3,10 +3,9 @@ import type { IFileSystemAdapter } from "@vrtmrz/livesync-commonlib/compat/servi
 import { NodePathAdapter } from "./NodePathAdapter";
 import { NodeTypeGuardAdapter } from "./NodeTypeGuardAdapter";
 import { NodeConversionAdapter } from "./NodeConversionAdapter";
-import { NodeStorageAdapter } from "@vrtmrz/livesync-commonlib/node";
+import { NodeStorageAdapter, fsPromises, path, validateStoragePath } from "@vrtmrz/livesync-commonlib/node";
 import { NodeVaultAdapter } from "./NodeVaultAdapter";
 import type { NodeFile, NodeFolder, NodeStat } from "./NodeTypes";
-import { path } from "@vrtmrz/livesync-commonlib/node";
 import type { CliDiagnosticReporter } from "@/apps/cli/cliOutput";
 
 /**
@@ -20,6 +19,9 @@ export class NodeFileSystemAdapter implements IFileSystemAdapter<NodeFile, NodeF
     readonly vault: NodeVaultAdapter;
 
     private fileCache = new Map<string, NodeFile>();
+    private fileCacheVersion = 0;
+    private completeScan: Promise<NodeFile[]> | undefined;
+    private reportedScanErrors = new WeakSet<object>();
 
     constructor(
         private basePath: string,
@@ -33,11 +35,20 @@ export class NodeFileSystemAdapter implements IFileSystemAdapter<NodeFile, NodeF
     }
 
     private resolvePath(p: FilePath | string): string {
-        return path.join(this.basePath, p);
+        return path.join(this.basePath, validateStoragePath(String(p), true));
     }
 
     private normalisePath(p: FilePath | string): string {
         return this.path.normalisePath(p);
+    }
+
+    private cacheFile(pathStr: string, file: NodeFile): void {
+        this.fileCache.set(pathStr, file);
+        this.fileCacheVersion++;
+    }
+
+    private evictFile(pathStr: string): void {
+        if (this.fileCache.delete(pathStr)) this.fileCacheVersion++;
     }
 
     private async hasExactPathCase(pathStr: string): Promise<boolean> {
@@ -59,7 +70,7 @@ export class NodeFileSystemAdapter implements IFileSystemAdapter<NodeFile, NodeF
     async getAbstractFileByPath(p: FilePath | string): Promise<NodeFile | null> {
         const pathStr = this.normalisePath(p);
         if (!this.fileCache.has(pathStr) && !(await this.hasExactPathCase(pathStr))) {
-            this.fileCache.delete(pathStr);
+            this.evictFile(pathStr);
             return null;
         }
         return await this.refreshFile(pathStr);
@@ -80,7 +91,7 @@ export class NodeFileSystemAdapter implements IFileSystemAdapter<NodeFile, NodeF
             }
         }
 
-        await this.scanDirectory();
+        await this.getFiles();
 
         for (const [cachedPath, cachedFile] of this.fileCache.entries()) {
             if (cachedPath.toLowerCase() === lowerPath) {
@@ -92,16 +103,45 @@ export class NodeFileSystemAdapter implements IFileSystemAdapter<NodeFile, NodeF
     }
 
     async getFiles(): Promise<NodeFile[]> {
-        if (this.fileCache.size === 0) {
-            await this.scanDirectory();
+        // Share one complete scan across concurrent callers. The cache is
+        // replaced only after a successful traversal, so an I/O failure cannot
+        // turn a partial inventory into database deletions.
+        if (!this.completeScan) {
+            const scan = this.buildCompleteInventory();
+            this.completeScan = scan;
+            void scan.then(
+                () => {
+                    if (this.completeScan === scan) this.completeScan = undefined;
+                },
+                () => {
+                    if (this.completeScan === scan) this.completeScan = undefined;
+                }
+            );
         }
-        return Array.from(this.fileCache.values());
+        return Array.from(await this.completeScan);
+    }
+
+    private async buildCompleteInventory(): Promise<NodeFile[]> {
+        // A targeted reflection can mutate the cache while the scan is running.
+        // Retry until one traversal observes a stable cache generation; fail
+        // closed rather than publishing an uncertain inventory.
+        for (let attempt = 0; attempt < 3; attempt++) {
+            const versionAtStart = this.fileCacheVersion;
+            const inventory = new Map<string, NodeFile>();
+            await this.scanDirectoryInto("", inventory);
+            if (this.fileCacheVersion !== versionAtStart) continue;
+
+            this.fileCache = inventory;
+            this.fileCacheVersion++;
+            return Array.from(inventory.values());
+        }
+        throw new Error("Vault changed repeatedly during the complete filesystem scan");
     }
 
     async renameFile(file: NodeFile, newPath: string): Promise<NodeFile> {
         const oldPath = file.path;
         await this.vault.rename(file, newPath);
-        this.fileCache.delete(oldPath);
+        this.evictFile(oldPath);
         const renamedFile = await this.refreshFile(newPath);
         if (!renamedFile) throw new Error(`Could not find renamed file: ${newPath}`);
         return renamedFile;
@@ -121,7 +161,7 @@ export class NodeFileSystemAdapter implements IFileSystemAdapter<NodeFile, NodeF
         try {
             const stat = await this.storage.stat(pathStr);
             if (stat?.type !== "file") {
-                this.fileCache.delete(pathStr);
+                this.evictFile(pathStr);
                 return null;
             }
 
@@ -134,40 +174,89 @@ export class NodeFileSystemAdapter implements IFileSystemAdapter<NodeFile, NodeF
                     type: "file",
                 },
             };
-            this.fileCache.set(pathStr, file);
+            this.cacheFile(pathStr, file);
             return file;
         } catch {
             // Evict so a deleted file is not returned by subsequent cache scans.
-            this.fileCache.delete(pathStr);
+            this.evictFile(pathStr);
             return null;
         }
     }
 
+    protected async readDirectory(relativePath: string): Promise<{ files: string[]; folders: string[] }> {
+        const entries = await fsPromises.readdir(this.resolvePath(relativePath), { withFileTypes: true });
+        const files: string[] = [];
+        const folders: string[] = [];
+        for (const entry of entries) {
+            const entryPath = path.join(relativePath, entry.name).replace(/\\/g, "/");
+            // Match NodeStorageAdapter's safety boundary: symbolic links are not
+            // part of the vault inventory and are never traversed.
+            if (entry.isFile()) files.push(entryPath);
+            else if (entry.isDirectory()) folders.push(entryPath);
+        }
+        return { files, folders };
+    }
+
     /**
-     * Helper method to recursively scan directory and populate file cache
+     * Explicit rescans remain public for CLI callers, but use the same atomic,
+     * fail-closed inventory path as getFiles().
      */
     async scanDirectory(relativePath: string = ""): Promise<void> {
+        if (relativePath === "") {
+            await this.getFiles();
+            return;
+        }
+        const versionAtStart = this.fileCacheVersion;
+        const inventory = new Map(this.fileCache);
+        await this.scanDirectoryInto(relativePath, inventory);
+        if (this.fileCacheVersion !== versionAtStart) {
+            throw new Error("Vault changed during the filesystem scan");
+        }
+        this.fileCache = inventory;
+        this.fileCacheVersion++;
+    }
+
+    private async scanDirectoryInto(relativePath: string, inventory: Map<string, NodeFile>): Promise<void> {
         const fullPath = this.resolvePath(relativePath);
         try {
-            const directoryStat = await this.storage.stat(relativePath);
-            if (directoryStat?.type !== "folder") throw new Error(`Directory does not exist: ${fullPath}`);
-            const entries = await this.storage.list(relativePath);
+            let directoryStat;
+            try {
+                // Preserve NodeStorageAdapter's nested-symbolic-link guard;
+                // native fs calls below are used only so ordinary I/O failures
+                // propagate instead of being converted to an empty listing.
+                await this.storage.stat(relativePath);
+                directoryStat = await fsPromises.stat(fullPath);
+            } catch (error) {
+                if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+                    throw new Error(`Directory does not exist: ${fullPath}`);
+                }
+                throw error;
+            }
+            if (!directoryStat.isDirectory()) throw new Error(`Directory does not exist: ${fullPath}`);
+            const entries = await this.readDirectory(relativePath);
 
             for (const entryPath of entries.files) {
-                const stat = await this.storage.stat(entryPath);
-                if (stat?.type !== "file") continue;
-                const file: NodeFile = {
+                const stat = await fsPromises.stat(this.resolvePath(entryPath));
+                if (!stat.isFile()) continue;
+                inventory.set(entryPath, {
                     path: entryPath as FilePath,
-                    stat,
-                };
-                this.fileCache.set(entryPath, file);
+                    stat: {
+                        size: stat.size,
+                        mtime: Math.floor(stat.mtimeMs),
+                        ctime: Math.floor(stat.ctimeMs),
+                        type: "file",
+                    },
+                });
             }
             for (const entryPath of entries.folders) {
-                await this.scanDirectory(entryPath);
+                await this.scanDirectoryInto(entryPath, inventory);
             }
         } catch (error) {
-            // Directory doesn't exist or is not readable
-            this.reportDiagnostic(`Error scanning directory ${fullPath}:`, error);
+            if (typeof error !== "object" || error === null || !this.reportedScanErrors.has(error)) {
+                this.reportDiagnostic(`Error scanning directory ${fullPath}:`, error);
+                if (typeof error === "object" && error !== null) this.reportedScanErrors.add(error);
+            }
+            throw error;
         }
     }
 }

--- a/src/apps/cli/adapters/NodeVaultAdapter.unit.spec.ts
+++ b/src/apps/cli/adapters/NodeVaultAdapter.unit.spec.ts
@@ -4,6 +4,30 @@ import type { FilePath } from "@vrtmrz/livesync-commonlib/compat/common/types";
 import { NodeFileSystemAdapter } from "./NodeFileSystemAdapter";
 import { NodeVaultAdapter } from "./NodeVaultAdapter";
 
+class FailingDirectoryAdapter extends NodeFileSystemAdapter {
+    constructor(
+        basePath: string,
+        private readonly failingPath: string,
+        reportDiagnostic: (message: string, error?: unknown) => void = () => undefined
+    ) {
+        super(basePath, reportDiagnostic);
+    }
+
+    protected override async readDirectory(relativePath: string): Promise<{ files: string[]; folders: string[] }> {
+        if (relativePath === this.failingPath) throw new Error(`Injected scan failure: ${relativePath}`);
+        return await super.readDirectory(relativePath);
+    }
+}
+
+class CountingDirectoryAdapter extends NodeFileSystemAdapter {
+    rootScans = 0;
+
+    protected override async readDirectory(relativePath: string): Promise<{ files: string[]; folders: string[] }> {
+        if (relativePath === "") this.rootScans++;
+        return await super.readDirectory(relativePath);
+    }
+}
+
 describe("NodeVaultAdapter.rename", () => {
     it("changes the directory entry case without changing the content", async () => {
         const directory = await fsPromises.mkdtemp(path.join(os.tmpdir(), "livesync-case-rename-"));
@@ -80,6 +104,64 @@ describe("NodeVaultAdapter.rename", () => {
 });
 
 describe("NodeFileSystemAdapter path case", () => {
+    it("returns the complete vault scan when the cache was pre-populated by one reflected file", async () => {
+        const directory = await fsPromises.mkdtemp(path.join(os.tmpdir(), "livesync-partial-cache-"));
+        try {
+            await fsPromises.writeFile(path.join(directory, "reflected.md"), "remote change", "utf8");
+            await fsPromises.writeFile(path.join(directory, "existing.md"), "existing content", "utf8");
+            const adapter = new NodeFileSystemAdapter(directory);
+
+            // A CouchDB replication can reflect one changed file before the daemon's
+            // startup mirror scan, leaving the adapter cache non-empty but incomplete.
+            await expect(adapter.getAbstractFileByPath("reflected.md")).resolves.toMatchObject({
+                path: "reflected.md",
+            });
+
+            expect((await adapter.getFiles()).map((file) => file.path).sort()).toEqual([
+                "existing.md",
+                "reflected.md",
+            ]);
+        } finally {
+            await fsPromises.rm(directory, { recursive: true, force: true });
+        }
+    });
+
+    it("rejects an incomplete inventory when any subtree scan fails", async () => {
+        const directory = await fsPromises.mkdtemp(path.join(os.tmpdir(), "livesync-failed-subtree-"));
+        const reportDiagnostic = vi.fn();
+        try {
+            await fsPromises.writeFile(path.join(directory, "visible.md"), "visible", "utf8");
+            await fsPromises.mkdir(path.join(directory, "blocked"));
+            await fsPromises.writeFile(path.join(directory, "blocked", "hidden.md"), "hidden", "utf8");
+            const adapter = new FailingDirectoryAdapter(directory, "blocked", reportDiagnostic);
+
+            await expect(adapter.getFiles()).rejects.toThrow("Injected scan failure: blocked");
+            expect(reportDiagnostic).toHaveBeenCalledWith(
+                `Error scanning directory ${path.join(directory, "blocked")}:`,
+                expect.any(Error)
+            );
+        } finally {
+            await fsPromises.rm(directory, { recursive: true, force: true });
+        }
+    });
+
+    it("shares one atomic inventory across concurrent getFiles calls", async () => {
+        const directory = await fsPromises.mkdtemp(path.join(os.tmpdir(), "livesync-concurrent-scan-"));
+        try {
+            await fsPromises.writeFile(path.join(directory, "a.md"), "a", "utf8");
+            await fsPromises.writeFile(path.join(directory, "b.md"), "b", "utf8");
+            const adapter = new CountingDirectoryAdapter(directory);
+
+            const [first, second] = await Promise.all([adapter.getFiles(), adapter.getFiles()]);
+            const expected = ["a.md", "b.md"];
+            expect(first.map((file) => file.path).sort()).toEqual(expected);
+            expect(second.map((file) => file.path).sort()).toEqual(expected);
+            expect(adapter.rootScans).toBe(1);
+        } finally {
+            await fsPromises.rm(directory, { recursive: true, force: true });
+        }
+    });
+
     it("finds the stored case and refreshes the cache after a case-only rename", async () => {
         const directory = await fsPromises.mkdtemp(path.join(os.tmpdir(), "livesync-case-cache-"));
         try {
@@ -107,12 +189,22 @@ describe("NodeFileSystemAdapter path case", () => {
         try {
             const adapter = new NodeFileSystemAdapter(missingDirectory, reportDiagnostic);
 
-            await adapter.scanDirectory();
+            await expect(adapter.scanDirectory()).rejects.toThrow(`Directory does not exist: ${missingDirectory}`);
 
             expect(reportDiagnostic).toHaveBeenCalledWith(
                 `Error scanning directory ${missingDirectory}:`,
                 expect.any(Error)
             );
+        } finally {
+            await fsPromises.rm(directory, { recursive: true, force: true });
+        }
+    });
+
+    it("rejects explicit scans outside the vault root", async () => {
+        const directory = await fsPromises.mkdtemp(path.join(os.tmpdir(), "livesync-scan-root-"));
+        try {
+            const adapter = new NodeFileSystemAdapter(directory);
+            await expect(adapter.scanDirectory("../outside")).rejects.toThrow(/outside|relative|parent|\.\./i);
         } finally {
             await fsPromises.rm(directory, { recursive: true, force: true });
         }

--- a/src/apps/cli/commands/daemonCommand.unit.spec.ts
+++ b/src/apps/cli/commands/daemonCommand.unit.spec.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
 import { createServiceContext } from "@vrtmrz/livesync-commonlib/context";
+import { NodeFileSystemAdapter } from "../adapters/NodeFileSystemAdapter";
 import { runCommand } from "./runCommand";
 import type { CLIOptions } from "./types";
 
@@ -206,6 +210,40 @@ describe("daemon command", () => {
         await runCommand(makeDaemonOptions(), { ...baseContext, core });
 
         expect(callOrder).toEqual(["replicate", "performFullScan"]);
+    });
+
+    it("full startup scan sees every disk file after replication pre-populates only one cache entry", async () => {
+        const directory = await fs.mkdtemp(path.join(os.tmpdir(), "livesync-daemon-partial-cache-"));
+        try {
+            await fs.writeFile(path.join(directory, "existing.md"), "existing");
+            await fs.writeFile(path.join(directory, "reflected.md"), "reflected");
+
+            const storageAccess = new NodeFileSystemAdapter(directory);
+            const core = createCoreMock();
+            core.serviceModules.storageAccess = storageAccess;
+            core.services.replication.replicate = vi.fn(async () => {
+                // Models a targeted remote reflection before the mandatory full scan.
+                await storageAccess.getAbstractFileByPath("reflected.md");
+                return true;
+            });
+
+            let scannedPaths: string[] = [];
+            vi.mocked(offlineScanner.performFullScan).mockImplementation(async () => {
+                scannedPaths = (await storageAccess.getFiles()).map((file) => file.path).sort();
+                return true;
+            });
+
+            const result = await runCommand(makeDaemonOptions(), {
+                ...baseContext,
+                vaultPath: directory,
+                core,
+            });
+
+            expect(result).toBe(true);
+            expect(scannedPaths).toEqual(["existing.md", "reflected.md"]);
+        } finally {
+            await fs.rm(directory, { recursive: true, force: true });
+        }
     });
 
     it("returns false when initial replication fails", async () => {

--- a/src/apps/cli/package.json
+++ b/src/apps/cli/package.json
@@ -12,7 +12,7 @@
         "buildRun": "npm run build && npm run cli --",
         "build:docker": "docker build -f Dockerfile -t livesync-cli ../../..",
         "check": "tsc -p tsconfig.json",
-        "test:unit": "cd ../../.. && npx vitest run --config vitest.config.unit.ts src/apps/cli/main.unit.spec.ts src/apps/cli/settingsPersistence.unit.spec.ts src/apps/cli/commands/utils.unit.spec.ts src/apps/cli/commands/runCommand.unit.spec.ts src/apps/cli/commands/p2p.unit.spec.ts",
+        "test:unit": "cd ../../.. && npx vitest run --config vitest.config.unit.ts src/apps/cli/main.unit.spec.ts src/apps/cli/settingsPersistence.unit.spec.ts src/apps/cli/adapters/NodeVaultAdapter.unit.spec.ts src/apps/cli/commands/daemonCommand.unit.spec.ts src/apps/cli/commands/utils.unit.spec.ts src/apps/cli/commands/runCommand.unit.spec.ts src/apps/cli/commands/p2p.unit.spec.ts",
         "test:e2e:two-vaults": "bash test/test-e2e-two-vaults-with-docker-linux.sh",
         "test:e2e:two-vaults:common": "bash test/test-e2e-two-vaults-common.sh",
         "test:e2e:two-vaults:matrix": "bash test/test-e2e-two-vaults-matrix.sh",


### PR DESCRIPTION
## Summary

- rebuild the CLI filesystem inventory from disk instead of treating any non-empty targeted cache as complete
- fail closed on directory/stat errors and publish the new cache only after a complete successful traversal
- share concurrent full scans and retry when targeted cache mutations overlap a traversal
- preserve rooted-path and symbolic-link safety checks
- add adapter and daemon-startup regressions to the default CLI unit suite

## Problem

The CLI daemon replicates CouchDB before running its startup mirror scan. A targeted remote reflection can populate `NodeFileSystemAdapter.fileCache` with only the changed file. Previously, `getFiles()` skipped its recursive scan whenever that cache was non-empty, so the scanner received an incomplete storage inventory.

With `NEWER_WINS` and persisted last-seen metadata, physically present files omitted from that inventory can be classified as locally missing and lead to unrelated `DELETE DATABASE` actions.

A second safety problem was that the recursive scan caught I/O errors and returned a partial cache as success. Concurrent `getFiles()` calls could also clear and populate the shared map non-atomically.

## Fix

`getFiles()` now:

1. shares one complete scan between concurrent callers;
2. builds into a private inventory;
3. uses filesystem operations that propagate ordinary I/O failures;
4. keeps the old cache unless the traversal completes successfully;
5. retries if a targeted cache mutation overlaps the traversal;
6. fails closed after repeated overlapping mutations;
7. atomically replaces the cache only after a complete stable scan.

The scan continues to validate rooted paths and refuses to traverse symbolic links.

## Regression coverage

- partial cache pre-populated by one targeted lookup still returns every disk file
- a failed subtree scan rejects instead of returning a partial inventory
- concurrent `getFiles()` callers share one atomic traversal
- explicit scans cannot escape the vault root
- symbolic links outside the vault are not traversed
- daemon ordering (`replicate` before `performFullScan`) sees the complete disk inventory
- adapter and daemon test files are included in `npm run test:unit`

## Verification

- `npm run test:unit` — 96 tests passed
- `npm run check` — passed
- `npm run build` — passed
- repeated disposable two-peer CouchDB drills covered remote-before-startup delivery, bidirectional continuous updates, intentional deletion, and divergent same-file restart/conflict behavior without unrelated deletions
