### PR TITLE
Refresh CI runtimes and maintenance checks

### DIFF
--- a/.github/workflows/cli-deno-tests.yml
+++ b/.github/workflows/cli-deno-tests.yml
@@ -84,10 +84,10 @@ jobs:
         task: ${{ fromJson(needs.prepare.outputs.task_matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.x'
           cache: 'npm'
@@ -99,7 +99,7 @@ jobs:
           deno-version: v2.x
 
       - name: Cache Deno dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/deno
           key: ${{ runner.os }}-deno-${{ hashFiles('src/apps/cli/testdeno/deno.lock', 'src/apps/cli/testdeno/deno.json') }}
@@ -151,7 +151,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Show Docker versions
         run: |

--- a/.github/workflows/cli-docker.yml
+++ b/.github/workflows/cli-docker.yml
@@ -46,7 +46,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Derive image tag
               id: meta
@@ -86,22 +86,22 @@ jobs:
                   echo "push=${PUSH}" >> $GITHUB_OUTPUT
 
             - name: Log in to GitHub Container Registry
-              uses: docker/login-action@v3
+              uses: docker/login-action@v4
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Set up QEMU
-              uses: docker/setup-qemu-action@v3
+              uses: docker/setup-qemu-action@v4
               with:
                   platforms: arm64
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
+              uses: docker/setup-buildx-action@v4
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: "24.x"
                   cache: "npm"
@@ -128,7 +128,7 @@ jobs:
 
             - name: Build and push
               if: ${{ steps.e2e.outcome == 'success' || (github.event_name == 'workflow_dispatch' && inputs.force) }}
-              uses: docker/build-push-action@v6
+              uses: docker/build-push-action@v7
               with:
                   context: .
                   file: src/apps/cli/Dockerfile

--- a/.github/workflows/cli-e2e.yml
+++ b/.github/workflows/cli-e2e.yml
@@ -22,10 +22,10 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.x'
           cache: 'npm'

--- a/.github/workflows/cli-p2p-compose-smoke.yml
+++ b/.github/workflows/cli-p2p-compose-smoke.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Show Docker versions
         run: |
@@ -83,7 +83,7 @@ jobs:
 
       - name: Upload benchmark results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cli-p2p-compose-smoke-results
           path: test/bench-network/bench-results/**

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.x'
           cache: 'npm'
@@ -85,10 +85,10 @@ jobs:
         run: npm run test:browser-apps:pages
 
       - name: Configure GitHub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 
@@ -103,4 +103,4 @@ jobs:
     steps:
       - name: Deploy GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/finalise-release.yml
+++ b/.github/workflows/finalise-release.yml
@@ -47,13 +47,13 @@ jobs:
                   fi
                   echo "name=${BRANCH}" >> "$GITHUB_OUTPUT"
 
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
               with:
                   ref: ${{ steps.branch.outputs.name }}
                   fetch-depth: 0
 
             - name: Use Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: "24.x"
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -33,13 +33,13 @@ jobs:
             contents: write
             pull-requests: write
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
               with:
                   ref: ${{ inputs.base_branch }}
                   fetch-depth: 0
 
             - name: Use Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: "24.x"
                   cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,12 @@ jobs:
       id-token: write
       attestations: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
         ref: ${{ inputs.tag }}
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '24.x'
     - name: Validate release
@@ -61,7 +61,7 @@ jobs:
               manifest.json
               styles.css
     - name: Create Release and Upload Assets
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         files: |
           main.js

--- a/.github/workflows/unit-ci.yml
+++ b/.github/workflows/unit-ci.yml
@@ -65,10 +65,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.x'
           cache: 'npm'
@@ -113,10 +113,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.x'
           cache: 'npm'
@@ -127,6 +127,9 @@ jobs:
       - name: Run source checks
         run: npm run check
 
+      - name: Run release process tests
+        run: npm run test:release-process
+
       - name: Run unit tests suite with coverage
         run: npm run test:unit:coverage
 
@@ -135,7 +138,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: unit-coverage-report
           path: coverage/**
@@ -146,7 +149,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Detect LiveSync-owned integration tests
         id: integration_tests
@@ -165,7 +168,7 @@ jobs:
 
       - name: Setup Node.js
         if: ${{ steps.integration_tests.outputs.present == 'true' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.x'
           cache: 'npm'

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
                 "@vrtmrz/obsidian-plugin-kit": "0.1.4",
                 "@vrtmrz/ui-interactions": "0.1.2",
                 "diff-match-patch": "^1.0.5",
-                "fflate": "^0.8.2",
                 "idb": "^8.0.3",
                 "markdown-it": "^14.2.0",
                 "minimatch": "^10.2.5",
@@ -2054,25 +2053,39 @@
             }
         },
         "node_modules/@humanfs/core": {
-            "version": "0.19.1",
-            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-            "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+            "version": "0.19.2",
+            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+            "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
             "dev": true,
             "license": "Apache-2.0",
+            "dependencies": {
+                "@humanfs/types": "^0.15.0"
+            },
             "engines": {
                 "node": ">=18.18.0"
             }
         },
         "node_modules/@humanfs/node": {
-            "version": "0.16.7",
-            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-            "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+            "version": "0.16.8",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+            "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@humanfs/core": "^0.19.1",
+                "@humanfs/core": "^0.19.2",
+                "@humanfs/types": "^0.15.0",
                 "@humanwhocodes/retry": "^0.4.0"
             },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/types": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+            "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+            "dev": true,
+            "license": "Apache-2.0",
             "engines": {
                 "node": ">=18.18.0"
             }
@@ -7214,9 +7227,9 @@
             }
         },
         "node_modules/fflate": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-            "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+            "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
             "license": "MIT"
         },
         "node_modules/file-entry-cache": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "i18n:json2yaml": "tsx _tools/json2yaml.ts",
         "i18n:yaml2json": "tsx _tools/yaml2json.ts",
         "test:unit": "vitest run --config vitest.config.unit.ts",
+        "test:release-process": "vitest run --config vitest.config.unit.ts utils/release-process.unit.spec.ts",
         "build:browser-apps": "npm run build --workspace livesync-webapp --workspace webpeer",
         "test:browser-apps": "npm run test:browser --workspace livesync-webapp && npm run test:browser --workspace webpeer",
         "test:browser-apps:pages": "deno test -A --no-check --frozen --config test/browser-apps/deno.json --lock test/browser-apps/deno.lock test/browser-apps/pages/browser-smoke.test.ts",
@@ -46,7 +47,7 @@
         "test:e2e:cli:p2p": "npm run test:e2e:p2p --workspace self-hosted-livesync-cli",
         "test:e2e:cli:all": "npm run test:e2e:all --workspace self-hosted-livesync-cli",
         "test:integration": "npx dotenv-cli -e .env -e .test.env -- vitest run --config vitest.config.integration.ts",
-        "test:unit:coverage": "vitest run --config vitest.config.unit.ts --coverage",
+        "test:unit:coverage": "vitest run --config vitest.config.unit.ts --coverage --exclude utils/release-process.unit.spec.ts",
         "test:e2e:obsidian:install-appimage": "tsx test/e2e-obsidian/scripts/install-appimage.ts",
         "test:e2e:obsidian:runner": "vitest run --config vitest.config.e2e-runner.ts",
         "test:e2e:obsidian:discover": "tsx test/e2e-obsidian/scripts/discover.ts",
@@ -182,7 +183,6 @@
         "@vrtmrz/obsidian-plugin-kit": "0.1.4",
         "@vrtmrz/ui-interactions": "0.1.2",
         "diff-match-patch": "^1.0.5",
-        "fflate": "^0.8.2",
         "idb": "^8.0.3",
         "markdown-it": "^14.2.0",
         "minimatch": "^10.2.5",
@@ -203,5 +203,11 @@
         "src/apps/cli",
         "src/apps/webpeer",
         "src/apps/webapp"
-    ]
+    ],
+    "allowScripts": {
+        "esbuild@0.28.1": true,
+        "leveldown@5.6.0": true,
+        "leveldown@6.1.1": true,
+        "svelte-preprocess": false
+    }
 }

--- a/vitest.config.common.ts
+++ b/vitest.config.common.ts
@@ -89,6 +89,7 @@ export default defineConfig({
             treeShaking: true,
         }),
         svelte({
+            configFile: false,
             preprocess: sveltePreprocess(),
             compilerOptions: { css: "injected", preserveComments: false },
         }),
@@ -99,12 +100,7 @@ export default defineConfig({
             src: path.resolve(__dirname, "./src"),
         },
     },
-    esbuild: {
-        define: define,
-        target: "es2018",
-        platform: "browser",
-    },
-    // define,
+    define,
     server: {
         headers: {
             "Service-Worker-Allowed": "/",

--- a/vitest.config.unit.ts
+++ b/vitest.config.unit.ts
@@ -7,6 +7,10 @@ import { defineConfig, mergeConfig } from "vitest/config";
 import viteConfig from "./vitest.config.common";
 
 const importOnlyFiles = ["**/encryption/encryptHKDF.ts"];
+const obsidianRuntimeOnlyFiles = [
+    "src/deps.ts",
+    "src/serviceModules/FileSystemAdapters/ObsidianTypeGuardAdapter.ts",
+];
 export default mergeConfig(
     viteConfig,
     defineConfig({
@@ -32,6 +36,7 @@ export default mergeConfig(
                     "src/apps/**/testdeno/**",
                     "**/*_obsolete.ts",
                     ...importOnlyFiles,
+                    ...obsidianRuntimeOnlyFiles,
                 ],
                 provider: "v8",
                 reporter: ["text", "json", "html", ["text", { file: "coverage-text.txt" }]],


### PR DESCRIPTION
This maintenance change refreshes CI action runtimes, resolves dependency metadata issues, and keeps release-process tests separate from unit coverage.

## Summary

- update GitHub Actions to Node.js 24-capable major versions
- declare reviewed npm lifecycle scripts and remove the unused direct `fflate` dependency
- update transitive lockfile dependencies to clear the npm audit findings
- move release-process tests into an explicit CI step outside unit coverage
- remove obsolete Vite and Svelte test configuration warnings
- exclude Obsidian-runtime-only modules from unit coverage instrumentation

## Verification

- `npm ci` with npm 11.18.0
- `npx --yes npm@10.9.2 ci --ignore-scripts`
- `npm audit --json` (zero vulnerabilities)
- `NODE_OPTIONS=--max-old-space-size=3072 npm run test:unit:coverage -- --maxWorkers=1` (118 files, 921 tests)
- `npm run test:release-process -- --maxWorkers=1` (1 file, 21 tests)
- `NODE_OPTIONS=--max-old-space-size=3072 npm run check`
- parsed every workflow as YAML and checked for superseded Node.js 20 action majors
- `git diff --check`