### PR TITLE
Keep active-file path compatibility warnings readable

### DIFF
--- a/src/common/messages/combinedMessages.prod.ts
+++ b/src/common/messages/combinedMessages.prod.ts
@@ -4213,7 +4213,7 @@ export const allMessages: Readonly<Record<string, Readonly<Record<string, string
         "zh-tw": "正在等待就緒⋯",
     },
     "moduleLog.pathComponentTooLong": {
-        def: "A file or folder name exceeds ${maxBytes} UTF-8 bytes and may not work on some Android and Linux file systems: ${components}",
+        def: "This path contains a file or folder name longer than ${maxBytes} UTF-8 bytes. It may not work on some Android and Linux file systems.",
     },
     "moduleLog.showLog": {
         def: "Show Log",

--- a/src/common/messagesJson/en.json
+++ b/src/common/messagesJson/en.json
@@ -483,7 +483,7 @@
     "moduleLiveSyncMain.optionResumeAndRestart": "Resume and restart Obsidian",
     "moduleLiveSyncMain.titleScramEnabled": "Scram Enabled",
     "moduleLocalDatabase.logWaitingForReady": "Waiting for ready...",
-    "moduleLog.pathComponentTooLong": "A file or folder name exceeds ${maxBytes} UTF-8 bytes and may not work on some Android and Linux file systems: ${components}",
+    "moduleLog.pathComponentTooLong": "This path contains a file or folder name longer than ${maxBytes} UTF-8 bytes. It may not work on some Android and Linux file systems.",
     "moduleLog.showLog": "Show Log",
     "moduleMigration.fix0256.buttons.checkItLater": "Check it later",
     "moduleMigration.fix0256.buttons.DismissForever": "I have fixed it, and do not ask again",

--- a/src/common/messagesYAML/en.yaml
+++ b/src/common/messagesYAML/en.yaml
@@ -733,8 +733,8 @@ moduleLocalDatabase:
     logWaitingForReady: Waiting for ready...
 moduleLog:
     pathComponentTooLong: >-
-        A file or folder name exceeds ${maxBytes} UTF-8 bytes and may not work on
-        some Android and Linux file systems: ${components}
+        This path contains a file or folder name longer than ${maxBytes} UTF-8
+        bytes. It may not work on some Android and Linux file systems.
     showLog: Show Log
 moduleMigration:
     fix0256:

--- a/src/common/translation.unit.spec.ts
+++ b/src/common/translation.unit.spec.ts
@@ -21,6 +21,23 @@ describe("LiveSync-owned translation catalogue", () => {
         expect($msg("moduleCheckRemoteSize.optionIncreaseLimit", { newMax: "800" }, "def")).toBe("increase to 800MB");
     });
 
+    it("keeps the active-file path compatibility warning concise", () => {
+        const oversizedComponent = `${"界".repeat(86)} (258 bytes)`;
+
+        expect(
+            $msg(
+                "moduleLog.pathComponentTooLong",
+                {
+                    maxBytes: "255",
+                    components: oversizedComponent,
+                },
+                "def"
+            )
+        ).toBe(
+            "This path contains a file or folder name longer than 255 UTF-8 bytes. It may not work on some Android and Linux file systems."
+        );
+    });
+
     it("uses Commonlib's canonical English when the application catalogue has no translation", () => {
         setLang("es");
 

--- a/src/modules/features/ModuleLog.ts
+++ b/src/modules/features/ModuleLog.ts
@@ -299,13 +299,9 @@ export class ModuleLog extends AbstractObsidianModule {
         }
         const oversizedPathComponents = findPathComponentsExceedingUtf8Limit(thisFile.path);
         if (oversizedPathComponents.length > 0) {
-            const components = oversizedPathComponents
-                .map(({ component, utf8Bytes }) => `${component} (${utf8Bytes} bytes)`)
-                .join(", ");
             reasonWarn.push(
                 $msg("moduleLog.pathComponentTooLong", {
                     maxBytes: `${ANDROID_LINUX_PATH_COMPONENT_UTF8_WARNING_BOUNDARY}`,
-                    components,
                 })
             );
         }

--- a/updates.md
+++ b/updates.md
@@ -23,7 +23,7 @@ Earlier releases remain available in the 1.0 release history, the 1.0 preview hi
 #### Improved
 
 - Start-up now keeps unconfigured Vaults on the onboarding path without running configured-only checks or accepting Config Doctor and incomplete-document repair requests. Returning a configured Vault to an unconfigured state also retires those requests for the current plug-in process, so completing setup admits them only after the requested restart.
-- The active-file warning now identifies file or folder names longer than 255 UTF-8 bytes as an Android and Linux compatibility risk, without rejecting or changing the path.
+- The active-file warning now concisely identifies file or folder names longer than 255 UTF-8 bytes as an Android and Linux compatibility risk, without rejecting or changing the path.
 
 ### Testing
 


### PR DESCRIPTION
This interface refinement keeps the active-file path compatibility warning readable by omitting the repeated oversized name.

## Summary

- retain the per-component UTF-8 check and its 255-byte compatibility boundary
- show the consequence and affected platforms without placing the complete offending name in the editor banner
- update only the English source catalogue and its generated artefacts
- keep the existing Unreleased note aligned with the concise presentation

Related to #1164.

## Verification

- confirmed the new regression assertion fails against the previous message because it includes the complete 258-byte fixture name
- `NODE_OPTIONS=--max-old-space-size=3072 npx vitest run --config vitest.config.unit.ts src/common/translation.unit.spec.ts src/common/pathCompatibility.unit.spec.ts --maxWorkers=1` (11 passed)
- focused path-compatibility coverage: 100% statements, branches, functions, and lines
- `NODE_OPTIONS=--max-old-space-size=3072 npm run check`
- real Obsidian production-build check: the inline title remains visible, the warning explains the compatibility risk, and the oversized name is not repeated in the banner
