### PR TITLE
fix(cli): decouple full directory scan from partial fileCache size

### DIFF
--- a/src/apps/cli/adapters/NodeFileSystemAdapter.ts
+++ b/src/apps/cli/adapters/NodeFileSystemAdapter.ts
@@ -20,6 +20,7 @@ export class NodeFileSystemAdapter implements IFileSystemAdapter<NodeFile, NodeF
     readonly vault: NodeVaultAdapter;
 
     private fileCache = new Map<string, NodeFile>();
+    private isFullyScanned = false;
 
     constructor(
         private basePath: string,
@@ -80,7 +81,10 @@ export class NodeFileSystemAdapter implements IFileSystemAdapter<NodeFile, NodeF
             }
         }
 
-        await this.scanDirectory();
+        if (!this.isFullyScanned) {
+            await this.scanDirectory();
+            this.isFullyScanned = true;
+        }
 
         for (const [cachedPath, cachedFile] of this.fileCache.entries()) {
             if (cachedPath.toLowerCase() === lowerPath) {
@@ -92,8 +96,9 @@ export class NodeFileSystemAdapter implements IFileSystemAdapter<NodeFile, NodeF
     }
 
     async getFiles(): Promise<NodeFile[]> {
-        if (this.fileCache.size === 0) {
+        if (!this.isFullyScanned) {
             await this.scanDirectory();
+            this.isFullyScanned = true;
         }
         return Array.from(this.fileCache.values());
     }


### PR DESCRIPTION
### Problem
When starting `livesync-cli` in `daemon` mode with an existing database and vault:
1. `replicateUnattended` runs first during initialisation, checking the existence of certain remote documents and populating `fileCache` in `NodeFileSystemAdapter` with a partial set of files.
2. Next, `performFullScan` calls `storageAccess.getFiles()`, which delegates to `NodeFileSystemAdapter.getFiles()`.
3. In `NodeFileSystemAdapter.ts`:
   ```typescript
   async getFiles(): Promise<NodeFile[]> {
       if (this.fileCache.size === 0) {
           await this.scanDirectory();
       }
       return Array.from(this.fileCache.values());
   }
   ```
   Because `fileCache.size` is already non-zero due to the pre-populated cache, `scanDirectory()` is completely skipped.
4. As a result, `getFiles()` only returns that partial subset. The offline scanner then deduces that all other files in the vault were deleted on disk, triggering false deletions in the database (`NEWER_WINS: Treating missing local file as deletion`).

### Solution
Introduce an explicit `isFullyScanned` boolean flag to track whether `scanDirectory()` has completed, rather than relying on `fileCache.size === 0`.

### Verification
- Tested in production with a decoupled vault containing ~5400 notes and attachments.
- Verified that on daemon startup, `scanDirectory()` is reliably executed, all 5400+ files are recognized as `STORAGE == DB` (0 files falsely deleted), and the daemon enters live synchronization mode smoothly.