### PR TITLE
Align existing-device setup guidance with synchronising-device terminology

### DIFF
--- a/src/common/messages/combinedMessages.prod.ts
+++ b/src/common/messages/combinedMessages.prod.ts
@@ -148,16 +148,9 @@ export const allMessages: Readonly<Record<string, Readonly<Record<string, string
         zh: "（正则表达式）如果已设置，则所有匹配此模式的本地和远端文件变更都会被跳过。",
         "zh-tw": "（正則表示式）若已設定，所有符合此模式的本機與遠端檔案變更都會被略過。",
     },
-    "(Select this if another device is already using LiveSync.) This option adds this device to that existing synchronisation setup.":
+    "(Select this if you already have another synchronising device.) This option adds this device to the same synchronisation.":
         {
-            def: "(Select this if another device is already using LiveSync.) This option adds this device to that existing synchronisation setup.",
-            es: "(Seleccione esto si ya utiliza la sincronización en otro ordenador o teléfono). Esta opción es adecuada si desea añadir este dispositivo a una configuración de LiveSync existente。",
-            ja: "（別の PC やスマートフォンですでに同期を利用している場合に選択してください。）この端末を既存の LiveSync 構成に追加する場合に適しています。",
-            ko: "(다른 컴퓨터나 스마트폰에서 이미 동기화를 사용 중이라면 선택하세요.) 이 기기를 기존 LiveSync 구성에 추가하려는 경우에 적합합니다.",
-            ru: "(Выберите этот вариант, если вы уже используете синхронизацию на другом компьютере или смартфоне.) Он подходит, если вы хотите добавить это устройство к уже существующей конфигурации LiveSync。",
-            zh: "（如果你已经在另一台电脑或手机上使用同步，请选择此项。）此选项适合将当前设备加入现有 LiveSync 配置的用户。",
-            "zh-tw":
-                "（如果你已經在另一台電腦或手機上使用同步，請選擇此項。）此選項適合將目前裝置加入既有 LiveSync 設定的使用者。",
+            def: "(Select this if you already have another synchronising device.) This option adds this device to the same synchronisation.",
         },
     "(Select this if you are configuring this device as the first synchronisation device.) This option is suitable if you are new to LiveSync and want to set it up from scratch.":
         {
@@ -12739,6 +12732,16 @@ export const allMessages: Readonly<Record<string, Readonly<Record<string, string
         def: "you wanted(Thank you)!",
         es: "tu solicitud (¡gracias!)",
     },
+    "(Select this if another device is already using LiveSync.) This option adds this device to that existing synchronisation setup.":
+        {
+            es: "(Seleccione esto si ya utiliza la sincronización en otro ordenador o teléfono). Esta opción es adecuada si desea añadir este dispositivo a una configuración de LiveSync existente。",
+            ja: "（別の PC やスマートフォンですでに同期を利用している場合に選択してください。）この端末を既存の LiveSync 構成に追加する場合に適しています。",
+            ko: "(다른 컴퓨터나 스마트폰에서 이미 동기화를 사용 중이라면 선택하세요.) 이 기기를 기존 LiveSync 구성에 추가하려는 경우에 적합합니다.",
+            ru: "(Выберите этот вариант, если вы уже используете синхронизацию на другом компьютере или смартфоне.) Он подходит, если вы хотите добавить это устройство к уже существующей конфигурации LiveSync。",
+            zh: "（如果你已经在另一台电脑或手机上使用同步，请选择此项。）此选项适合将当前设备加入现有 LiveSync 配置的用户。",
+            "zh-tw":
+                "（如果你已經在另一台電腦或手機上使用同步，請選擇此項。）此選項適合將目前裝置加入既有 LiveSync 設定的使用者。",
+        },
     "Compute revisions for chunks (Previous behaviour)": {
         es: "Calcular revisiones para chunks (comportamiento anterior)",
     },

--- a/src/common/messagesJson/en.json
+++ b/src/common/messagesJson/en.json
@@ -15,7 +15,7 @@
     "(Obsolete) Use an old adapter for compatibility": "(Obsolete) Use an old adapter for compatibility",
     "(RegExp) Empty to sync all files. Set filter as a regular expression to limit synchronising files.": "(RegExp) Empty to sync all files. Set filter as a regular expression to limit synchronising files.",
     "(RegExp) If this is set, any changes to local and remote files that match this will be skipped.": "(RegExp) If this is set, any changes to local and remote files that match this will be skipped.",
-    "(Select this if another device is already using LiveSync.) This option adds this device to that existing synchronisation setup.": "(Select this if another device is already using LiveSync.) This option adds this device to that existing synchronisation setup.",
+    "(Select this if you already have another synchronising device.) This option adds this device to the same synchronisation.": "(Select this if you already have another synchronising device.) This option adds this device to the same synchronisation.",
     "(Select this if you are configuring this device as the first synchronisation device.) This option is suitable if you are new to LiveSync and want to set it up from scratch.": "(Select this if you are configuring this device as the first synchronisation device.) This option is suitable if you are new to LiveSync and want to set it up from scratch.",
     "↑: Overwrite Remote": "↑: Overwrite Remote",
     "↓: Overwrite Local": "↓: Overwrite Local",

--- a/src/common/messagesYAML/en.yaml
+++ b/src/common/messagesYAML/en.yaml
@@ -2093,7 +2093,7 @@ xxhash64 (Fastest): xxhash64 (Fastest)
 "I am setting this up for the first time": "I am setting this up for the first time"
 "(Select this if you are configuring this device as the first synchronisation device.) This option is suitable if you are new to LiveSync and want to set it up from scratch.": "(Select this if you are configuring this device as the first synchronisation device.) This option is suitable if you are new to LiveSync and want to set it up from scratch."
 "I am adding a device to an existing synchronisation setup": "I am adding a device to an existing synchronisation setup"
-"(Select this if another device is already using LiveSync.) This option adds this device to that existing synchronisation setup.": "(Select this if another device is already using LiveSync.) This option adds this device to that existing synchronisation setup."
+"(Select this if you already have another synchronising device.) This option adds this device to the same synchronisation.": "(Select this if you already have another synchronising device.) This option adds this device to the same synchronisation."
 "Yes, I want to set up a new synchronisation": "Yes, I want to set up a new synchronisation"
 "Yes, I want to add this device to my existing synchronisation": "Yes, I want to add this device to my existing synchronisation"
 "No, please take me back": "No, please take me back"

--- a/src/modules/features/SetupWizard/dialogs/Intro.svelte
+++ b/src/modules/features/SetupWizard/dialogs/Intro.svelte
@@ -59,7 +59,7 @@
             bind:value={userType}
         >
             {translateMessage(
-                "(Select this if another device is already using LiveSync.) This option adds this device to that existing synchronisation setup."
+                "(Select this if you already have another synchronising device.) This option adds this device to the same synchronisation."
             )}
         </Option>
     </Options>


### PR DESCRIPTION
This wording-only change aligns the additional-device onboarding guidance with the project's defined 'Synchronising devices' terminology and leaves unreviewed translations untouched.

## Summary

- Replace the English guidance introduced in #1118 with the agreed wording.
- Retain non-English catalogue entries under their original key, so the revised message uses the English fallback until its translations are reviewed.
- Rebake the generated message catalogues.

## Verification

- `npm run i18n:bake`
- `npm run test:unit -- src/common/translation.unit.spec.ts --maxWorkers=1`
- Verified the English fallback for `de`, `es`, `fr`, `he`, `ja`, `ko`, `ru`, `zh`, and `zh-tw`
- `NODE_OPTIONS=--max-old-space-size=3072 npm run build`
- `git diff --check`
