### PR TITLE
Avoid resolving CLI development peers in Docker runtime

### DIFF
--- a/src/apps/cli/Dockerfile
+++ b/src/apps/cli/Dockerfile
@@ -82,9 +82,11 @@ RUN apt-get update \
 
 WORKDIR /deps
 
-# package.json lists only the packages that the CLI requires
+# Remove build-only dependencies before resolving the standalone runtime tree.
+# npm --omit=dev omits them from disk, but still resolves their peer graph.
 COPY src/apps/cli/package.json ./package.json
-RUN npm install --omit=dev
+RUN npm pkg delete devDependencies \
+    && npm install --omit=dev
 
 # ─────────────────────────────────────────────────────────────────────────────
 #  Stage 3 — runtime


### PR DESCRIPTION
This Docker build fix restores CLI image creation by removing build-only dependencies before npm resolves the runtime dependency tree.

## Summary

- remove `devDependencies` from the copied CLI manifest inside the `runtime-deps` stage
- retain `npm install --omit=dev` for the production installation
- avoid a broad `legacy-peer-deps` workaround and leave the source manifest and lockfile unchanged

`npm --omit=dev` still resolves the omitted development dependency graph. The current npm 10.9.8 resolver follows Vite and Vitest peer edges before failing in Arborist with `Cannot read properties of null (reading 'edgesOut')`. Removing build-only entries from the isolated runtime manifest prevents that unrelated graph from entering runtime resolution.

## Verification

- before the change, `docker build --target runtime-deps --progress=plain -f src/apps/cli/Dockerfile .` reproduced the `edgesOut` failure
- after the change, the same target installed 135 production packages successfully
- `NODE_OPTIONS=--max-old-space-size=3072 npm run test:e2e:docker:all` completed all setup/put/cat, push/pull, two-Vault CouchDB synchronisation and conflict, mirror, and remote-administration cases
